### PR TITLE
Allow consumers to distinguish retriable errors on write

### DIFF
--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -10,6 +10,7 @@ pub mod constraints;
 pub mod indexes;
 pub mod ns_lookup;
 pub mod on_conflict;
+pub mod retriable_error;
 pub mod secrets;
 
 #[derive(Debug, Snafu)]

--- a/src/util/retriable_error.rs
+++ b/src/util/retriable_error.rs
@@ -1,0 +1,47 @@
+use datafusion::error::DataFusionError;
+use snafu::Snafu;
+
+#[derive(Debug, Snafu)]
+pub enum RetriableError {
+    #[snafu(display("{source}"))]
+    DataRetrievalError {
+        source: datafusion::error::DataFusionError,
+    },
+}
+
+#[must_use]
+pub fn is_retriable_error(err: &DataFusionError) -> bool {
+    match err {
+        DataFusionError::External(err) => return err.downcast_ref::<RetriableError>().is_some(),
+        DataFusionError::Context(_, err) => is_retriable_error(err.as_ref()),
+        _ => false,
+    }
+}
+
+/// Checks if the data retrieval error is NOT related to invalid input (e.g., SQL, plan creation, schema issues).
+/// In this case, the error is wrapped as `RetriableError::DataRetrievalError`
+/// so we can detect this error and retry later at a higher level
+#[must_use]
+pub fn check_and_mark_retriable_error(err: DataFusionError) -> DataFusionError {
+    // don't wrap as retriable errors related to invalid SQL, schema, query plan, etc.
+    if is_invalid_query_error(&err) {
+        return err;
+    }
+
+    // already wrapped RetriableError
+    if is_retriable_error(&err) {
+        return err;
+    }
+
+    DataFusionError::External(Box::new(RetriableError::DataRetrievalError { source: err }))
+}
+
+fn is_invalid_query_error(error: &DataFusionError) -> bool {
+    match error {
+        DataFusionError::Context(_, err) => is_invalid_query_error(err.as_ref()),
+        DataFusionError::SQL(..) | DataFusionError::Plan(..) | DataFusionError::SchemaError(..) => {
+            true
+        }
+        _ => false,
+    }
+}


### PR DESCRIPTION
When performing `.collect()` on a DataFusion plan that inserts data into one of the TableProviders in this repo that supports `insert_into` (DuckDB, Sqlite and Postgres) - allow the consumer to distinguish whether the error is one that can be retried.