### PR TITLE
Make `connect()` and `postgres_conn()` public

### DIFF
--- a/src/postgres.rs
+++ b/src/postgres.rs
@@ -340,7 +340,7 @@ impl Postgres {
         &self.constraints
     }
 
-    async fn connect(&self) -> Result<Box<DynPostgresConnection>> {
+    pub async fn connect(&self) -> Result<Box<DynPostgresConnection>> {
         let mut conn = self.pool.connect().await.context(DbConnectionSnafu)?;
 
         let pg_conn = Self::postgres_conn(&mut conn)?;
@@ -355,7 +355,7 @@ impl Postgres {
         Ok(conn)
     }
 
-    fn postgres_conn(
+    pub fn postgres_conn(
         db_connection: &mut Box<DynPostgresConnection>,
     ) -> Result<&mut PostgresConnection> {
         db_connection

--- a/src/postgres/write.rs
+++ b/src/postgres/write.rs
@@ -40,6 +40,10 @@ impl PostgresTableWriter {
             on_conflict,
         })
     }
+
+    pub fn postgres(&self) -> Arc<Postgres> {
+        Arc::clone(&self.postgres)
+    }
 }
 
 #[async_trait]


### PR DESCRIPTION
Fixes a visibility issue that prevents working with this directly.