### PR TITLE
Streaming write for DuckDB TableProvider

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,6 @@ tokio-rusqlite = { version = "0.5.1", optional = true }
 datafusion-federation = { git = "https://github.com/spiceai/datafusion-federation.git", rev = "c3f696adceaad7f579af7f163cb933e08d7f8ba1" }
 datafusion-federation-sql = { git = "https://github.com/spiceai/datafusion-federation.git", folder = "sources/sql", rev = "c3f696adceaad7f579af7f163cb933e08d7f8ba1" }
 itertools = "0.13.0"
-flume = { version = "0.11.0", optional = true }
 
 [dev-dependencies]
 reqwest = "0.12.5"
@@ -56,4 +55,4 @@ tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 mysql = ["dep:mysql_async"]
 postgres = ["dep:tokio-postgres", "dep:uuid", "dep:postgres-native-tls", "dep:bb8", "dep:bb8-postgres", "dep:native-tls", "dep:pem", "dep:async-stream"]
 sqlite = ["dep:rusqlite", "dep:tokio-rusqlite"]
-duckdb = ["dep:duckdb", "dep:r2d2", "dep:uuid", "dep:flume"]
+duckdb = ["dep:duckdb", "dep:r2d2", "dep:uuid"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ tokio-rusqlite = { version = "0.5.1", optional = true }
 datafusion-federation = { git = "https://github.com/spiceai/datafusion-federation.git", rev = "c3f696adceaad7f579af7f163cb933e08d7f8ba1" }
 datafusion-federation-sql = { git = "https://github.com/spiceai/datafusion-federation.git", folder = "sources/sql", rev = "c3f696adceaad7f579af7f163cb933e08d7f8ba1" }
 itertools = "0.13.0"
+flume = { version = "0.11.0", optional = true }
 
 [dev-dependencies]
 reqwest = "0.12.5"
@@ -55,4 +56,4 @@ tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 mysql = ["dep:mysql_async"]
 postgres = ["dep:tokio-postgres", "dep:uuid", "dep:postgres-native-tls", "dep:bb8", "dep:bb8-postgres", "dep:native-tls", "dep:pem", "dep:async-stream"]
 sqlite = ["dep:rusqlite", "dep:tokio-rusqlite"]
-duckdb = ["dep:duckdb", "dep:r2d2", "dep:uuid"]
+duckdb = ["dep:duckdb", "dep:r2d2", "dep:uuid", "dep:flume"]

--- a/src/duckdb/write.rs
+++ b/src/duckdb/write.rs
@@ -190,9 +190,9 @@ impl DataSink for DuckDBDataSink {
         }
 
         if notify_commit_transaction.send(()).is_err() {
-            return Err(DataFusionError::Execution(format!(
-                "Unable to send message to commit transaction to duckdb writer."
-            )));
+            return Err(DataFusionError::Execution(
+                "Unable to send message to commit transaction to duckdb writer.".to_string(),
+            ));
         };
 
         // Drop the sender to signal the receiver that no more data is coming


### PR DESCRIPTION
PR implements streaming write support for the DuckDB `TableProvider`, which is critical for handling large volumes of data that cannot be stored entirely in memory before writing to a DuckDB file-based `TableProvider`.

Since DuckDB transactions are not `Sync`, they cannot be used in the asynchronous context required for stream reading. To address this, a separate Tokio task has been created for synchronous DuckDB writing. A `tokio` channel with `blocking_recv` is used to propagate `RecordBatches` for writing.