### PR TITLE
Mysql streaming

### DIFF
--- a/src/sql/db_connection_pool/dbconnection/mysqlconn.rs
+++ b/src/sql/db_connection_pool/dbconnection/mysqlconn.rs
@@ -96,7 +96,6 @@ impl<'a> AsyncDbConnection<Conn, &'a (dyn ToValue + Sync)> for MySQLConnection {
                 .context(QuerySnafu)?;
 
             let Some(stream) = exec_iter.stream::<Row>().await.context(QuerySnafu)? else {
-                // This should expect exact one stream
                 yield Err(Error::QueryResultStreamError {});
                 return;
             };

--- a/src/sql/db_connection_pool/dbconnection/mysqlconn.rs
+++ b/src/sql/db_connection_pool/dbconnection/mysqlconn.rs
@@ -1,17 +1,20 @@
 use std::{any::Any, sync::Arc};
 
 use crate::sql::arrow_sql_gen::{self, mysql::rows_to_arrow};
-use arrow::datatypes::SchemaRef;
+use arrow::datatypes::{Schema, SchemaRef};
+use async_stream::stream;
+use datafusion::error::DataFusionError;
 use datafusion::execution::SendableRecordBatchStream;
-use datafusion::physical_plan::memory::MemoryStream;
+use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
 use datafusion::sql::TableReference;
 use futures::lock::Mutex;
+use futures::{stream, StreamExt};
 use mysql_async::prelude::Queryable;
 use mysql_async::{prelude::ToValue, Conn, Params, Row};
 use snafu::prelude::*;
 
-use super::Result;
 use super::{AsyncDbConnection, DbConnection};
+use super::Result;
 
 #[derive(Debug, Snafu)]
 pub enum Error {
@@ -20,6 +23,9 @@ pub enum Error {
 
     #[snafu(display("Failed to convert query result to Arrow: {source}"))]
     ConversionError { source: arrow_sql_gen::mysql::Error },
+
+    #[snafu(display("Unable to get MySQL query result stream"))]
+    QueryResultStreamError {},
 }
 
 pub struct MySQLConnection {
@@ -78,18 +84,55 @@ impl<'a> AsyncDbConnection<Conn, &'a (dyn ToValue + Sync)> for MySQLConnection {
         sql: &str,
         params: &[&'a (dyn ToValue + Sync)],
     ) -> Result<SendableRecordBatchStream> {
-        let mut conn = self.conn.lock().await;
-        let conn = &mut *conn;
-
         let params_vec: Vec<_> = params.iter().map(|&p| p.to_value()).collect();
-        let rows: Vec<Row> = conn
-            .exec(sql.replace('"', ""), Params::from(params_vec))
-            .await
-            .context(QuerySnafu)?;
-        let rec = rows_to_arrow(&rows).context(ConversionSnafu)?;
-        let schema = rec.schema();
-        let recs = vec![rec];
-        Ok(Box::pin(MemoryStream::try_new(recs, schema, None)?))
+        let sql = sql.replace('"', "");
+        let conn = Arc::clone(&self.conn);
+
+        let mut stream = Box::pin(stream! {
+            let mut conn = conn.lock().await;
+            let mut exec_iter = conn
+                .exec_iter(sql, Params::from(params_vec))
+                .await
+                .context(QuerySnafu)?;
+
+            let Some(stream) = exec_iter.stream::<Row>().await.context(QuerySnafu)? else {
+                // This should expect exact one stream
+                yield Err(Error::QueryResultStreamError {});
+                return;
+            };
+
+            let mut chunked_stream = stream.chunks(4_000).boxed();
+
+            while let Some(chunk) = chunked_stream.next().await {
+                let rows = chunk
+                    .into_iter()
+                    .collect::<Result<Vec<_>, _>>()
+                    .context(QuerySnafu)?;
+
+                let rec = rows_to_arrow(&rows).context(ConversionSnafu)?;
+                yield Ok::<_, Error>(rec)
+            }
+        });
+
+        let Some(first_chunk) = stream.next().await else {
+            return Ok(Box::pin(RecordBatchStreamAdapter::new(
+                Arc::new(Schema::empty()),
+                stream::empty(),
+            )));
+        };
+
+        let first_chunk = first_chunk?;
+        let schema = first_chunk.schema();
+
+        Ok(Box::pin(RecordBatchStreamAdapter::new(schema, {
+            stream! {
+                yield Ok(first_chunk);
+                while let Some(batch) = stream.next().await {
+                    yield batch
+                        .map_err(|e| DataFusionError::Execution(format!("Failed to fetch batch: {e}")))
+                }
+            }
+        })))
     }
 
     async fn execute(&self, query: &str, params: &[&'a (dyn ToValue + Sync)]) -> Result<u64> {


### PR DESCRIPTION
Changes:
- this adds streaming capability to mysql connector. It utilizes the `exec_iter` from mysql_async to return the data in a stream rather than collecting all data then return.