### PR TITLE
Refine postgres data connector get_schema method

### DIFF
--- a/src/sql/arrow_sql_gen/postgres.rs
+++ b/src/sql/arrow_sql_gen/postgres.rs
@@ -20,7 +20,7 @@ use snafu::prelude::*;
 use std::time::{SystemTime, UNIX_EPOCH};
 use tokio_postgres::types::FromSql;
 use tokio_postgres::types::Kind;
-use tokio_postgres::{types::Type, Column, Row};
+use tokio_postgres::{types::Type, Row};
 
 pub mod builder;
 pub mod composite;

--- a/src/sql/arrow_sql_gen/postgres.rs
+++ b/src/sql/arrow_sql_gen/postgres.rs
@@ -164,31 +164,6 @@ macro_rules! handle_composite_types {
     }
 }
 
-/// Converts Postgres Columns to Arrow Data Types
-///
-/// # Errors
-///
-/// Returns an error if the Postgres column type is not supported
-pub fn columns_to_schema(cols: &[Column]) -> Result<Arc<Schema>> {
-    let mut arrow_fields: Vec<Option<Field>> = Vec::new();
-
-    for column in cols {
-        let column_name = column.name();
-        let column_type = column.type_();
-        let data_type = map_column_type_to_data_type(column_type);
-        match &data_type {
-            Some(data_type) => {
-                arrow_fields.push(Some(Field::new(column_name, data_type.clone(), true)));
-            }
-            None => arrow_fields.push(None),
-        }
-    }
-
-    let arrow_fields = arrow_fields.into_iter().flatten().collect::<Vec<Field>>();
-
-    Ok(Arc::new(Schema::new(arrow_fields)))
-}
-
 /// Converts Postgres `Row`s to an Arrow `RecordBatch`. Assumes that all rows have the same schema and
 /// sets the schema based on the first row.
 ///


### PR DESCRIPTION
Postgres `get_schema` would require getting actual data to determine the precision of numeric columns. The current implementation of `get_schema` would cause numeric columns missing in schema. Therefore refine get_schema method to execute sql query instead of preparing statement

- Related issue: https://github.com/spiceai/spiceai/issues/1915