### PR TITLE
Upgrade to DuckDB version 1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ bigdecimal_0_3_0 = { package = "bigdecimal", version = "0.3.0" }
 byteorder = "1.5.0"
 chrono = "0.4.38"
 datafusion = "40.0.0"
-duckdb = { git = "https://github.com/spiceai/duckdb-rs.git", rev = "c7b8e22885001e2013493aebbaf190039d826c05", features = [
+duckdb = { version = "1", features = [
   "bundled",
   "r2d2",
   "vtab",


### PR DESCRIPTION
Upgrade `duckdb-rs` from the Spice AI fork to the crates.io published version