### PR TITLE
Simplify connection parameters for MySQL & Postgres tables

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ url = "2.5.1"
 pem = { version = "3.0.4", optional = true }
 tokio-rusqlite = { version = "0.5.1", optional = true }
 datafusion-federation = "0.1"
-datafusion-federation-sql = { git = "https://github.com/spiceai/datafusion-federation.git", folder = "sources/sql", rev = "eeb9b9c0ed41650db282ba27bc663feb64e62147" }
+datafusion-federation-sql = { git = "https://github.com/spiceai/datafusion-federation.git", rev = "eeb9b9c0ed41650db282ba27bc663feb64e62147" }
 itertools = "0.13.0"
 
 [dev-dependencies]

--- a/examples/mysql.rs
+++ b/examples/mysql.rs
@@ -30,14 +30,14 @@ use datafusion_table_providers::{
 async fn main() {
     let mysql_params = to_secret_map(HashMap::from([
         (
-            "mysql_connection_string".to_string(),
+            "connection_string".to_string(),
             "mysql://root:password@localhost:3306/mysql_db".to_string(),
         ),
-        ("mysql_sslmode".to_string(), "disabled".to_string()),
+        ("sslmode".to_string(), "disabled".to_string()),
     ]));
 
     let mysql_pool = Arc::new(
-        MySQLConnectionPool::new(Arc::new(mysql_params))
+        MySQLConnectionPool::new(mysql_params)
             .await
             .expect("unable to create MySQL connection pool"),
     );

--- a/examples/postgres.rs
+++ b/examples/postgres.rs
@@ -29,16 +29,16 @@ use datafusion_table_providers::{
 #[tokio::main]
 async fn main() {
     let postgres_params = to_secret_map(HashMap::from([
-        ("pg_host".to_string(), "localhost".to_string()),
-        ("pg_user".to_string(), "postgres".to_string()),
-        ("pg_db".to_string(), "postgres_db".to_string()),
-        ("pg_pass".to_string(), "password".to_string()),
-        ("pg_port".to_string(), "5432".to_string()),
-        ("pg_sslmode".to_string(), "disable".to_string()),
+        ("host".to_string(), "localhost".to_string()),
+        ("user".to_string(), "postgres".to_string()),
+        ("db".to_string(), "postgres_db".to_string()),
+        ("pass".to_string(), "password".to_string()),
+        ("port".to_string(), "5432".to_string()),
+        ("sslmode".to_string(), "disable".to_string()),
     ]));
 
     let postgres_pool = Arc::new(
-        PostgresConnectionPool::new(Arc::new(postgres_params))
+        PostgresConnectionPool::new(postgres_params)
             .await
             .expect("unable to create Postgres connection pool"),
     );

--- a/src/postgres.rs
+++ b/src/postgres.rs
@@ -240,7 +240,7 @@ impl TableProviderFactory for PostgresTableProviderFactory {
             );
         }
 
-        let params = Arc::new(to_secret_map(options));
+        let params = to_secret_map(options);
 
         let pool = Arc::new(
             PostgresConnectionPool::new(params)

--- a/src/sql/db_connection_pool/postgrespool.rs
+++ b/src/sql/db_connection_pool/postgrespool.rs
@@ -83,9 +83,8 @@ impl PostgresConnectionPool {
         let mut ssl_mode = "verify-full".to_string();
         let mut ssl_rootcert_path: Option<PathBuf> = None;
 
-        if let Some(pg_connection_string) = params
-            .get("pg_connection_string")
-            .map(Secret::expose_secret)
+        if let Some(pg_connection_string) =
+            params.get("connection_string").map(Secret::expose_secret)
         {
             let (str, mode, cert_path) = parse_connection_string(pg_connection_string.as_str());
             connection_string = str;
@@ -123,7 +122,7 @@ impl PostgresConnectionPool {
                 }
                 _ => {
                     InvalidParameterSnafu {
-                        parameter_name: "pg_sslmode".to_string(),
+                        parameter_name: "sslmode".to_string(),
                     }
                     .fail()?;
                 }

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -112,21 +112,6 @@ mod tests {
     }
 
     #[test]
-    fn test_partial_prefix() {
-        let mut hashmap = HashMap::new();
-        hashmap.insert("prefix_key1".to_string(), "value1".to_string());
-        hashmap.insert("key2".to_string(), "value2".to_string());
-
-        let result = remove_prefix_from_hashmap_keys(hashmap, "prefix_");
-
-        let mut expected = HashMap::new();
-        expected.insert("key1".to_string(), "value1".to_string());
-        expected.insert("key2".to_string(), "value2".to_string());
-
-        assert_eq!(result, expected);
-    }
-
-    #[test]
     fn test_full_prefix() {
         let mut hashmap = HashMap::new();
         hashmap.insert("prefix_".to_string(), "value1".to_string());

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -46,3 +46,98 @@ where
         })
         .collect()
 }
+
+#[must_use]
+pub fn remove_prefix_from_hashmap_keys<V>(
+    hashmap: HashMap<String, V>,
+    prefix: &str,
+) -> HashMap<String, V> {
+    hashmap
+        .into_iter()
+        .map(|(key, value)| {
+            let new_key = key
+                .strip_prefix(prefix)
+                .map_or(key.clone(), |s| s.to_string());
+            (new_key, value)
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    #[test]
+    fn test_remove_prefix() {
+        let mut hashmap = HashMap::new();
+        hashmap.insert("prefix_key1".to_string(), "value1".to_string());
+        hashmap.insert("prefix_key2".to_string(), "value2".to_string());
+        hashmap.insert("key3".to_string(), "value3".to_string());
+
+        let result = remove_prefix_from_hashmap_keys(hashmap, "prefix_");
+
+        let mut expected = HashMap::new();
+        expected.insert("key1".to_string(), "value1".to_string());
+        expected.insert("key2".to_string(), "value2".to_string());
+        expected.insert("key3".to_string(), "value3".to_string());
+
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn test_no_prefix() {
+        let mut hashmap = HashMap::new();
+        hashmap.insert("key1".to_string(), "value1".to_string());
+        hashmap.insert("key2".to_string(), "value2".to_string());
+
+        let result = remove_prefix_from_hashmap_keys(hashmap, "prefix_");
+
+        let mut expected = HashMap::new();
+        expected.insert("key1".to_string(), "value1".to_string());
+        expected.insert("key2".to_string(), "value2".to_string());
+
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn test_empty_hashmap() {
+        let hashmap: HashMap<String, String> = HashMap::new();
+
+        let result = remove_prefix_from_hashmap_keys(hashmap, "prefix_");
+
+        let expected: HashMap<String, String> = HashMap::new();
+
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn test_partial_prefix() {
+        let mut hashmap = HashMap::new();
+        hashmap.insert("prefix_key1".to_string(), "value1".to_string());
+        hashmap.insert("key2".to_string(), "value2".to_string());
+
+        let result = remove_prefix_from_hashmap_keys(hashmap, "prefix_");
+
+        let mut expected = HashMap::new();
+        expected.insert("key1".to_string(), "value1".to_string());
+        expected.insert("key2".to_string(), "value2".to_string());
+
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn test_full_prefix() {
+        let mut hashmap = HashMap::new();
+        hashmap.insert("prefix_".to_string(), "value1".to_string());
+        hashmap.insert("prefix_key2".to_string(), "value2".to_string());
+
+        let result = remove_prefix_from_hashmap_keys(hashmap, "prefix_");
+
+        let mut expected = HashMap::new();
+        expected.insert("".to_string(), "value1".to_string());
+        expected.insert("key2".to_string(), "value2".to_string());
+
+        assert_eq!(result, expected);
+    }
+}


### PR DESCRIPTION
Simplifies the connection parameters for MySQL and Postgres tables to not require the `Arc` around the HashMap, and to not require the `mysql_` or `pg_` prefix for the connection parameters. They are still supported, but will be removed internally to keep it consistent.