### PR TITLE
Add LIKE expr support for Postgres, DuckDB and SQLite

### DIFF
--- a/src/sql/sql_provider_datafusion/expr.rs
+++ b/src/sql/sql_provider_datafusion/expr.rs
@@ -103,6 +103,16 @@ pub fn to_sql_with_engine(expr: &Expr, engine: Option<Engine>) -> Result<String>
                 expr: format!("{expr}"),
             }),
         },
+        Expr::Like(like_expr) => {
+            let expr = to_sql_with_engine(&like_expr.expr, engine)?;
+            let pattern = to_sql_with_engine(&like_expr.pattern, engine)?;
+            let op_name = if like_expr.negated {
+                "NOT LIKE"
+            } else {
+                "LIKE"
+            };
+            Ok(format!("{expr} {op_name} {pattern}"))
+        },
         _ => Err(Error::UnsupportedFilterExpr {
             expr: format!("{expr}"),
         }),

--- a/src/sql/sql_provider_datafusion/expr.rs
+++ b/src/sql/sql_provider_datafusion/expr.rs
@@ -114,7 +114,7 @@ pub fn to_sql_with_engine(expr: &Expr, engine: Option<Engine>) -> Result<String>
                 (Some(Engine::SQLite), false) => format!("LIKE {pattern} COLLATE BINARY"),
                 _ => {
                     return Err(Error::UnsupportedFilterExpr {
-                        expr: format!("{expr}"),
+                        expr: expr.to_string(),
                     });
                 }
             };


### PR DESCRIPTION
PR fixes the following error when using LIKE expressions, for example

```sql
select * from part where p_type like '%BRASS'
```

Before:
```sql
Error An internal error occurred. Execute '.error' to show details.
sql> .error
Status { code: Internal, message: "External error: Execution error: Unable to generate SQL: Expression not supported p_type LIKE LargeUtf8(\"%BRASS\")", source: None }
```

After

```sql
+-----------+----------------------------------------+----------------+----------+-------------------------+--------+-------------+---------------+---------------------+
| p_partkey | p_name                                 | p_mfgr         | p_brand  | p_type                  | p_size | p_container | p_retailprice | p_comment           |
+-----------+----------------------------------------+----------------+----------+-------------------------+--------+-------------+---------------+---------------------+
| 2         | blush thistle blue yellow saddle       | Manufacturer#1 | Brand#13 | LARGE BRUSHED BRASS     | 1      | LG CASE     | 902.00        | lar accounts amo    |
| 3         | spring green yellow purple cornsilk    | Manufacturer#4 | Brand#42 | STANDARD POLISHED BRASS | 21     | WRAP CASE   | 903.00        | egular deposits hag |
| 4         | cornflower chocolate smoke green pink  | Manufacturer#3 | Brand#34 | SMALL PLATED BRASS      | 14     | MED DRUM    | 904.00        | p furiously r       |
| 15        | blanched honeydew sky turquoise medium | Manufacturer#1 | Brand#15 | LARGE ANODIZED BRASS    | 45     | LG CASE     | 915.01        | usual ac            |
| 22        | medium forest blue ghost black         | Manufacturer#4 | Brand#43 | PROMO POLISHED BRASS    | 19     | LG DRUM     | 922.02        |  even p             |
+-----------+----------------------------------------+----------------+----------+-------------------------+--------+-------------+---------------+---------------------+
```