### PR TITLE
feat: Use SQLite WAL transaction mode

### DIFF
--- a/src/sql/db_connection_pool/mod.rs
+++ b/src/sql/db_connection_pool/mod.rs
@@ -32,7 +32,7 @@ pub trait DbConnectionPool<T, P: 'static> {
     fn join_push_down(&self) -> JoinPushDown;
 }
 
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub enum Mode {
     #[default]
     Memory,

--- a/src/sqlite.rs
+++ b/src/sqlite.rs
@@ -157,6 +157,16 @@ impl TableProviderFactory for SqliteTableProviderFactory {
 
         let db_path = self.sqlite_file_path(&name, &cmd.options);
 
+        // use a separate pool instance from writing to allow for concurrent reads+writes
+        // even though we setup SQLite to use WAL mode, the pool isn't really a pool so shares the same connection
+        // and we can't have concurrent writes when sharing the same connection
+        let read_pool: Arc<SqliteConnectionPool> = Arc::new(
+            SqliteConnectionPool::new(&db_path, mode.clone())
+                .await
+                .context(DbConnectionPoolSnafu)
+                .map_err(to_datafusion_error)?,
+        );
+
         let pool: Arc<SqliteConnectionPool> = Arc::new(
             SqliteConnectionPool::new(&db_path, mode)
                 .await
@@ -200,7 +210,7 @@ impl TableProviderFactory for SqliteTableProviderFactory {
                 .map_err(to_datafusion_error)?;
         }
 
-        let dyn_pool: Arc<DynSqliteConnectionPool> = pool;
+        let dyn_pool: Arc<DynSqliteConnectionPool> = read_pool;
 
         let read_provider = Arc::new(SqlTable::new_with_schema(
             "sqlite",


### PR DESCRIPTION
## 🗣 Description

* Sets up SQLite connections to use [WAL transaction mode](https://www.sqlite.org/wal.html) - this prevents database locking as a whole during writes
* Uses a separate connection pool for reads to allow for concurrent reads and writes at the connection level