### PR TITLE
fix: Reuse write pool for in-memory SQLite

### DIFF
--- a/src/sql/db_connection_pool/mod.rs
+++ b/src/sql/db_connection_pool/mod.rs
@@ -32,7 +32,7 @@ pub trait DbConnectionPool<T, P: 'static> {
     fn join_push_down(&self) -> JoinPushDown;
 }
 
-#[derive(Default, Clone)]
+#[derive(Default, Clone, Copy, PartialEq, Eq)]
 pub enum Mode {
     #[default]
     Memory,


### PR DESCRIPTION
## 🗣 Description

* Reuses the write connection pool for in-memory SQLite databases

If we spin up a new connection pool, we create a different in-memory database so the read provider isn't reading the same database anymore.

* Updates connection PRAGMA configuration to only execute for file mode SQLite databases

In-memory SQLite databases [don't support WAL journal mode](https://www.sqlite.org/pragma.html#pragma_journal_mode), so let's not try to apply it. The other tuning parameters also don't make sense for in-memory databases.