### PR TITLE
Support mysql BINARY, VARBINARY and Postgres Type::BYTEA

### DIFF
--- a/src/sql/arrow_sql_gen/mysql.rs
+++ b/src/sql/arrow_sql_gen/mysql.rs
@@ -461,7 +461,7 @@ pub fn map_column_to_data_type(
         | ColumnType::MYSQL_TYPE_LONG_BLOB => Some(DataType::LargeUtf8),
         ColumnType::MYSQL_TYPE_STRING
         | ColumnType::MYSQL_TYPE_VAR_STRING => {
-            if column_flag {
+            if column_is_binary {
                 Some(DataType::Binary)
             } else {
                 Some(DataType::LargeUtf8)

--- a/src/sql/arrow_sql_gen/mysql.rs
+++ b/src/sql/arrow_sql_gen/mysql.rs
@@ -430,7 +430,10 @@ pub fn rows_to_arrow(rows: &[Row]) -> Result<RecordBatch> {
 }
 
 #[allow(clippy::unnecessary_wraps)]
-pub fn map_column_to_data_type(column_type: ColumnType, column_flag: bool) -> Option<DataType> {
+pub fn map_column_to_data_type(
+    column_type: ColumnType,
+    column_is_binary: bool,
+) -> Option<DataType> {
     match column_type {
         ColumnType::MYSQL_TYPE_NULL => Some(DataType::Null),
         ColumnType::MYSQL_TYPE_BIT => Some(DataType::UInt64),

--- a/src/sql/arrow_sql_gen/postgres.rs
+++ b/src/sql/arrow_sql_gen/postgres.rs
@@ -228,6 +228,9 @@ pub fn rows_to_arrow(rows: &[Row]) -> Result<RecordBatch> {
                 Type::VARCHAR => {
                     handle_primitive_type!(builder, Type::VARCHAR, StringBuilder, &str, row, i);
                 }
+                Type::BYTEA => {
+                    handle_primitive_type!(builder, Type::BYTEA, BinaryBuilder, Vec<u8>, row, i);
+                }
                 Type::BPCHAR => {
                     let Some(builder) = builder else {
                         return NoBuilderForIndexSnafu { index: i }.fail();
@@ -524,6 +527,7 @@ fn map_column_type_to_data_type(column_type: &Type) -> Option<DataType> {
         Type::FLOAT4 => Some(DataType::Float32),
         Type::FLOAT8 => Some(DataType::Float64),
         Type::TEXT | Type::VARCHAR | Type::BPCHAR | Type::UUID => Some(DataType::Utf8),
+        Type::BYTEA => Some(DataType::Binary),
         Type::BOOL => Some(DataType::Boolean),
         // Inspect the scale from the first row. Precision will always be 38 for Decimal128.
         Type::NUMERIC => None,


### PR DESCRIPTION
Support mysql BINARY, VARBINARY and Postgres Type::BYTEA for the mysql table provider and postgres table provider
* mysql `BINARY` & `CHAR` are both of type `MYSQL_TYPE_STRING` in mysql-async library. Add additional binary flag data to determine mysql binary / char and cast them to arrow binary / largestring accordingly