### PR TITLE
Improve MySQL auth error message

### DIFF
--- a/src/sql/db_connection_pool/mysqlpool.rs
+++ b/src/sql/db_connection_pool/mysqlpool.rs
@@ -133,7 +133,7 @@ impl MySQLConnectionPool {
                 // We override it with a more user-friendly error message.
                 mysql_async::Error::Driver(DriverError::UnknownAuthPlugin { .. }) => {
                     mysql_async::Error::Other(
-                        "Unable to authenticate. Are the user name and password correct?".into(),
+                        "Unable to authenticate. Is the user name and password correct?".into(),
                     )
                 }
                 _ => err,


### PR DESCRIPTION
PR improves MySQL auth error message when incorrect user name is specified.

>Unable to create MySQL connection pool: ConnectionPoolRunError: Driver error: `Unknown authentication plugin `sha256_password'.'

This happens when auth failed and server requests to switch auth but mysql_async crate does not support requested auth plugin (sha256_password)
https://github.com/blackbeam/mysql_async/blob/e15a0233dd4ea01cad3d6613c9bd88e63e7edd67/src/conn/mod.rs#L610