### PR TITLE
Proper cast for arrow binary, largebinary, varbinary types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ futures = "0.3.30"
 mysql_async = { version = "0.34.1", features = ["native-tls-tls", "chrono"], optional = true }
 r2d2 = { version = "0.8.10", optional = true }
 rusqlite = { version = "0.31.0", optional = true }
-sea-query = { version = "0.30.7", features = ["backend-sqlite", "backend-postgres", "postgres-array", "with-rust_decimal", "with-bigdecimal", "with-time"] }
+sea-query = { version = "0.31.0", features = ["backend-sqlite", "backend-postgres", "postgres-array", "with-rust_decimal", "with-bigdecimal", "with-time"] }
 secrecy = "0.8.0"
 snafu = "0.8.3"
 time = "0.3.36"


### PR DESCRIPTION
* Update sea-query to 0.31.0
* Proper casting for arrow binary, largebinary, varbinary types to seaquery column types to facilitate arrow column -> sql row conversion
Reference: https://docs.rs/arrow/latest/arrow/datatypes/enum.DataType.html#