### PR TITLE
feat: Add database base path for SQLite files

### DIFF
--- a/src/sqlite.rs
+++ b/src/sqlite.rs
@@ -84,7 +84,7 @@ type Result<T, E = Error> = std::result::Result<T, E>;
 
 pub struct SqliteTableProviderFactory {
     db_path_param: String,
-    db_base_folder: String,
+    db_base_folder_param: String,
 }
 
 impl SqliteTableProviderFactory {
@@ -92,13 +92,13 @@ impl SqliteTableProviderFactory {
     pub fn new() -> Self {
         Self {
             db_path_param: "sqlite_file".to_string(),
-            db_base_folder: ".".to_string(),
+            db_base_folder_param: "data_directory".to_string(),
         }
     }
 
     #[must_use]
-    pub fn db_base_folder(mut self, db_base_folder: &str) -> Self {
-        self.db_base_folder = db_base_folder.to_string();
+    pub fn db_base_folder_param(mut self, db_base_folder_param: &str) -> Self {
+        self.db_base_folder_param = db_base_folder_param.to_string();
         self
     }
 
@@ -110,7 +110,11 @@ impl SqliteTableProviderFactory {
 
     #[must_use]
     pub fn sqlite_file_path(&self, name: &str, options: &HashMap<String, String>) -> String {
-        let default_filepath = format!("{}/{name}_sqlite.db", self.db_base_folder);
+        let db_base_folder = options
+            .get(&self.db_base_folder_param)
+            .cloned()
+            .unwrap_or(".".to_string()); // default to the current directory
+        let default_filepath = format!("{db_base_folder}/{name}_sqlite.db");
 
         options
             .get(&self.db_path_param)

--- a/src/sqlite.rs
+++ b/src/sqlite.rs
@@ -84,6 +84,7 @@ type Result<T, E = Error> = std::result::Result<T, E>;
 
 pub struct SqliteTableProviderFactory {
     db_path_param: String,
+    db_base_folder: String,
 }
 
 impl SqliteTableProviderFactory {
@@ -91,7 +92,14 @@ impl SqliteTableProviderFactory {
     pub fn new() -> Self {
         Self {
             db_path_param: "sqlite_file".to_string(),
+            db_base_folder: ".".to_string(),
         }
+    }
+
+    #[must_use]
+    pub fn db_base_folder(mut self, db_base_folder: &str) -> Self {
+        self.db_base_folder = db_base_folder.to_string();
+        self
     }
 
     #[must_use]
@@ -102,10 +110,12 @@ impl SqliteTableProviderFactory {
 
     #[must_use]
     pub fn sqlite_file_path(&self, name: &str, options: &HashMap<String, String>) -> String {
+        let default_filepath = format!("{}/{name}_sqlite.db", self.db_base_folder);
+
         options
             .get(&self.db_path_param)
             .cloned()
-            .unwrap_or_else(|| format!("{name}_sqlite.db"))
+            .unwrap_or(default_filepath)
     }
 }
 


### PR DESCRIPTION
## 🗣 Description

<!-- include a description about your pull request and changes, and why these changes need to be made -->

* Adds `db_base_folder` to `SqliteTableProviderFactory` to allow a base folder path be set for SQLite DB files.