### PR TITLE
Fix the wrong conversion of arrow date 64

### DIFF
--- a/src/sql/arrow_sql_gen/statement.rs
+++ b/src/sql/arrow_sql_gen/statement.rs
@@ -246,7 +246,7 @@ impl InsertBuilder {
                             }
                             row_values.push(
                                 match OffsetDateTime::from_unix_timestamp(
-                                    valid_array.value(row) * 86_400,
+                                    valid_array.value(row) / 1000,
                                 ) {
                                     Ok(offset_time) => offset_time.date().into(),
                                     Err(e) => {


### PR DESCRIPTION
Date64 counts the number of milliseconds from unix epoch. Fix the conversion so that it can correctly be calculated to unix timestamp using from_unix_timestamp function