### PR TITLE
test: Add SQLite-Arrow roundtrip integration test

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -59,4 +59,4 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
 
       - name: Run integration test
-        run: cargo test --test integration --no-default-features --features postgres -- --nocapture
+        run: make test-integration

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,8 @@ rand = "0.8.5"
 reqwest = "0.12.5"
 secrecy = "0.8.0"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
+test-log = { version = "0.2.16", features = ["trace"] }
+rstest = "0.22.0"
 
 [features]
 mysql = ["dep:mysql_async", "dep:async-stream"]

--- a/Makefile
+++ b/Makefile
@@ -11,4 +11,4 @@ lint:
 
 .PHONY: test-integration
 test-integration:
-	cargo test --test integration --no-default-features --features postgres,sqlite -- --nocapture
+	RUST_LOG=debug cargo test --test integration --no-default-features --features postgres,sqlite -- --nocapture

--- a/Makefile
+++ b/Makefile
@@ -11,4 +11,4 @@ lint:
 
 .PHONY: test-integration
 test-integration:
-	cargo test --test integration --no-default-features --features postgres -- --nocapture
+	cargo test --test integration --no-default-features --features postgres,sqlite -- --nocapture

--- a/src/sqlite.rs
+++ b/src/sqlite.rs
@@ -131,7 +131,7 @@ impl Default for SqliteTableProviderFactory {
     }
 }
 
-type DynSqliteConnectionPool =
+pub type DynSqliteConnectionPool =
     dyn DbConnectionPool<Connection, &'static (dyn ToSql + Sync)> + Send + Sync;
 
 fn handle_db_error(err: db_connection_pool::Error) -> DataFusionError {

--- a/tests/arrow_record_batch_gen/mod.rs
+++ b/tests/arrow_record_batch_gen/mod.rs
@@ -39,7 +39,7 @@ pub(crate) fn get_arrow_binary_record_batch() -> RecordBatch {
 }
 
 // All Int types
-pub(crate) fn get_arrow_int_recordbatch() -> RecordBatch {
+pub(crate) fn get_arrow_int_record_batch() -> RecordBatch {
     // Arrow Integer Types
     let int8_arr = Int8Array::from(vec![1, 2, 3]);
     let int16_arr = Int16Array::from(vec![1, 2, 3]);

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1,29 +1,9 @@
-use arrow::array::RecordBatch;
-use tracing::subscriber::DefaultGuard;
-use tracing_subscriber::EnvFilter;
-
 mod arrow_record_batch_gen;
 mod docker;
 #[cfg(feature = "postgres")]
 mod postgres;
 #[cfg(feature = "sqlite")]
 mod sqlite;
-
-fn init_tracing(default_level: Option<&str>) -> DefaultGuard {
-    let filter = match (default_level, std::env::var("SPICED_LOG").ok()) {
-        (_, Some(log)) => EnvFilter::new(log),
-        (Some(level), None) => EnvFilter::new(level),
-        _ => EnvFilter::new(
-            "runtime=TRACE,datafusion-federation=TRACE,datafusion-federation-sql=TRACE",
-        ),
-    };
-
-    let subscriber = tracing_subscriber::FmtSubscriber::builder()
-        .with_env_filter(filter)
-        .with_ansi(true)
-        .finish();
-    tracing::subscriber::set_default(subscriber)
-}
 
 fn container_registry() -> String {
     std::env::var("CONTAINER_REGISTRY")

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -6,6 +6,8 @@ mod arrow_record_batch_gen;
 mod docker;
 #[cfg(feature = "postgres")]
 mod postgres;
+#[cfg(feature = "sqlite")]
+mod sqlite;
 
 fn init_tracing(default_level: Option<&str>) -> DefaultGuard {
     let filter = match (default_level, std::env::var("SPICED_LOG").ok()) {

--- a/tests/postgres/mod.rs
+++ b/tests/postgres/mod.rs
@@ -1,146 +1,134 @@
-use super::*;
-use crate::arrow_record_batch_gen::*;
-use datafusion::execution::context::SessionContext;
-use datafusion_table_providers::sql::arrow_sql_gen::statement::{
-    CreateTableBuilder, InsertBuilder,
-};
-use datafusion_table_providers::{
-    postgres::DynPostgresConnectionPool, sql::sql_provider_datafusion::SqlTable,
-};
-use std::sync::Arc;
+#[cfg(feature = "postgres")]
 mod common;
 
-async fn arrow_postgres_round_trip(
-    port: usize,
-    arrow_record: RecordBatch,
-    table_name: &str,
-) -> Result<(), String> {
-    tracing::debug!("Running tests on {table_name}");
-    let ctx = SessionContext::new();
+#[cfg(feature = "postgres")]
+mod test {
+    use super::common;
+    use crate::arrow_record_batch_gen::*;
+    use arrow::array::RecordBatch;
+    use datafusion::execution::context::SessionContext;
+    use datafusion_table_providers::sql::arrow_sql_gen::statement::{
+        CreateTableBuilder, InsertBuilder,
+    };
+    use datafusion_table_providers::{
+        postgres::DynPostgresConnectionPool, sql::sql_provider_datafusion::SqlTable,
+    };
+    use rstest::{fixture, rstest};
+    use std::sync::Arc;
 
-    let pool = common::get_postgres_connection_pool(port)
-        .await
-        .map_err(|e| format!("Failed to create postgres connection pool: {e}"))?;
+    async fn arrow_postgres_round_trip(port: usize, arrow_record: RecordBatch, table_name: &str) {
+        tracing::debug!("Running tests on {table_name}");
+        let ctx = SessionContext::new();
 
-    let db_conn = pool
-        .connect_direct()
-        .await
-        .expect("connection can be established");
+        let pool = common::get_postgres_connection_pool(port)
+            .await
+            .expect("Postgres connection pool should be created");
 
-    // Create postgres table from arrow records and insert arrow records
-    let schema = Arc::clone(&arrow_record.schema());
-    let create_table_stmts = CreateTableBuilder::new(schema, table_name).build_postgres();
-    let insert_table_stmt = InsertBuilder::new(table_name, vec![arrow_record.clone()])
-        .build_postgres(None)
-        .map_err(|e| format!("Unable to construct postgres insert statement: {e}"))?;
+        let db_conn = pool
+            .connect_direct()
+            .await
+            .expect("Connection should be established");
 
-    // Test arrow -> Postgres row coverage
-    for create_table_stmt in create_table_stmts {
+        // Create postgres table from arrow records and insert arrow records
+        let schema = Arc::clone(&arrow_record.schema());
+        let create_table_stmts = CreateTableBuilder::new(schema, table_name).build_postgres();
+        let insert_table_stmt = InsertBuilder::new(table_name, vec![arrow_record.clone()])
+            .build_postgres(None)
+            .expect("Postgres insert statement should be constructed");
+
+        // Test arrow -> Postgres row coverage
+        for create_table_stmt in create_table_stmts {
+            let _ = db_conn
+                .conn
+                .execute(&create_table_stmt, &[])
+                .await
+                .expect("Postgres table should be created");
+        }
         let _ = db_conn
             .conn
-            .execute(&create_table_stmt, &[])
+            .execute(&insert_table_stmt, &[])
             .await
-            .map_err(|e| format!("Postgres table cannot be created: {e}"));
+            .expect("Postgres table data should be inserted");
+
+        // Register datafusion table, test row -> arrow conversion
+        let sqltable_pool: Arc<DynPostgresConnectionPool> = Arc::new(pool);
+        let table = SqlTable::new("postgres", &sqltable_pool, table_name, None)
+            .await
+            .expect("Table should be created");
+        ctx.register_table(table_name, Arc::new(table))
+            .expect("Table should be registered");
+        let sql = format!("SELECT * FROM {table_name}");
+        let df = ctx
+            .sql(&sql)
+            .await
+            .expect("DataFrame should be created from query");
+
+        let record_batch = df.collect().await.expect("RecordBatch should be collected");
+
+        // Print original arrow record batch and record batch converted from postgres row in terminal
+        // Check if the values are the same
+        tracing::debug!("Original Arrow Record Batch: {:?}", arrow_record.columns());
+        tracing::debug!(
+            "Postgres returned Record Batch: {:?}",
+            record_batch[0].columns()
+        );
+
+        // Check results
+        assert_eq!(record_batch.len(), 1);
+        assert_eq!(record_batch[0].num_rows(), arrow_record.num_rows());
+        assert_eq!(record_batch[0].num_columns(), arrow_record.num_columns());
     }
-    let _ = db_conn
-        .conn
-        .execute(&insert_table_stmt, &[])
-        .await
-        .map_err(|e| format!("Postgres table cannot be created: {e}"));
 
-    // Register datafusion table, test row -> arrow conversion
-    let sqltable_pool: Arc<DynPostgresConnectionPool> = Arc::new(pool);
-    let table = SqlTable::new("postgres", &sqltable_pool, table_name, None)
-        .await
-        .expect("table can be created");
-    ctx.register_table(table_name, Arc::new(table))
-        .expect("Table should be registered");
-    let sql = format!("SELECT * FROM {table_name}");
-    let df = ctx
-        .sql(&sql)
-        .await
-        .expect("DataFrame can't be created from query");
+    #[fixture]
+    #[once]
+    fn setup_container_port() -> usize {
+        let port = tokio::task::block_in_place(|| {
+            let handle = tokio::runtime::Handle::current();
+            handle.block_on(async {
+                let port = common::get_random_port();
+                let _ = common::start_postgres_docker_container(port)
+                    .await
+                    .expect("Postgres container to start");
 
-    let record_batch = df.collect().await.expect("RecordBatch can't be collected");
+                tracing::debug!("Container started");
 
-    // Print original arrow record batch and record batch converted from postgres row in terminal
-    // Check if the values are the same
-    tracing::debug!("Original Arrow Record Batch: {:?}", arrow_record.columns());
-    tracing::debug!(
-        "Postgres returned Record Batch: {:?}",
-        record_batch[0].columns()
-    );
+                port
+            })
+        });
 
-    // Check results
-    assert_eq!(record_batch.len(), 1);
-    assert_eq!(record_batch[0].num_rows(), arrow_record.num_rows());
-    assert_eq!(record_batch[0].num_columns(), arrow_record.num_columns());
+        port
+    }
 
-    Ok(())
-}
-
-#[tokio::test]
-#[cfg(feature = "postgres")]
-async fn test_arrow_postgres_types_conversion() -> Result<(), String> {
-    let _tracing = init_tracing(Some("integration=debug,info"));
-    let port = common::get_random_port();
-    let _running_container = common::start_postgres_docker_container(port)
-        .await
-        .map_err(|e| format!("Failed to create postgres container: {e}"))?;
-
-    tracing::debug!("Container started");
-
-    arrow_postgres_round_trip(port, get_arrow_binary_record_batch(), "binary_types")
-        .await
-        .unwrap();
-
-    arrow_postgres_round_trip(port, get_arrow_int_record_batch(), "int_types")
-        .await
-        .unwrap();
-
-    arrow_postgres_round_trip(port, get_arrow_float_record_batch(), "float_types")
-        .await
-        .unwrap();
-
-    arrow_postgres_round_trip(port, get_arrow_utf8_record_batch(), "utf8_types")
-        .await
-        .unwrap();
-
-    // arrow_postgres_round_trip(port, get_arrow_time_record_batch(), "time_types")
-    //     .await
-    //     .unwrap();
-
-    arrow_postgres_round_trip(port, get_arrow_timestamp_record_batch(), "timestamp_types")
-        .await
-        .unwrap();
-
-    // arrow_postgres_round_trip(port, get_arrow_date_record_batch(), "date_types")
-    //     .await
-    //     .unwrap();
-
-    arrow_postgres_round_trip(port, get_arrow_struct_record_batch(), "struct_types")
-        .await
-        .unwrap();
-
-    // arrow_postgres_round_trip(port, get_arrow_decimal_record_batch(), "decimal_types")
-    //     .await
-    //     .unwrap();
-
-    arrow_postgres_round_trip(port, get_arrow_interval_record_batch(), "interval_types")
-        .await
-        .unwrap();
-
-    // arrow_postgres_round_trip(port, get_arrow_duration_record_batch(), "duration_types")
-    //     .await
-    //     .unwrap();
-
-    // arrow_postgres_round_trip(port, get_arrow_list_record_batch(), "list_types")
-    //     .await
-    //     .unwrap();
-
-    arrow_postgres_round_trip(port, get_arrow_null_record_batch(), "null_types")
-        .await
-        .unwrap();
-
-    Ok(())
+    #[rstest]
+    #[case::binary(get_arrow_binary_record_batch(), "binary")]
+    #[case::int(get_arrow_int_record_batch(), "int")]
+    #[case::float(get_arrow_float_record_batch(), "float")]
+    #[case::utf8(get_arrow_utf8_record_batch(), "utf8")]
+    #[ignore] // TODO: time types are broken in Postgres
+    #[case::time(get_arrow_time_record_batch(), "time")]
+    #[case::timestamp(get_arrow_timestamp_record_batch(), "timestamp")]
+    #[ignore] // TODO: date types are broken in Postgres
+    #[case::date(get_arrow_date_record_batch(), "date")]
+    #[case::struct_type(get_arrow_struct_record_batch(), "struct")]
+    #[ignore] // TODO: decimal types are broken in Postgres
+    #[case::decimal(get_arrow_decimal_record_batch(), "decimal")]
+    #[case::interval(get_arrow_interval_record_batch(), "interval")]
+    #[ignore] // TODO: duration types are broken in Postgres
+    #[case::duration(get_arrow_duration_record_batch(), "duration")]
+    #[ignore] // TODO: list types are broken in Postgres
+    #[case::list(get_arrow_list_record_batch(), "list")]
+    #[case::null(get_arrow_null_record_batch(), "null")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
+    async fn test_arrow_sqlite_roundtrip(
+        setup_container_port: &usize,
+        #[case] arrow_record: RecordBatch,
+        #[case] table_name: &str,
+    ) {
+        arrow_postgres_round_trip(
+            *setup_container_port,
+            arrow_record,
+            &format!("{table_name}_types"),
+        )
+        .await;
+    }
 }

--- a/tests/postgres/mod.rs
+++ b/tests/postgres/mod.rs
@@ -1,11 +1,9 @@
 use super::*;
 use crate::arrow_record_batch_gen::*;
 use datafusion::execution::context::SessionContext;
-#[cfg(feature = "postgres")]
 use datafusion_table_providers::sql::arrow_sql_gen::statement::{
     CreateTableBuilder, InsertBuilder,
 };
-#[cfg(feature = "postgres")]
 use datafusion_table_providers::{
     postgres::DynPostgresConnectionPool, sql::sql_provider_datafusion::SqlTable,
 };
@@ -96,7 +94,7 @@ async fn test_arrow_postgres_types_conversion() -> Result<(), String> {
         .await
         .unwrap();
 
-    arrow_postgres_round_trip(port, get_arrow_int_recordbatch(), "int_types")
+    arrow_postgres_round_trip(port, get_arrow_int_record_batch(), "int_types")
         .await
         .unwrap();
 

--- a/tests/sqlite/mod.rs
+++ b/tests/sqlite/mod.rs
@@ -1,168 +1,103 @@
-use super::*;
-use crate::arrow_record_batch_gen::*;
-use datafusion::execution::context::SessionContext;
-use datafusion_table_providers::sql::arrow_sql_gen::statement::{
-    CreateTableBuilder, InsertBuilder,
-};
-use datafusion_table_providers::sql::db_connection_pool::sqlitepool::SqliteConnectionPoolFactory;
-use datafusion_table_providers::sql::db_connection_pool::{DbConnectionPool, Mode};
-use datafusion_table_providers::sql::sql_provider_datafusion::SqlTable;
-use datafusion_table_providers::sqlite::DynSqliteConnectionPool;
-use std::sync::Arc;
-
-async fn arrow_sqlite_round_trip(arrow_record: RecordBatch, table_name: &str) -> () {
-    tracing::debug!("Running tests on {table_name}");
-    let ctx = SessionContext::new();
-
-    let pool = SqliteConnectionPoolFactory::new(":memory:", Mode::Memory)
-        .build()
-        .await
-        .expect("Sqlite connection pool to be created");
-
-    let conn = pool
-        .connect()
-        .await
-        .expect("Sqlite connection should be established");
-    let conn = conn.as_async().unwrap();
-
-    // Create sqlite table from arrow records and insert arrow records
-    let schema = Arc::clone(&arrow_record.schema());
-    let create_table_stmts = CreateTableBuilder::new(schema, table_name).build_sqlite();
-    let insert_table_stmt = InsertBuilder::new(table_name, vec![arrow_record.clone()])
-        .build_sqlite(None)
-        .expect("SQLite insert statement should be constructed");
-
-    // Test arrow -> Sqlite row coverage
-    let _ = conn
-        .execute(&create_table_stmts, &[])
-        .await
-        .expect("Sqlite table should be created");
-    let _ = conn
-        .execute(&insert_table_stmt, &[])
-        .await
-        .expect("Sqlite data should be inserted");
-
-    // Register datafusion table, test row -> arrow conversion
-    let sqltable_pool: Arc<DynSqliteConnectionPool> = Arc::new(pool);
-    let table = SqlTable::new("sqlite", &sqltable_pool, table_name, None)
-        .await
-        .expect("Table should be created");
-    ctx.register_table(table_name, Arc::new(table))
-        .expect("Table should be registered");
-    let sql = format!("SELECT * FROM {table_name}");
-    let df = ctx
-        .sql(&sql)
-        .await
-        .expect("DataFrame should be created from query");
-
-    let record_batch = df.collect().await.expect("RecordBatch should be collected");
-
-    // Print original arrow record batch and record batch converted from postgres row in terminal
-    // Check if the values are the same
-    tracing::debug!("Original Arrow Record Batch: {:?}", arrow_record.columns());
-    tracing::debug!(
-        "Postgres returned Record Batch: {:?}",
-        record_batch[0].columns()
-    );
-
-    // Check results
-    assert_eq!(record_batch.len(), 1);
-    assert_eq!(record_batch[0].num_rows(), arrow_record.num_rows());
-    assert_eq!(record_batch[0].num_columns(), arrow_record.num_columns());
-}
-
-#[tokio::test]
 #[cfg(feature = "sqlite")]
-async fn test_arrow_sqlite_types_conversion_binary() {
-    let _tracing = init_tracing(Some("integration=debug,info"));
-    arrow_sqlite_round_trip(get_arrow_binary_record_batch(), "binary_types").await;
-}
+mod test {
+    use crate::arrow_record_batch_gen::*;
+    use arrow::array::RecordBatch;
+    use datafusion::execution::context::SessionContext;
+    use datafusion_table_providers::sql::arrow_sql_gen::statement::{
+        CreateTableBuilder, InsertBuilder,
+    };
+    use datafusion_table_providers::sql::db_connection_pool::sqlitepool::SqliteConnectionPoolFactory;
+    use datafusion_table_providers::sql::db_connection_pool::{DbConnectionPool, Mode};
+    use datafusion_table_providers::sql::sql_provider_datafusion::SqlTable;
+    use datafusion_table_providers::sqlite::DynSqliteConnectionPool;
+    use rstest::rstest;
+    use std::sync::Arc;
 
-#[tokio::test]
-#[cfg(feature = "sqlite")]
-async fn test_arrow_sqlite_types_conversion_int() {
-    let _tracing = init_tracing(Some("integration=debug,info"));
-    arrow_sqlite_round_trip(get_arrow_int_record_batch(), "int_types").await;
-}
+    async fn arrow_sqlite_round_trip(arrow_record: RecordBatch, table_name: &str) -> () {
+        tracing::debug!("Running tests on {table_name}");
+        let ctx = SessionContext::new();
 
-#[tokio::test]
-#[cfg(feature = "sqlite")]
-async fn test_arrow_sqlite_types_conversion_float() {
-    let _tracing = init_tracing(Some("integration=debug,info"));
-    arrow_sqlite_round_trip(get_arrow_float_record_batch(), "float_types").await;
-}
+        let pool = SqliteConnectionPoolFactory::new(":memory:", Mode::Memory)
+            .build()
+            .await
+            .expect("Sqlite connection pool to be created");
 
-#[tokio::test]
-#[cfg(feature = "sqlite")]
-async fn test_arrow_sqlite_types_conversion_utf8() {
-    let _tracing = init_tracing(Some("integration=debug,info"));
-    arrow_sqlite_round_trip(get_arrow_utf8_record_batch(), "utf8_types").await;
-}
+        let conn = pool
+            .connect()
+            .await
+            .expect("Sqlite connection should be established");
+        let conn = conn.as_async().unwrap();
 
-#[tokio::test]
-#[cfg(feature = "sqlite")]
-async fn test_arrow_sqlite_types_conversion_time() {
-    let _tracing = init_tracing(Some("integration=debug,info"));
-    arrow_sqlite_round_trip(get_arrow_time_record_batch(), "time_types").await;
-}
+        // Create sqlite table from arrow records and insert arrow records
+        let schema = Arc::clone(&arrow_record.schema());
+        let create_table_stmts = CreateTableBuilder::new(schema, table_name).build_sqlite();
+        let insert_table_stmt = InsertBuilder::new(table_name, vec![arrow_record.clone()])
+            .build_sqlite(None)
+            .expect("SQLite insert statement should be constructed");
 
-#[tokio::test]
-#[cfg(feature = "sqlite")]
-async fn test_arrow_sqlite_types_conversion_timestamp() {
-    let _tracing = init_tracing(Some("integration=debug,info"));
-    arrow_sqlite_round_trip(get_arrow_timestamp_record_batch(), "timestamp_types").await;
-}
+        // Test arrow -> Sqlite row coverage
+        let _ = conn
+            .execute(&create_table_stmts, &[])
+            .await
+            .expect("Sqlite table should be created");
+        let _ = conn
+            .execute(&insert_table_stmt, &[])
+            .await
+            .expect("Sqlite data should be inserted");
 
-#[tokio::test]
-#[cfg(feature = "sqlite")]
-async fn test_arrow_sqlite_types_conversion_date() {
-    let _tracing = init_tracing(Some("integration=debug,info"));
-    arrow_sqlite_round_trip(get_arrow_date_record_batch(), "date_types").await;
-}
+        // Register datafusion table, test row -> arrow conversion
+        let sqltable_pool: Arc<DynSqliteConnectionPool> = Arc::new(pool);
+        let table = SqlTable::new("sqlite", &sqltable_pool, table_name, None)
+            .await
+            .expect("Table should be created");
+        ctx.register_table(table_name, Arc::new(table))
+            .expect("Table should be registered");
+        let sql = format!("SELECT * FROM {table_name}");
+        let df = ctx
+            .sql(&sql)
+            .await
+            .expect("DataFrame should be created from query");
 
-#[ignore]
-#[tokio::test]
-#[cfg(feature = "sqlite")]
-async fn test_arrow_sqlite_types_conversion_struct() {
-    let _tracing = init_tracing(Some("integration=debug,info"));
-    arrow_sqlite_round_trip(get_arrow_struct_record_batch(), "struct_types").await;
-}
+        let record_batch = df.collect().await.expect("RecordBatch should be collected");
 
-#[ignore]
-#[tokio::test]
-#[cfg(feature = "sqlite")]
-async fn test_arrow_sqlite_types_conversion_decimal() {
-    let _tracing = init_tracing(Some("integration=debug,info"));
-    arrow_sqlite_round_trip(get_arrow_decimal_record_batch(), "decimal_types").await;
-}
+        // Print original arrow record batch and record batch converted from sqlite row in terminal
+        // Check if the values are the same
+        tracing::debug!("Original Arrow Record Batch: {:?}", arrow_record.columns());
+        tracing::debug!(
+            "Sqlite returned Record Batch: {:?}",
+            record_batch[0].columns()
+        );
 
-#[ignore]
-#[tokio::test]
-#[cfg(feature = "sqlite")]
-async fn test_arrow_sqlite_types_conversion_interval() {
-    let _tracing = init_tracing(Some("integration=debug,info"));
-    arrow_sqlite_round_trip(get_arrow_interval_record_batch(), "interval_types").await;
-}
+        // Check results
+        assert_eq!(record_batch.len(), 1);
+        assert_eq!(record_batch[0].num_rows(), arrow_record.num_rows());
+        assert_eq!(record_batch[0].num_columns(), arrow_record.num_columns());
+    }
 
-#[ignore]
-#[tokio::test]
-#[cfg(feature = "sqlite")]
-async fn test_arrow_sqlite_types_conversion_duration() {
-    let _tracing = init_tracing(Some("integration=debug,info"));
-    arrow_sqlite_round_trip(get_arrow_duration_record_batch(), "duration_types").await;
-}
-
-#[ignore]
-#[tokio::test]
-#[cfg(feature = "sqlite")]
-async fn test_arrow_sqlite_types_conversion_list() {
-    let _tracing = init_tracing(Some("integration=debug,info"));
-    arrow_sqlite_round_trip(get_arrow_list_record_batch(), "list_types").await;
-}
-
-#[tokio::test]
-#[cfg(feature = "sqlite")]
-async fn test_arrow_sqlite_types_conversion_null() {
-    let _tracing = init_tracing(Some("integration=debug,info"));
-    arrow_sqlite_round_trip(get_arrow_null_record_batch(), "null_types").await;
+    #[rstest]
+    #[case::binary(get_arrow_binary_record_batch(), "binary")]
+    #[case::int(get_arrow_int_record_batch(), "int")]
+    #[case::float(get_arrow_float_record_batch(), "float")]
+    #[case::utf8(get_arrow_utf8_record_batch(), "utf8")]
+    #[case::time(get_arrow_time_record_batch(), "time")]
+    #[case::timestamp(get_arrow_timestamp_record_batch(), "timestamp")]
+    #[case::date(get_arrow_date_record_batch(), "date")]
+    #[ignore] // TODO: struct types are broken in SQLite
+    #[case::struct_type(get_arrow_struct_record_batch(), "struct")]
+    #[ignore] // TODO: decimal types are broken in SQLite
+    #[case::decimal(get_arrow_decimal_record_batch(), "decimal")]
+    #[ignore] // TODO: interval types are broken in SQLite
+    #[case::interval(get_arrow_interval_record_batch(), "interval")]
+    #[ignore] // TODO: duration types are broken in SQLite
+    #[case::duration(get_arrow_duration_record_batch(), "duration")]
+    #[ignore] // TODO: list types are broken in SQLite
+    #[case::list(get_arrow_list_record_batch(), "list")]
+    #[case::null(get_arrow_null_record_batch(), "null")]
+    #[test_log::test(tokio::test)]
+    async fn test_arrow_sqlite_roundtrip(
+        #[case] arrow_record: RecordBatch,
+        #[case] table_name: &str,
+    ) {
+        arrow_sqlite_round_trip(arrow_record, &format!("{table_name}_types")).await;
+    }
 }

--- a/tests/sqlite/mod.rs
+++ b/tests/sqlite/mod.rs
@@ -1,0 +1,168 @@
+use super::*;
+use crate::arrow_record_batch_gen::*;
+use datafusion::execution::context::SessionContext;
+use datafusion_table_providers::sql::arrow_sql_gen::statement::{
+    CreateTableBuilder, InsertBuilder,
+};
+use datafusion_table_providers::sql::db_connection_pool::sqlitepool::SqliteConnectionPoolFactory;
+use datafusion_table_providers::sql::db_connection_pool::{DbConnectionPool, Mode};
+use datafusion_table_providers::sql::sql_provider_datafusion::SqlTable;
+use datafusion_table_providers::sqlite::DynSqliteConnectionPool;
+use std::sync::Arc;
+
+async fn arrow_sqlite_round_trip(arrow_record: RecordBatch, table_name: &str) -> () {
+    tracing::debug!("Running tests on {table_name}");
+    let ctx = SessionContext::new();
+
+    let pool = SqliteConnectionPoolFactory::new(":memory:", Mode::Memory)
+        .build()
+        .await
+        .expect("Sqlite connection pool to be created");
+
+    let conn = pool
+        .connect()
+        .await
+        .expect("Sqlite connection should be established");
+    let conn = conn.as_async().unwrap();
+
+    // Create sqlite table from arrow records and insert arrow records
+    let schema = Arc::clone(&arrow_record.schema());
+    let create_table_stmts = CreateTableBuilder::new(schema, table_name).build_sqlite();
+    let insert_table_stmt = InsertBuilder::new(table_name, vec![arrow_record.clone()])
+        .build_sqlite(None)
+        .expect("SQLite insert statement should be constructed");
+
+    // Test arrow -> Sqlite row coverage
+    let _ = conn
+        .execute(&create_table_stmts, &[])
+        .await
+        .expect("Sqlite table should be created");
+    let _ = conn
+        .execute(&insert_table_stmt, &[])
+        .await
+        .expect("Sqlite data should be inserted");
+
+    // Register datafusion table, test row -> arrow conversion
+    let sqltable_pool: Arc<DynSqliteConnectionPool> = Arc::new(pool);
+    let table = SqlTable::new("sqlite", &sqltable_pool, table_name, None)
+        .await
+        .expect("Table should be created");
+    ctx.register_table(table_name, Arc::new(table))
+        .expect("Table should be registered");
+    let sql = format!("SELECT * FROM {table_name}");
+    let df = ctx
+        .sql(&sql)
+        .await
+        .expect("DataFrame should be created from query");
+
+    let record_batch = df.collect().await.expect("RecordBatch should be collected");
+
+    // Print original arrow record batch and record batch converted from postgres row in terminal
+    // Check if the values are the same
+    tracing::debug!("Original Arrow Record Batch: {:?}", arrow_record.columns());
+    tracing::debug!(
+        "Postgres returned Record Batch: {:?}",
+        record_batch[0].columns()
+    );
+
+    // Check results
+    assert_eq!(record_batch.len(), 1);
+    assert_eq!(record_batch[0].num_rows(), arrow_record.num_rows());
+    assert_eq!(record_batch[0].num_columns(), arrow_record.num_columns());
+}
+
+#[tokio::test]
+#[cfg(feature = "sqlite")]
+async fn test_arrow_sqlite_types_conversion_binary() {
+    let _tracing = init_tracing(Some("integration=debug,info"));
+    arrow_sqlite_round_trip(get_arrow_binary_record_batch(), "binary_types").await;
+}
+
+#[tokio::test]
+#[cfg(feature = "sqlite")]
+async fn test_arrow_sqlite_types_conversion_int() {
+    let _tracing = init_tracing(Some("integration=debug,info"));
+    arrow_sqlite_round_trip(get_arrow_int_record_batch(), "int_types").await;
+}
+
+#[tokio::test]
+#[cfg(feature = "sqlite")]
+async fn test_arrow_sqlite_types_conversion_float() {
+    let _tracing = init_tracing(Some("integration=debug,info"));
+    arrow_sqlite_round_trip(get_arrow_float_record_batch(), "float_types").await;
+}
+
+#[tokio::test]
+#[cfg(feature = "sqlite")]
+async fn test_arrow_sqlite_types_conversion_utf8() {
+    let _tracing = init_tracing(Some("integration=debug,info"));
+    arrow_sqlite_round_trip(get_arrow_utf8_record_batch(), "utf8_types").await;
+}
+
+#[tokio::test]
+#[cfg(feature = "sqlite")]
+async fn test_arrow_sqlite_types_conversion_time() {
+    let _tracing = init_tracing(Some("integration=debug,info"));
+    arrow_sqlite_round_trip(get_arrow_time_record_batch(), "time_types").await;
+}
+
+#[tokio::test]
+#[cfg(feature = "sqlite")]
+async fn test_arrow_sqlite_types_conversion_timestamp() {
+    let _tracing = init_tracing(Some("integration=debug,info"));
+    arrow_sqlite_round_trip(get_arrow_timestamp_record_batch(), "timestamp_types").await;
+}
+
+#[tokio::test]
+#[cfg(feature = "sqlite")]
+async fn test_arrow_sqlite_types_conversion_date() {
+    let _tracing = init_tracing(Some("integration=debug,info"));
+    arrow_sqlite_round_trip(get_arrow_date_record_batch(), "date_types").await;
+}
+
+#[ignore]
+#[tokio::test]
+#[cfg(feature = "sqlite")]
+async fn test_arrow_sqlite_types_conversion_struct() {
+    let _tracing = init_tracing(Some("integration=debug,info"));
+    arrow_sqlite_round_trip(get_arrow_struct_record_batch(), "struct_types").await;
+}
+
+#[ignore]
+#[tokio::test]
+#[cfg(feature = "sqlite")]
+async fn test_arrow_sqlite_types_conversion_decimal() {
+    let _tracing = init_tracing(Some("integration=debug,info"));
+    arrow_sqlite_round_trip(get_arrow_decimal_record_batch(), "decimal_types").await;
+}
+
+#[ignore]
+#[tokio::test]
+#[cfg(feature = "sqlite")]
+async fn test_arrow_sqlite_types_conversion_interval() {
+    let _tracing = init_tracing(Some("integration=debug,info"));
+    arrow_sqlite_round_trip(get_arrow_interval_record_batch(), "interval_types").await;
+}
+
+#[ignore]
+#[tokio::test]
+#[cfg(feature = "sqlite")]
+async fn test_arrow_sqlite_types_conversion_duration() {
+    let _tracing = init_tracing(Some("integration=debug,info"));
+    arrow_sqlite_round_trip(get_arrow_duration_record_batch(), "duration_types").await;
+}
+
+#[ignore]
+#[tokio::test]
+#[cfg(feature = "sqlite")]
+async fn test_arrow_sqlite_types_conversion_list() {
+    let _tracing = init_tracing(Some("integration=debug,info"));
+    arrow_sqlite_round_trip(get_arrow_list_record_batch(), "list_types").await;
+}
+
+#[tokio::test]
+#[cfg(feature = "sqlite")]
+async fn test_arrow_sqlite_types_conversion_null() {
+    let _tracing = init_tracing(Some("integration=debug,info"));
+    arrow_sqlite_round_trip(get_arrow_null_record_batch(), "null_types").await;
+}


### PR DESCRIPTION
## 🗣 Description

* Adds round-trip integration test for testing Arrow data types in SQLite.

By default ignores the following tests as they fail: `struct`, `decimal`, `interval`, `duration`, `list`.