### PR TITLE
fix: Don't attach empty SQLite attachments

### DIFF
--- a/src/sql/db_connection_pool/sqlitepool.rs
+++ b/src/sql/db_connection_pool/sqlitepool.rs
@@ -68,7 +68,6 @@ impl SqliteConnectionPoolFactory {
                     attach_databases.sort();
 
                     JoinPushDown::AllowedFor(attach_databases.join(";")) // push down is allowed cross-database when they're attached together
-                                                                         // hash the list of databases to generate the comparison for push down
                 }
             }
             (Mode::File, None) => JoinPushDown::AllowedFor(self.path.to_string()),


### PR DESCRIPTION
## 🗣 Description

* Fixes SQLite database attachments to avoid attempting to attach when an empty vec of attachments is supplied.
* Updates tests to use randomised DB filenames to make new tests easier to add without clashing filenames.