### PR TITLE
Properly support decimal types in mysql row -> arrow conversion

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,4 +11,4 @@ lint:
 
 .PHONY: test-integration
 test-integration:
-	RUST_LOG=debug cargo test --test integration --no-default-features --features postgres,sqlite -- --nocapture
+	RUST_LOG=debug cargo test --test integration --no-default-features --features postgres,sqlite,mysql -- --nocapture

--- a/src/sql/db_connection_pool/dbconnection/mysqlconn.rs
+++ b/src/sql/db_connection_pool/dbconnection/mysqlconn.rs
@@ -2,7 +2,7 @@ use std::{any::Any, sync::Arc};
 
 use crate::sql::arrow_sql_gen::mysql::map_column_to_data_type;
 use crate::sql::arrow_sql_gen::{self, mysql::rows_to_arrow};
-use arrow::datatypes::{DataType, Field, Schema, SchemaRef};
+use arrow::datatypes::{Field, Schema, SchemaRef};
 use async_stream::stream;
 use datafusion::error::DataFusionError;
 use datafusion::execution::SendableRecordBatchStream;
@@ -169,18 +169,19 @@ fn columns_meta_to_schema(columns_meta: Vec<Row>) -> Result<SchemaRef> {
         let column_type = map_str_type_to_column_type(&data_type)?;
         let column_is_binary = map_str_type_to_is_binary(&data_type);
 
-        let arrow_data_type = match column_type {
-            // map_column_to_data_type does not support decimal mapping and uses special logic to handle conversion based on actual value
-            // so we handle it separately
+        let scale = match column_type {
             ColumnType::MYSQL_TYPE_DECIMAL | ColumnType::MYSQL_TYPE_NEWDECIMAL => {
                 let (_precision, scale) = extract_decimal_precision_and_scale(&data_type)
                     .context(super::UnableToGetSchemaSnafu)?;
                 // rows_to_arrow uses hardcoded precision 38 for decimal so we use it here as well
-                DataType::Decimal128(38, scale)
+                Some(scale)
             }
-            _ => map_column_to_data_type(column_type, column_is_binary)
-                .context(UnsupportedDataTypeSnafu { data_type })?,
+            _ => None,
         };
+
+        let arrow_data_type = map_column_to_data_type(column_type, column_is_binary, scale)
+            .context(UnsupportedDataTypeSnafu { data_type })?;
+
         fields.push(Field::new(&column_name, arrow_data_type, true));
     }
     Ok(Arc::new(Schema::new(fields)))

--- a/src/sql/db_connection_pool/mysqlpool.rs
+++ b/src/sql/db_connection_pool/mysqlpool.rs
@@ -149,6 +149,17 @@ impl MySQLConnectionPool {
             join_push_down,
         })
     }
+
+    /// Returns a direct connection to the underlying database.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if there is a problem creating the connection pool.
+    pub async fn connect_direct(&self) -> super::Result<MySQLConnection> {
+        let pool = Arc::clone(&self.pool);
+        let conn = pool.get_conn().await.context(ConnectionPoolRunSnafu)?;
+        Ok(MySQLConnection::new(conn))
+    }
 }
 
 fn get_join_context(opts: &mysql_async::Opts) -> JoinPushDown {

--- a/tests/arrow_record_batch_gen/mod.rs
+++ b/tests/arrow_record_batch_gen/mod.rs
@@ -120,6 +120,8 @@ pub(crate) fn get_arrow_utf8_record_batch() -> RecordBatch {
 }
 
 // Time32, Time64
+#[allow(clippy::identity_op)]
+#[allow(clippy::erasing_op)]
 pub(crate) fn get_arrow_time_record_batch() -> RecordBatch {
     // Time32, Time64 Types
     let time32_milli_array: Time32MillisecondArray = vec![

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1,5 +1,7 @@
 mod arrow_record_batch_gen;
 mod docker;
+#[cfg(feature = "mysql")]
+mod mysql;
 #[cfg(feature = "postgres")]
 mod postgres;
 #[cfg(feature = "sqlite")]

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1,3 +1,5 @@
+use rand::Rng;
+
 mod arrow_record_batch_gen;
 mod docker;
 #[cfg(feature = "mysql")]
@@ -10,4 +12,8 @@ mod sqlite;
 fn container_registry() -> String {
     std::env::var("CONTAINER_REGISTRY")
         .unwrap_or_else(|_| "public.ecr.aws/docker/library/".to_string())
+}
+
+fn get_random_port() -> usize {
+    rand::thread_rng().gen_range(15432..65535)
 }

--- a/tests/mysql/common.rs
+++ b/tests/mysql/common.rs
@@ -47,7 +47,6 @@ pub async fn start_mysql_docker_container(
     port: usize,
 ) -> Result<RunningContainer<'static>, anyhow::Error> {
     let container_name = format!("{MYSQL_DOCKER_CONTAINER}-{port}");
-    let container_name: &'static str = Box::leak(container_name.into_boxed_str());
 
     let port = if let Ok(port) = port.try_into() {
         port

--- a/tests/mysql/common.rs
+++ b/tests/mysql/common.rs
@@ -1,0 +1,95 @@
+use bollard::secret::HealthConfig;
+use datafusion_table_providers::sql::db_connection_pool::mysqlpool::MySQLConnectionPool;
+use rand::Rng;
+use secrecy::SecretString;
+use std::collections::HashMap;
+use tracing::instrument;
+
+use crate::{
+    container_registry,
+    docker::{ContainerRunnerBuilder, RunningContainer},
+};
+
+const MYSQL_ROOT_PASSWORD: &str = "integration-test-pw";
+const MYSQL_DOCKER_CONTAINER: &str = "runtime-integration-test-mysql";
+
+fn get_mysql_params(port: usize) -> HashMap<String, SecretString> {
+    let mut params = HashMap::new();
+    params.insert(
+        "mysql_host".to_string(),
+        SecretString::from("localhost".to_string()),
+    );
+    params.insert(
+        "mysql_tcp_port".to_string(),
+        SecretString::from(port.to_string()),
+    );
+    params.insert(
+        "mysql_user".to_string(),
+        SecretString::from("root".to_string()),
+    );
+    params.insert(
+        "mysql_pass".to_string(),
+        SecretString::from(MYSQL_ROOT_PASSWORD.to_string()),
+    );
+    params.insert(
+        "mysql_db".to_string(),
+        SecretString::from("mysqldb".to_string()),
+    );
+    params.insert(
+        "mysql_sslmode".to_string(),
+        SecretString::from("disabled".to_string()),
+    );
+    params
+}
+
+#[instrument]
+pub async fn start_mysql_docker_container(
+    port: usize,
+) -> Result<RunningContainer<'static>, anyhow::Error> {
+    let container_name = format!("{MYSQL_DOCKER_CONTAINER}-{port}");
+    let container_name: &'static str = Box::leak(container_name.into_boxed_str());
+
+    let port = if let Ok(port) = port.try_into() {
+        port
+    } else {
+        15432
+    };
+
+    let running_container = ContainerRunnerBuilder::new(container_name)
+        .image(format!("{}mysql:latest", container_registry()))
+        .add_port_binding(3306, port)
+        .add_env_var("MYSQL_ROOT_PASSWORD", MYSQL_ROOT_PASSWORD)
+        .add_env_var("MYSQL_DATABASE", "mysqldb")
+        .healthcheck(HealthConfig {
+            test: Some(vec![
+                "CMD-SHELL".to_string(),
+                format!("mysqladmin ping --password={MYSQL_ROOT_PASSWORD}"),
+            ]),
+            interval: Some(250_000_000), // 250ms
+            timeout: Some(100_000_000),  // 100ms
+            retries: Some(5),
+            start_period: Some(500_000_000), // 100ms
+            start_interval: None,
+        })
+        .build()?
+        .run()
+        .await?;
+
+    tokio::time::sleep(std::time::Duration::from_millis(5000)).await;
+    Ok(running_container)
+}
+
+#[instrument]
+pub(super) async fn get_mysql_connection_pool(
+    port: usize,
+) -> Result<MySQLConnectionPool, anyhow::Error> {
+    let mysql_pool = MySQLConnectionPool::new(get_mysql_params(port))
+        .await
+        .expect("Failed to create MySQL Connection Pool");
+
+    Ok(mysql_pool)
+}
+
+pub(super) fn get_random_port() -> usize {
+    rand::thread_rng().gen_range(15432..65535)
+}

--- a/tests/mysql/common.rs
+++ b/tests/mysql/common.rs
@@ -1,6 +1,5 @@
 use bollard::secret::HealthConfig;
 use datafusion_table_providers::sql::db_connection_pool::mysqlpool::MySQLConnectionPool;
-use rand::Rng;
 use secrecy::SecretString;
 use std::collections::HashMap;
 use tracing::instrument;
@@ -43,9 +42,7 @@ fn get_mysql_params(port: usize) -> HashMap<String, SecretString> {
 }
 
 #[instrument]
-pub async fn start_mysql_docker_container(
-    port: usize,
-) -> Result<RunningContainer<'static>, anyhow::Error> {
+pub async fn start_mysql_docker_container(port: usize) -> Result<RunningContainer, anyhow::Error> {
     let container_name = format!("{MYSQL_DOCKER_CONTAINER}-{port}");
 
     let port = if let Ok(port) = port.try_into() {
@@ -87,8 +84,4 @@ pub(super) async fn get_mysql_connection_pool(
         .expect("Failed to create MySQL Connection Pool");
 
     Ok(mysql_pool)
-}
-
-pub(super) fn get_random_port() -> usize {
-    rand::thread_rng().gen_range(15432..65535)
 }

--- a/tests/mysql/mod.rs
+++ b/tests/mysql/mod.rs
@@ -1,132 +1,127 @@
-#[cfg(feature = "mysql")]
+use datafusion::execution::context::SessionContext;
+use datafusion_table_providers::{
+    mysql::MySQLConnectionPool, sql::sql_provider_datafusion::SqlTable,
+};
+use rstest::{fixture, rstest};
+use std::sync::Arc;
+use tokio::sync::{Mutex, MutexGuard};
+
+use arrow::array::*;
+
+use datafusion_table_providers::sql::db_connection_pool::dbconnection::AsyncDbConnection;
+
 mod common;
 
-#[cfg(feature = "mysql")]
-mod test {
-    use super::common;
-    use datafusion::execution::context::SessionContext;
-    use datafusion_table_providers::{
-        mysql::MySQLConnectionPool, sql::sql_provider_datafusion::SqlTable,
-    };
-    use rstest::{fixture, rstest};
-    use std::sync::Arc;
-    use tokio::sync::{Mutex, MutexGuard};
+async fn arrow_mysql_one_way(port: usize) {
+    let table_name = "test_table";
+    tracing::debug!("Running tests on {table_name}");
+    let ctx = SessionContext::new();
 
-    use arrow::array::*;
+    let pool = common::get_mysql_connection_pool(port)
+        .await
+        .expect("MySQL connection pool should be created");
 
-    use datafusion_table_providers::sql::db_connection_pool::dbconnection::AsyncDbConnection;
+    let db_conn = pool
+        .connect_direct()
+        .await
+        .expect("Connection should be established");
 
-    async fn arrow_mysql_one_way(port: usize) {
-        let table_name = "test_table";
-        tracing::debug!("Running tests on {table_name}");
-        let ctx = SessionContext::new();
-
-        let pool = common::get_mysql_connection_pool(port)
-            .await
-            .expect("MySQL connection pool should be created");
-
-        let db_conn = pool
-            .connect_direct()
-            .await
-            .expect("Connection should be established");
-
-        // Create mysql table with decimal columns that contains null value
-        let create_table_stmt = "
+    // Create mysql table with decimal columns that contains null value
+    let create_table_stmt = "
         CREATE TABLE IF NOT EXISTS test_table (id INT AUTO_INCREMENT PRIMARY KEY, salary DECIMAL(10, 2));
         ";
-        let insert_table_stmt = "
+    let insert_table_stmt = "
         INSERT INTO test_table (salary) VALUES (NULL), (12);
         ";
 
-        // Create table and insert data into mysql test_table
-        let _ = db_conn
-            .execute(&create_table_stmt, &[])
-            .await
-            .expect("MySQL table should be created");
+    // Create table and insert data into mysql test_table
+    let _ = db_conn
+        .execute(create_table_stmt, &[])
+        .await
+        .expect("MySQL table should be created");
 
-        let _ = db_conn
-            .execute(&insert_table_stmt, &[])
-            .await
-            .expect("MySQL table data should be inserted");
+    let _ = db_conn
+        .execute(insert_table_stmt, &[])
+        .await
+        .expect("MySQL table data should be inserted");
 
-        // Register datafusion table, test mysql row -> arrow conversion
-        let sqltable_pool: Arc<MySQLConnectionPool> = Arc::new(pool);
-        let table = SqlTable::new("mysql", &sqltable_pool, table_name, None)
-            .await
-            .expect("Table should be created");
+    // Register datafusion table, test mysql row -> arrow conversion
+    let sqltable_pool: Arc<MySQLConnectionPool> = Arc::new(pool);
+    let table = SqlTable::new("mysql", &sqltable_pool, table_name, None)
+        .await
+        .expect("Table should be created");
 
-        ctx.register_table(table_name, Arc::new(table))
-            .expect("Table should be registered");
+    ctx.register_table(table_name, Arc::new(table))
+        .expect("Table should be registered");
 
-        let sql = format!("SELECT * FROM {table_name}");
-        let df = ctx
-            .sql(&sql)
-            .await
-            .expect("DataFrame should be created from query");
+    let sql = format!("SELECT * FROM {table_name}");
+    let df = ctx
+        .sql(&sql)
+        .await
+        .expect("DataFrame should be created from query");
 
-        let record_batch = df.collect().await.expect("RecordBatch should be collected");
-        tracing::debug!(
-            "MySQL returned Record Batch: {:?}",
-            record_batch[0].columns()
-        );
+    let record_batch = df.collect().await.expect("RecordBatch should be collected");
+    tracing::debug!(
+        "MySQL returned Record Batch: {:?}",
+        record_batch[0].columns()
+    );
 
-        let int32_array = Int32Array::from(vec![1, 2]);
-        let decimal128_array = Decimal128Array::from(vec![None, Some(i128::from(1200))])
-            .with_precision_and_scale(38, 2)
-            .unwrap();
+    let int32_array = Int32Array::from(vec![1, 2]);
+    let decimal128_array = Decimal128Array::from(vec![None, Some(i128::from(1200))])
+        .with_precision_and_scale(38, 2)
+        .unwrap();
 
-        // Check results
-        assert_eq!(record_batch.len(), 1);
-        assert_eq!(
-            record_batch[0]
-                .column(0)
-                .as_any()
-                .downcast_ref::<Int32Array>()
-                .unwrap(),
-            &int32_array
-        );
-        assert_eq!(
-            record_batch[0]
-                .column(1)
-                .as_any()
-                .downcast_ref::<Decimal128Array>()
-                .unwrap(),
-            &decimal128_array
-        );
+    // Check results
+    assert_eq!(record_batch.len(), 1);
+    assert_eq!(
+        record_batch[0]
+            .column(0)
+            .as_any()
+            .downcast_ref::<Int32Array>()
+            .unwrap(),
+        &int32_array
+    );
+    assert_eq!(
+        record_batch[0]
+            .column(1)
+            .as_any()
+            .downcast_ref::<Decimal128Array>()
+            .unwrap(),
+        &decimal128_array
+    );
+}
+
+#[derive(Debug)]
+struct ContainerManager {
+    port: usize,
+    claimed: bool,
+}
+
+#[fixture]
+#[once]
+fn container_manager() -> Mutex<ContainerManager> {
+    Mutex::new(ContainerManager {
+        port: common::get_random_port(),
+        claimed: false,
+    })
+}
+
+async fn start_container(manager: &MutexGuard<'_, ContainerManager>) {
+    let _ = common::start_mysql_docker_container(manager.port)
+        .await
+        .expect("MySQL container to start");
+
+    tracing::debug!("Container started");
+}
+
+#[rstest]
+#[test_log::test(tokio::test)]
+async fn test_mysql_arrow_oneway(container_manager: &Mutex<ContainerManager>) {
+    let mut container_manager = container_manager.lock().await;
+    if !container_manager.claimed {
+        container_manager.claimed = true;
+        start_container(&container_manager).await;
     }
 
-    #[derive(Debug)]
-    struct ContainerManager {
-        port: usize,
-        claimed: bool,
-    }
-
-    #[fixture]
-    #[once]
-    fn container_manager() -> Mutex<ContainerManager> {
-        Mutex::new(ContainerManager {
-            port: common::get_random_port(),
-            claimed: false,
-        })
-    }
-
-    async fn start_container(manager: &MutexGuard<'_, ContainerManager>) {
-        let _ = common::start_mysql_docker_container(manager.port.into())
-            .await
-            .expect("MySQL container to start");
-
-        tracing::debug!("Container started");
-    }
-
-    #[rstest]
-    #[test_log::test(tokio::test)]
-    async fn test_mysql_arrow_oneway(container_manager: &Mutex<ContainerManager>) {
-        let mut container_manager = container_manager.lock().await;
-        if !container_manager.claimed {
-            container_manager.claimed = true;
-            start_container(&container_manager).await;
-        }
-
-        arrow_mysql_one_way(container_manager.port).await;
-    }
+    arrow_mysql_one_way(container_manager.port).await;
 }

--- a/tests/mysql/mod.rs
+++ b/tests/mysql/mod.rs
@@ -1,0 +1,132 @@
+#[cfg(feature = "mysql")]
+mod common;
+
+#[cfg(feature = "mysql")]
+mod test {
+    use super::common;
+    use datafusion::execution::context::SessionContext;
+    use datafusion_table_providers::{
+        mysql::MySQLConnectionPool, sql::sql_provider_datafusion::SqlTable,
+    };
+    use rstest::{fixture, rstest};
+    use std::sync::Arc;
+    use tokio::sync::{Mutex, MutexGuard};
+
+    use arrow::array::*;
+
+    use datafusion_table_providers::sql::db_connection_pool::dbconnection::AsyncDbConnection;
+
+    async fn arrow_mysql_one_way(port: usize) {
+        let table_name = "test_table";
+        tracing::debug!("Running tests on {table_name}");
+        let ctx = SessionContext::new();
+
+        let pool = common::get_mysql_connection_pool(port)
+            .await
+            .expect("MySQL connection pool should be created");
+
+        let db_conn = pool
+            .connect_direct()
+            .await
+            .expect("Connection should be established");
+
+        // Create mysql table with decimal columns that contains null value
+        let create_table_stmt = "
+        CREATE TABLE IF NOT EXISTS test_table (id INT AUTO_INCREMENT PRIMARY KEY, salary DECIMAL(10, 2));
+        ";
+        let insert_table_stmt = "
+        INSERT INTO test_table (salary) VALUES (NULL), (12);
+        ";
+
+        // Create table and insert data into mysql test_table
+        let _ = db_conn
+            .execute(&create_table_stmt, &[])
+            .await
+            .expect("MySQL table should be created");
+
+        let _ = db_conn
+            .execute(&insert_table_stmt, &[])
+            .await
+            .expect("MySQL table data should be inserted");
+
+        // Register datafusion table, test mysql row -> arrow conversion
+        let sqltable_pool: Arc<MySQLConnectionPool> = Arc::new(pool);
+        let table = SqlTable::new("mysql", &sqltable_pool, table_name, None)
+            .await
+            .expect("Table should be created");
+
+        ctx.register_table(table_name, Arc::new(table))
+            .expect("Table should be registered");
+
+        let sql = format!("SELECT * FROM {table_name}");
+        let df = ctx
+            .sql(&sql)
+            .await
+            .expect("DataFrame should be created from query");
+
+        let record_batch = df.collect().await.expect("RecordBatch should be collected");
+        tracing::debug!(
+            "MySQL returned Record Batch: {:?}",
+            record_batch[0].columns()
+        );
+
+        let int32_array = Int32Array::from(vec![1, 2]);
+        let decimal128_array = Decimal128Array::from(vec![None, Some(i128::from(1200))])
+            .with_precision_and_scale(38, 2)
+            .unwrap();
+
+        // Check results
+        assert_eq!(record_batch.len(), 1);
+        assert_eq!(
+            record_batch[0]
+                .column(0)
+                .as_any()
+                .downcast_ref::<Int32Array>()
+                .unwrap(),
+            &int32_array
+        );
+        assert_eq!(
+            record_batch[0]
+                .column(1)
+                .as_any()
+                .downcast_ref::<Decimal128Array>()
+                .unwrap(),
+            &decimal128_array
+        );
+    }
+
+    #[derive(Debug)]
+    struct ContainerManager {
+        port: usize,
+        claimed: bool,
+    }
+
+    #[fixture]
+    #[once]
+    fn container_manager() -> Mutex<ContainerManager> {
+        Mutex::new(ContainerManager {
+            port: common::get_random_port(),
+            claimed: false,
+        })
+    }
+
+    async fn start_container(manager: &MutexGuard<'_, ContainerManager>) {
+        let _ = common::start_mysql_docker_container(manager.port.into())
+            .await
+            .expect("MySQL container to start");
+
+        tracing::debug!("Container started");
+    }
+
+    #[rstest]
+    #[test_log::test(tokio::test)]
+    async fn test_mysql_arrow_oneway(container_manager: &Mutex<ContainerManager>) {
+        let mut container_manager = container_manager.lock().await;
+        if !container_manager.claimed {
+            container_manager.claimed = true;
+            start_container(&container_manager).await;
+        }
+
+        arrow_mysql_one_way(container_manager.port).await;
+    }
+}

--- a/tests/postgres/common.rs
+++ b/tests/postgres/common.rs
@@ -1,7 +1,6 @@
 use bollard::secret::HealthConfig;
 #[cfg(feature = "postgres")]
 use datafusion_table_providers::sql::db_connection_pool::postgrespool::PostgresConnectionPool;
-use rand::Rng;
 use secrecy::SecretString;
 use std::collections::HashMap;
 use tracing::instrument;
@@ -40,14 +39,10 @@ fn get_pg_params(port: usize) -> HashMap<String, SecretString> {
     params
 }
 
-pub(super) fn get_random_port() -> usize {
-    rand::thread_rng().gen_range(15432..65535)
-}
-
 #[instrument]
 pub(super) async fn start_postgres_docker_container(
     port: usize,
-) -> Result<RunningContainer<'static>, anyhow::Error> {
+) -> Result<RunningContainer, anyhow::Error> {
     let container_name = format!("{PG_DOCKER_CONTAINER}-{port}");
     let port = if let Ok(port) = port.try_into() {
         port

--- a/tests/postgres/common.rs
+++ b/tests/postgres/common.rs
@@ -49,7 +49,6 @@ pub(super) async fn start_postgres_docker_container(
     port: usize,
 ) -> Result<RunningContainer<'static>, anyhow::Error> {
     let container_name = format!("{PG_DOCKER_CONTAINER}-{port}");
-    let container_name: &'static str = Box::leak(container_name.into_boxed_str());
     let port = if let Ok(port) = port.try_into() {
         port
     } else {

--- a/tests/postgres/mod.rs
+++ b/tests/postgres/mod.rs
@@ -90,7 +90,7 @@ mod test {
     #[once]
     fn container_manager() -> Mutex<ContainerManager> {
         Mutex::new(ContainerManager {
-            port: common::get_random_port(),
+            port: crate::get_random_port(),
             claimed: false,
         })
     }

--- a/tests/sqlite/mod.rs
+++ b/tests/sqlite/mod.rs
@@ -1,103 +1,97 @@
-#[cfg(feature = "sqlite")]
-mod test {
-    use crate::arrow_record_batch_gen::*;
-    use arrow::array::RecordBatch;
-    use datafusion::execution::context::SessionContext;
-    use datafusion_table_providers::sql::arrow_sql_gen::statement::{
-        CreateTableBuilder, InsertBuilder,
-    };
-    use datafusion_table_providers::sql::db_connection_pool::sqlitepool::SqliteConnectionPoolFactory;
-    use datafusion_table_providers::sql::db_connection_pool::{DbConnectionPool, Mode};
-    use datafusion_table_providers::sql::sql_provider_datafusion::SqlTable;
-    use datafusion_table_providers::sqlite::DynSqliteConnectionPool;
-    use rstest::rstest;
-    use std::sync::Arc;
+use crate::arrow_record_batch_gen::*;
+use arrow::array::RecordBatch;
+use datafusion::execution::context::SessionContext;
+use datafusion_table_providers::sql::arrow_sql_gen::statement::{
+    CreateTableBuilder, InsertBuilder,
+};
+use datafusion_table_providers::sql::db_connection_pool::sqlitepool::SqliteConnectionPoolFactory;
+use datafusion_table_providers::sql::db_connection_pool::{DbConnectionPool, Mode};
+use datafusion_table_providers::sql::sql_provider_datafusion::SqlTable;
+use datafusion_table_providers::sqlite::DynSqliteConnectionPool;
+use rstest::rstest;
+use std::sync::Arc;
 
-    async fn arrow_sqlite_round_trip(arrow_record: RecordBatch, table_name: &str) -> () {
-        tracing::debug!("Running tests on {table_name}");
-        let ctx = SessionContext::new();
+async fn arrow_sqlite_round_trip(arrow_record: RecordBatch, table_name: &str) {
+    tracing::debug!("Running tests on {table_name}");
+    let ctx = SessionContext::new();
 
-        let pool = SqliteConnectionPoolFactory::new(":memory:", Mode::Memory)
-            .build()
-            .await
-            .expect("Sqlite connection pool to be created");
+    let pool = SqliteConnectionPoolFactory::new(":memory:", Mode::Memory)
+        .build()
+        .await
+        .expect("Sqlite connection pool to be created");
 
-        let conn = pool
-            .connect()
-            .await
-            .expect("Sqlite connection should be established");
-        let conn = conn.as_async().unwrap();
+    let conn = pool
+        .connect()
+        .await
+        .expect("Sqlite connection should be established");
+    let conn = conn.as_async().unwrap();
 
-        // Create sqlite table from arrow records and insert arrow records
-        let schema = Arc::clone(&arrow_record.schema());
-        let create_table_stmts = CreateTableBuilder::new(schema, table_name).build_sqlite();
-        let insert_table_stmt = InsertBuilder::new(table_name, vec![arrow_record.clone()])
-            .build_sqlite(None)
-            .expect("SQLite insert statement should be constructed");
+    // Create sqlite table from arrow records and insert arrow records
+    let schema = Arc::clone(&arrow_record.schema());
+    let create_table_stmts = CreateTableBuilder::new(schema, table_name).build_sqlite();
+    let insert_table_stmt = InsertBuilder::new(table_name, vec![arrow_record.clone()])
+        .build_sqlite(None)
+        .expect("SQLite insert statement should be constructed");
 
-        // Test arrow -> Sqlite row coverage
-        let _ = conn
-            .execute(&create_table_stmts, &[])
-            .await
-            .expect("Sqlite table should be created");
-        let _ = conn
-            .execute(&insert_table_stmt, &[])
-            .await
-            .expect("Sqlite data should be inserted");
+    // Test arrow -> Sqlite row coverage
+    let _ = conn
+        .execute(&create_table_stmts, &[])
+        .await
+        .expect("Sqlite table should be created");
+    let _ = conn
+        .execute(&insert_table_stmt, &[])
+        .await
+        .expect("Sqlite data should be inserted");
 
-        // Register datafusion table, test row -> arrow conversion
-        let sqltable_pool: Arc<DynSqliteConnectionPool> = Arc::new(pool);
-        let table = SqlTable::new("sqlite", &sqltable_pool, table_name, None)
-            .await
-            .expect("Table should be created");
-        ctx.register_table(table_name, Arc::new(table))
-            .expect("Table should be registered");
-        let sql = format!("SELECT * FROM {table_name}");
-        let df = ctx
-            .sql(&sql)
-            .await
-            .expect("DataFrame should be created from query");
+    // Register datafusion table, test row -> arrow conversion
+    let sqltable_pool: Arc<DynSqliteConnectionPool> = Arc::new(pool);
+    let table = SqlTable::new("sqlite", &sqltable_pool, table_name, None)
+        .await
+        .expect("Table should be created");
+    ctx.register_table(table_name, Arc::new(table))
+        .expect("Table should be registered");
+    let sql = format!("SELECT * FROM {table_name}");
+    let df = ctx
+        .sql(&sql)
+        .await
+        .expect("DataFrame should be created from query");
 
-        let record_batch = df.collect().await.expect("RecordBatch should be collected");
+    let record_batch = df.collect().await.expect("RecordBatch should be collected");
 
-        // Print original arrow record batch and record batch converted from sqlite row in terminal
-        // Check if the values are the same
-        tracing::debug!("Original Arrow Record Batch: {:?}", arrow_record.columns());
-        tracing::debug!(
-            "Sqlite returned Record Batch: {:?}",
-            record_batch[0].columns()
-        );
+    // Print original arrow record batch and record batch converted from sqlite row in terminal
+    // Check if the values are the same
+    tracing::debug!("Original Arrow Record Batch: {:?}", arrow_record.columns());
+    tracing::debug!(
+        "Sqlite returned Record Batch: {:?}",
+        record_batch[0].columns()
+    );
 
-        // Check results
-        assert_eq!(record_batch.len(), 1);
-        assert_eq!(record_batch[0].num_rows(), arrow_record.num_rows());
-        assert_eq!(record_batch[0].num_columns(), arrow_record.num_columns());
-    }
+    // Check results
+    assert_eq!(record_batch.len(), 1);
+    assert_eq!(record_batch[0].num_rows(), arrow_record.num_rows());
+    assert_eq!(record_batch[0].num_columns(), arrow_record.num_columns());
+}
 
-    #[rstest]
-    #[case::binary(get_arrow_binary_record_batch(), "binary")]
-    #[case::int(get_arrow_int_record_batch(), "int")]
-    #[case::float(get_arrow_float_record_batch(), "float")]
-    #[case::utf8(get_arrow_utf8_record_batch(), "utf8")]
-    #[case::time(get_arrow_time_record_batch(), "time")]
-    #[case::timestamp(get_arrow_timestamp_record_batch(), "timestamp")]
-    #[case::date(get_arrow_date_record_batch(), "date")]
-    #[ignore] // TODO: struct types are broken in SQLite
-    #[case::struct_type(get_arrow_struct_record_batch(), "struct")]
-    #[ignore] // TODO: decimal types are broken in SQLite
-    #[case::decimal(get_arrow_decimal_record_batch(), "decimal")]
-    #[ignore] // TODO: interval types are broken in SQLite
-    #[case::interval(get_arrow_interval_record_batch(), "interval")]
-    #[ignore] // TODO: duration types are broken in SQLite
-    #[case::duration(get_arrow_duration_record_batch(), "duration")]
-    #[ignore] // TODO: list types are broken in SQLite
-    #[case::list(get_arrow_list_record_batch(), "list")]
-    #[case::null(get_arrow_null_record_batch(), "null")]
-    #[test_log::test(tokio::test)]
-    async fn test_arrow_sqlite_roundtrip(
-        #[case] arrow_record: RecordBatch,
-        #[case] table_name: &str,
-    ) {
-        arrow_sqlite_round_trip(arrow_record, &format!("{table_name}_types")).await;
-    }
+#[rstest]
+#[case::binary(get_arrow_binary_record_batch(), "binary")]
+#[case::int(get_arrow_int_record_batch(), "int")]
+#[case::float(get_arrow_float_record_batch(), "float")]
+#[case::utf8(get_arrow_utf8_record_batch(), "utf8")]
+#[case::time(get_arrow_time_record_batch(), "time")]
+#[case::timestamp(get_arrow_timestamp_record_batch(), "timestamp")]
+#[case::date(get_arrow_date_record_batch(), "date")]
+#[ignore] // TODO: struct types are broken in SQLite
+#[case::struct_type(get_arrow_struct_record_batch(), "struct")]
+#[ignore] // TODO: decimal types are broken in SQLite
+#[case::decimal(get_arrow_decimal_record_batch(), "decimal")]
+#[ignore] // TODO: interval types are broken in SQLite
+#[case::interval(get_arrow_interval_record_batch(), "interval")]
+#[ignore] // TODO: duration types are broken in SQLite
+#[case::duration(get_arrow_duration_record_batch(), "duration")]
+#[ignore] // TODO: list types are broken in SQLite
+#[case::list(get_arrow_list_record_batch(), "list")]
+#[case::null(get_arrow_null_record_batch(), "null")]
+#[test_log::test(tokio::test)]
+async fn test_arrow_sqlite_roundtrip(#[case] arrow_record: RecordBatch, #[case] table_name: &str) {
+    arrow_sqlite_round_trip(arrow_record, &format!("{table_name}_types")).await;
 }


### PR DESCRIPTION
Properly support decimal types in mysql row -> arrow conversion. Changes include:
* Use `column.decimals()` to infer mysql decimal precision in `rows_to_arrow`
* Map `ColumnType::MYSQL_TYPE_DECIMAL | ColumnType::MYSQL_TYPE_NEWDECIMAL` into **concrete Arrow Decimal types instead of None** in `map_column_to_data_type`
* Use **non-empty** Array builder for mysql  `ColumnType::MYSQL_TYPE_DECIMAL | ColumnType::MYSQL_TYPE_NEWDECIMAL `