### PR TITLE
Enable arrow time types in arrow - pg row round trip integration test

### DIFF
--- a/tests/mysql/mod.rs
+++ b/tests/mysql/mod.rs
@@ -109,6 +109,5 @@ async fn test_mysql_arrow_oneway() {
     let mysql_container = start_mysql_container(port).await;
 
     arrow_mysql_one_way(port).await;
-
     mysql_container.remove().await.expect("container to stop");
 }

--- a/tests/postgres/mod.rs
+++ b/tests/postgres/mod.rs
@@ -104,7 +104,6 @@ async fn start_container(manager: &MutexGuard<'_, ContainerManager>) {
 #[case::int(get_arrow_int_record_batch(), "int")]
 #[case::float(get_arrow_float_record_batch(), "float")]
 #[case::utf8(get_arrow_utf8_record_batch(), "utf8")]
-#[ignore] // TODO: time types are broken in Postgres
 #[case::time(get_arrow_time_record_batch(), "time")]
 #[case::timestamp(get_arrow_timestamp_record_batch(), "timestamp")]
 #[case::date(get_arrow_date_record_batch(), "date")]


### PR DESCRIPTION
Arrow time types are fixed and support with postgres conversions, enable the time types test in the postgres integration test