### PR TITLE
feat: Add support for DuckDB ATTACH databases together

### DIFF
--- a/src/duckdb.rs
+++ b/src/duckdb.rs
@@ -130,14 +130,15 @@ impl DuckDBTableProviderFactory {
 
     #[must_use]
     pub fn attach_databases(&self, options: &HashMap<String, String>) -> Vec<Arc<str>> {
-        if let Some(attach_databases) = options.get(&self.attach_databases_param) {
-            attach_databases
-                .split(';')
-                .map(Arc::from)
-                .collect::<Vec<Arc<str>>>()
-        } else {
-            Vec::new()
-        }
+        options
+            .get(&self.attach_databases_param)
+            .map(|attach_databases| {
+                attach_databases
+                    .split(';')
+                    .map(Arc::from)
+                    .collect::<Vec<Arc<str>>>()
+            })
+            .unwrap_or_default()
     }
 
     #[must_use]

--- a/src/sql/db_connection_pool/duckdbpool.rs
+++ b/src/sql/db_connection_pool/duckdbpool.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use arrow::array::AsArray;
 use async_trait::async_trait;
 use duckdb::{vtab::arrow::ArrowVTab, AccessMode, DuckdbConnectionManager, ToSql};
 use snafu::{prelude::*, ResultExt};
@@ -25,6 +26,7 @@ pub enum Error {
 pub struct DuckDbConnectionPool {
     pool: Arc<r2d2::Pool<DuckdbConnectionManager>>,
     join_push_down: JoinPushDown,
+    attached_databases: Vec<Arc<str>>,
 }
 
 impl DuckDbConnectionPool {
@@ -58,6 +60,7 @@ impl DuckDbConnectionPool {
             pool,
             // There can't be any other tables that share the same context for an in-memory DuckDB.
             join_push_down: JoinPushDown::Disallow,
+            attached_databases: Vec::new(),
         })
     }
 
@@ -93,7 +96,14 @@ impl DuckDbConnectionPool {
             pool,
             // Allow join-push down for any other instances that connect to the same underlying file.
             join_push_down: JoinPushDown::AllowedFor(path.to_string()),
+            attached_databases: Vec::new(),
         })
+    }
+
+    #[must_use]
+    pub fn set_attached_databases(mut self, databases: &[Arc<str>]) -> Self {
+        self.attached_databases = databases.to_vec();
+        self
     }
 
     /// Create a new `DuckDbConnectionPool` from a database URL.
@@ -125,6 +135,48 @@ impl DbConnectionPool<r2d2::PooledConnection<DuckdbConnectionManager>, &'static 
         let pool = Arc::clone(&self.pool);
         let conn: r2d2::PooledConnection<DuckdbConnectionManager> =
             pool.get().context(ConnectionPoolSnafu)?;
+
+        println!("connect attached_databases: {:?}", self.attached_databases);
+
+        if !self.attached_databases.is_empty() {
+            for (i, db) in self.attached_databases.iter().enumerate() {
+                let db_id = format!("attachment_{i}");
+                conn.execute(
+                    &format!("ATTACH IF NOT EXISTS '{db}' AS {db_id} (READ_ONLY)"),
+                    [],
+                )
+                .context(DuckDBSnafu)?;
+            }
+
+            let mut stmt = conn.prepare("SHOW DATABASES").context(DuckDBSnafu)?;
+            let results = stmt.query_arrow([]).context(DuckDBSnafu)?;
+            let results = results.collect::<Vec<_>>();
+
+            let db_ids = results
+                .iter()
+                .flat_map(|r| match r.column(0).data_type() {
+                    arrow::datatypes::DataType::Utf8 => r
+                        .column(0)
+                        .as_string::<i32>()
+                        .into_iter()
+                        .flatten()
+                        .collect::<Vec<_>>(),
+                    arrow::datatypes::DataType::LargeUtf8 => r
+                        .column(0)
+                        .as_string::<i64>()
+                        .into_iter()
+                        .flatten()
+                        .collect::<Vec<_>>(),
+                    _ => {
+                        unreachable!("Unexpected data type from SHOW DATABASES");
+                    }
+                })
+                .collect::<Vec<_>>();
+
+            conn.execute(&format!("SET search_path = \"{}\"", db_ids.join(",")), [])
+                .context(DuckDBSnafu)?;
+        }
+
         Ok(Box::new(DuckDbConnection::new(conn)))
     }
 
@@ -148,4 +200,90 @@ fn get_config(access_mode: &AccessMode) -> Result<duckdb::Config> {
         .context(DuckDBSnafu)?;
 
     Ok(config)
+}
+
+#[cfg(test)]
+mod test {
+
+    use rand::Rng;
+
+    use super::*;
+    use crate::sql::db_connection_pool::DbConnectionPool;
+    use std::sync::Arc;
+
+    fn random_db_name() -> String {
+        let mut rng = rand::thread_rng();
+        let mut name = String::new();
+
+        for _ in 0..10 {
+            name.push(rng.gen_range(b'a'..=b'z') as char);
+        }
+
+        format!("./{name}.sqlite")
+    }
+
+    #[tokio::test]
+    async fn test_duckdb_connection_pool() {
+        let pool = DuckDbConnectionPool::new_memory().unwrap();
+        let conn = pool.connect().await.unwrap();
+        let conn = conn.as_sync().unwrap();
+
+        conn.execute("CREATE TABLE test (a INTEGER, b VARCHAR)", &[])
+            .unwrap();
+        conn.execute("INSERT INTO test VALUES (1, 'a')", &[])
+            .unwrap();
+
+        conn.query_arrow("SELECT * FROM test", &[]).unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_duckdb_connection_pool_with_attached_databases() {
+        let db_base_name = random_db_name();
+        let db_attached_name = random_db_name();
+        let pool = DuckDbConnectionPool::new_file(&db_base_name, &AccessMode::ReadWrite)
+            .unwrap()
+            .set_attached_databases(&[Arc::from(db_attached_name.as_str())]);
+
+        let pool_attached =
+            DuckDbConnectionPool::new_file(&db_attached_name, &AccessMode::ReadWrite)
+                .unwrap()
+                .set_attached_databases(&[Arc::from(db_base_name.as_str())]);
+
+        let conn = pool.pool.get().unwrap();
+
+        conn.execute("CREATE TABLE test_one (a INTEGER, b VARCHAR)", [])
+            .unwrap();
+        conn.execute("INSERT INTO test_one VALUES (1, 'a')", [])
+            .unwrap();
+
+        let conn_attached = pool_attached.pool.get().unwrap();
+
+        conn_attached
+            .execute("CREATE TABLE test_two (a INTEGER, b VARCHAR)", [])
+            .unwrap();
+        conn_attached
+            .execute("INSERT INTO test_two VALUES (1, 'a')", [])
+            .unwrap();
+
+        let conn = pool.connect().await.unwrap();
+        let conn = conn.as_sync().unwrap();
+
+        let conn_attached = pool_attached.connect().await.unwrap();
+        let conn_attached = conn_attached.as_sync().unwrap();
+
+        conn.query_arrow("SELECT * FROM test_one", &[]).unwrap();
+
+        conn_attached
+            .query_arrow("SELECT * FROM test_two", &[])
+            .unwrap();
+
+        conn_attached
+            .query_arrow("SELECT * FROM test_one", &[])
+            .unwrap();
+
+        conn.query_arrow("SELECT * FROM test_two", &[]).unwrap();
+
+        std::fs::remove_file(&db_base_name).unwrap();
+        std::fs::remove_file(&db_attached_name).unwrap();
+    }
 }

--- a/src/sql/db_connection_pool/sqlitepool.rs
+++ b/src/sql/db_connection_pool/sqlitepool.rs
@@ -215,7 +215,7 @@ mod tests {
     use super::*;
     use crate::sql::db_connection_pool::Mode;
     use rand::Rng;
-    use rstest::{fixture, rstest};
+    use rstest::rstest;
 
     fn random_db_name() -> String {
         let mut rng = rand::thread_rng();


### PR DESCRIPTION
## 🗣 Description

* Adds support for using `ATTACH` in DuckDB, to attach different databases together