### PR TITLE
Preserve timezone information in arrow type - pg type conversion

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ futures = "0.3.30"
 mysql_async = { version = "0.34.1", features = ["native-tls-tls", "chrono"], optional = true }
 r2d2 = { version = "0.8.10", optional = true }
 rusqlite = { version = "0.31.0", optional = true }
-sea-query = { version = "0.31.0", features = ["backend-sqlite", "backend-postgres", "postgres-array", "with-rust_decimal", "with-bigdecimal", "with-time"] }
+sea-query = { version = "0.31.0", features = ["backend-sqlite", "backend-postgres", "postgres-array", "with-rust_decimal", "with-bigdecimal", "with-time", "with-chrono"] }
 secrecy = "0.8.0"
 serde_json = "1.0.124"
 snafu = "0.8.3"

--- a/src/sql/arrow_sql_gen/postgres.rs
+++ b/src/sql/arrow_sql_gen/postgres.rs
@@ -18,7 +18,7 @@ use bigdecimal::num_bigint::Sign;
 use bigdecimal::BigDecimal;
 use bigdecimal::ToPrimitive;
 use byteorder::{BigEndian, ReadBytesExt};
-use chrono::Timelike;
+use chrono::{DateTime, Offset, Timelike, Utc};
 use composite::CompositeType;
 use geo_types::geometry::Point;
 use sea_query::{Alias, ColumnType, SeaRc};
@@ -452,7 +452,7 @@ pub fn rows_to_arrow(rows: &[Row]) -> Result<RecordBatch> {
                     };
                     dec_builder.append_value(v_i128);
                 }
-                ref pg_type @ (Type::TIMESTAMP | Type::TIMESTAMPTZ) => {
+                Type::TIMESTAMP => {
                     let Some(builder) = builder else {
                         return NoBuilderForIndexSnafu { index: i }.fail();
                     };
@@ -468,7 +468,7 @@ pub fn rows_to_arrow(rows: &[Row]) -> Result<RecordBatch> {
                     let v = row
                         .try_get::<usize, Option<SystemTime>>(i)
                         .with_context(|_| FailedToGetRowValueSnafu {
-                            pg_type: pg_type.clone(),
+                            pg_type: Type::TIMESTAMP,
                         })?;
 
                     match v {
@@ -484,6 +484,55 @@ pub fn rows_to_arrow(rows: &[Row]) -> Result<RecordBatch> {
                         None => builder.append_null(),
                     }
                 }
+                Type::TIMESTAMPTZ => {
+                    let v = row
+                        .try_get::<usize, Option<DateTime<Utc>>>(i)
+                        .with_context(|_| FailedToGetRowValueSnafu {
+                            pg_type: Type::TIMESTAMPTZ,
+                        })?;
+
+                    let time_zone = v.unwrap_or_default().offset().fix();
+                    let timestampz_builder = builder.get_or_insert_with(|| {
+                        Box::new(
+                            TimestampMillisecondBuilder::new().with_timezone(time_zone.to_string()),
+                        )
+                    });
+
+                    let Some(timestampz_builder) = timestampz_builder
+                        .as_any_mut()
+                        .downcast_mut::<TimestampMillisecondBuilder>()
+                    else {
+                        return FailedToDowncastBuilderSnafu {
+                            postgres_type: format!("{postgres_type}"),
+                        }
+                        .fail();
+                    };
+
+                    if arrow_field.is_none() {
+                        let Some(field_name) = column_names.get(i) else {
+                            return NoColumnNameForIndexSnafu { index: i }.fail();
+                        };
+                        let new_arrow_field = Field::new(
+                            field_name,
+                            DataType::Timestamp(
+                                TimeUnit::Millisecond,
+                                Some(Arc::from(time_zone.to_string())),
+                            ),
+                            true,
+                        );
+
+                        *arrow_field = Some(new_arrow_field);
+                    }
+
+                    match v {
+                        Some(v) => {
+                            let utc_timestamp = v.to_utc().timestamp_millis();
+                            timestampz_builder.append_value(utc_timestamp);
+                        }
+                        None => timestampz_builder.append_null(),
+                    }
+                }
+
                 Type::DATE => {
                     let Some(builder) = builder else {
                         return NoBuilderForIndexSnafu { index: i }.fail();
@@ -674,11 +723,9 @@ fn map_column_type_to_data_type(column_type: &Type) -> Option<DataType> {
         Type::BOOL => Some(DataType::Boolean),
         Type::JSON => Some(DataType::LargeUtf8),
         // Inspect the scale from the first row. Precision will always be 38 for Decimal128.
-        Type::NUMERIC => None,
+        Type::NUMERIC | Type::TIMESTAMPTZ => None,
         // We get a SystemTime that we can always convert into milliseconds
-        Type::TIMESTAMP | Type::TIMESTAMPTZ => {
-            Some(DataType::Timestamp(TimeUnit::Millisecond, None))
-        }
+        Type::TIMESTAMP => Some(DataType::Timestamp(TimeUnit::Millisecond, None)),
         Type::DATE => Some(DataType::Date32),
         Type::TIME => Some(DataType::Time64(TimeUnit::Nanosecond)),
         Type::INTERVAL => Some(DataType::Interval(IntervalUnit::MonthDayNano)),

--- a/src/sql/arrow_sql_gen/statement.rs
+++ b/src/sql/arrow_sql_gen/statement.rs
@@ -1092,7 +1092,7 @@ pub(crate) fn map_data_type_to_column_type(data_type: &DataType) -> ColumnType {
             ColumnType::Decimal(Some((u32::from(*p), *s as u32)))
         }
         DataType::Timestamp(_unit, time_zone) => {
-            if let Some(_time_zone) = time_zone {
+            if time_zone.is_some() {
                 return ColumnType::TimestampWithTimeZone;
             }
             ColumnType::Timestamp

--- a/src/sql/arrow_sql_gen/statement.rs
+++ b/src/sql/arrow_sql_gen/statement.rs
@@ -4,6 +4,7 @@ use arrow::{
     util::display::array_value_to_string,
 };
 use bigdecimal_0_3_0::BigDecimal;
+use chrono::{DateTime, FixedOffset};
 use num_bigint::BigInt;
 use sea_query::{
     Alias, ColumnDef, ColumnType, Expr, GenericBuilder, Index, InsertStatement, IntoIden,
@@ -346,7 +347,7 @@ impl InsertBuilder {
                         }
                         _ => unreachable!(),
                     },
-                    DataType::Timestamp(TimeUnit::Second, _) => {
+                    DataType::Timestamp(TimeUnit::Second, timezone) => {
                         let array = column
                             .as_any()
                             .downcast_ref::<array::TimestampSecondArray>();
@@ -356,13 +357,27 @@ impl InsertBuilder {
                                 row_values.push(Keyword::Null.into());
                                 continue;
                             }
-                            insert_timestamp_into_row_values(
-                                OffsetDateTime::from_unix_timestamp(valid_array.value(row)),
-                                &mut row_values,
-                            )?;
+                            if let Some(timezone) = timezone {
+                                let utc_time = DateTime::from_timestamp_nanos(
+                                    valid_array.value(row) * 1_000_000_000,
+                                )
+                                .to_utc();
+                                let offset = parse_fixed_offset(timezone.as_ref()).ok_or(
+                                    Error::FailedToCreateInsertStatement {
+                                        source: "Unable to parse arrow timezone information".into(),
+                                    },
+                                )?;
+                                let time_with_offset = utc_time.with_timezone(&offset);
+                                row_values.push(time_with_offset.into());
+                            } else {
+                                insert_timestamp_into_row_values(
+                                    OffsetDateTime::from_unix_timestamp(valid_array.value(row)),
+                                    &mut row_values,
+                                )?;
+                            }
                         }
                     }
-                    DataType::Timestamp(TimeUnit::Millisecond, _) => {
+                    DataType::Timestamp(TimeUnit::Millisecond, timezone) => {
                         let array = column
                             .as_any()
                             .downcast_ref::<array::TimestampMillisecondArray>();
@@ -372,15 +387,29 @@ impl InsertBuilder {
                                 row_values.push(Keyword::Null.into());
                                 continue;
                             }
-                            insert_timestamp_into_row_values(
-                                OffsetDateTime::from_unix_timestamp_nanos(
-                                    i128::from(valid_array.value(row)) * 1_000_000,
-                                ),
-                                &mut row_values,
-                            )?;
+                            if let Some(timezone) = timezone {
+                                let utc_time = DateTime::from_timestamp_nanos(
+                                    valid_array.value(row) * 1_000_000,
+                                )
+                                .to_utc();
+                                let offset = parse_fixed_offset(timezone.as_ref()).ok_or(
+                                    Error::FailedToCreateInsertStatement {
+                                        source: "Unable to parse arrow timezone information".into(),
+                                    },
+                                )?;
+                                let time_with_offset = utc_time.with_timezone(&offset);
+                                row_values.push(time_with_offset.into());
+                            } else {
+                                insert_timestamp_into_row_values(
+                                    OffsetDateTime::from_unix_timestamp_nanos(
+                                        i128::from(valid_array.value(row)) * 1_000_000,
+                                    ),
+                                    &mut row_values,
+                                )?;
+                            }
                         }
                     }
-                    DataType::Timestamp(TimeUnit::Microsecond, _) => {
+                    DataType::Timestamp(TimeUnit::Microsecond, timezone) => {
                         let array = column
                             .as_any()
                             .downcast_ref::<array::TimestampMicrosecondArray>();
@@ -390,15 +419,28 @@ impl InsertBuilder {
                                 row_values.push(Keyword::Null.into());
                                 continue;
                             }
-                            insert_timestamp_into_row_values(
-                                OffsetDateTime::from_unix_timestamp_nanos(
-                                    i128::from(valid_array.value(row)) * 1_000,
-                                ),
-                                &mut row_values,
-                            )?;
+                            if let Some(timezone) = timezone {
+                                let utc_time =
+                                    DateTime::from_timestamp_nanos(valid_array.value(row) * 1_000)
+                                        .to_utc();
+                                let offset = parse_fixed_offset(timezone.as_ref()).ok_or(
+                                    Error::FailedToCreateInsertStatement {
+                                        source: "Unable to parse arrow timezone information".into(),
+                                    },
+                                )?;
+                                let time_with_offset = utc_time.with_timezone(&offset);
+                                row_values.push(time_with_offset.into());
+                            } else {
+                                insert_timestamp_into_row_values(
+                                    OffsetDateTime::from_unix_timestamp_nanos(
+                                        i128::from(valid_array.value(row)) * 1_000,
+                                    ),
+                                    &mut row_values,
+                                )?;
+                            }
                         }
                     }
-                    DataType::Timestamp(TimeUnit::Nanosecond, _) => {
+                    DataType::Timestamp(TimeUnit::Nanosecond, timezone) => {
                         let array = column
                             .as_any()
                             .downcast_ref::<array::TimestampNanosecondArray>();
@@ -408,12 +450,24 @@ impl InsertBuilder {
                                 row_values.push(Keyword::Null.into());
                                 continue;
                             }
-                            insert_timestamp_into_row_values(
-                                OffsetDateTime::from_unix_timestamp_nanos(i128::from(
-                                    valid_array.value(row),
-                                )),
-                                &mut row_values,
-                            )?;
+                            if let Some(timezone) = timezone {
+                                let utc_time =
+                                    DateTime::from_timestamp_nanos(valid_array.value(row)).to_utc();
+                                let offset = parse_fixed_offset(timezone.as_ref()).ok_or(
+                                    Error::FailedToCreateInsertStatement {
+                                        source: "Unable to parse arrow timezone information".into(),
+                                    },
+                                )?;
+                                let time_with_offset = utc_time.with_timezone(&offset);
+                                row_values.push(time_with_offset.into());
+                            } else {
+                                insert_timestamp_into_row_values(
+                                    OffsetDateTime::from_unix_timestamp_nanos(i128::from(
+                                        valid_array.value(row),
+                                    )),
+                                    &mut row_values,
+                                )?;
+                            }
                         }
                     }
                     DataType::List(list_type) => {
@@ -894,6 +948,34 @@ fn insert_timestamp_into_row_values(
     }
 }
 
+// Reference: https://github.com/apache/arrow-rs/blob/6c59b7637592e4b67b18762b8313f91086c0d5d8/arrow-array/src/timezone.rs#L25
+#[allow(clippy::cast_lossless)]
+fn parse_fixed_offset(tz: &str) -> Option<FixedOffset> {
+    let bytes = tz.as_bytes();
+
+    let mut values = match bytes.len() {
+        // [+-]XX:XX
+        6 if bytes[3] == b':' => [bytes[1], bytes[2], bytes[4], bytes[5]],
+        // [+-]XXXX
+        5 => [bytes[1], bytes[2], bytes[3], bytes[4]],
+        // [+-]XX
+        3 => [bytes[1], bytes[2], b'0', b'0'],
+        _ => return None,
+    };
+    values.iter_mut().for_each(|x| *x = x.wrapping_sub(b'0'));
+    if values.iter().any(|x| *x > 9) {
+        return None;
+    }
+    let secs =
+        (values[0] * 10 + values[1]) as i32 * 60 * 60 + (values[2] * 10 + values[3]) as i32 * 60;
+
+    match bytes[0] {
+        b'+' => FixedOffset::east_opt(secs),
+        b'-' => FixedOffset::west_opt(secs),
+        _ => None,
+    }
+}
+
 #[allow(clippy::needless_pass_by_value)]
 fn insert_list_into_row_values(
     list_array: Arc<dyn Array>,
@@ -1009,7 +1091,12 @@ pub(crate) fn map_data_type_to_column_type(data_type: &DataType) -> ColumnType {
         DataType::Decimal128(p, s) | DataType::Decimal256(p, s) => {
             ColumnType::Decimal(Some((u32::from(*p), *s as u32)))
         }
-        DataType::Timestamp(_unit, _time_zone) => ColumnType::Timestamp,
+        DataType::Timestamp(_unit, time_zone) => {
+            if let Some(_time_zone) = time_zone {
+                return ColumnType::TimestampWithTimeZone;
+            }
+            ColumnType::Timestamp
+        }
         DataType::Date32 | DataType::Date64 => ColumnType::Date,
         DataType::Time64(_unit) | DataType::Time32(_unit) => ColumnType::Time,
         DataType::List(list_type)

--- a/tests/arrow_record_batch_gen/mod.rs
+++ b/tests/arrow_record_batch_gen/mod.rs
@@ -186,7 +186,7 @@ pub(crate) fn get_arrow_timestamp_record_batch() -> RecordBatch {
         1_680_040_000_000,
         1_680_080_000_000,
     ])
-    .with_timezone("+10:00".to_string());
+    .with_timezone("+10".to_string());
     let timestamp_micro_array = TimestampMicrosecondArray::from(vec![
         1_680_000_000_000_000,
         1_680_040_000_000_000,
@@ -208,7 +208,7 @@ pub(crate) fn get_arrow_timestamp_record_batch() -> RecordBatch {
         ),
         Field::new(
             "timestamp_milli",
-            DataType::Timestamp(TimeUnit::Millisecond, Some(Arc::from("+10:00".to_string()))),
+            DataType::Timestamp(TimeUnit::Millisecond, Some(Arc::from("+10".to_string()))),
             false,
         ),
         Field::new(

--- a/tests/arrow_record_batch_gen/mod.rs
+++ b/tests/arrow_record_batch_gen/mod.rs
@@ -362,7 +362,7 @@ pub(crate) fn get_arrow_duration_record_batch() -> (RecordBatch, SchemaRef) {
             Arc::new(duration_sec_array),
         ],
     )
-    .expect("Failed to created arrow interval record batch");
+    .expect("Failed to created arrow duration record batch");
 
     (record_batch, schema)
 }
@@ -500,6 +500,48 @@ pub(crate) fn get_arrow_bytea_array_record_batch() -> (RecordBatch, SchemaRef) {
             .expect("Failed to created arrow bytea array record batch");
 
     (record_batch, schema)
+}
+
+pub(crate) fn get_pg_interval_expected_result() -> RecordBatch {
+    let col1 = IntervalMonthDayNanoArray::from(vec![
+        IntervalMonthDayNano::new(0, 1, 1000000000),
+        IntervalMonthDayNano::new(0, 33, 0),
+        IntervalMonthDayNano::new(0, 0, 43200000000000),
+    ]);
+    let col2 = IntervalMonthDayNanoArray::from(vec![
+        IntervalMonthDayNano::new(1, 2, 1000),
+        IntervalMonthDayNano::new(12, 1, 0),
+        IntervalMonthDayNano::new(0, 0, 12 * 1000 * 1000),
+    ]);
+    let col3 = IntervalMonthDayNanoArray::from(vec![
+        IntervalMonthDayNano::new(2, 0, 0),
+        IntervalMonthDayNano::new(25, 0, 0),
+        IntervalMonthDayNano::new(-1, 0, 0),
+    ]);
+
+    let schema = Arc::new(Schema::new(vec![
+        Field::new(
+            "interval_daytime",
+            DataType::Interval(IntervalUnit::MonthDayNano),
+            true,
+        ),
+        Field::new(
+            "interval_monthday_nano",
+            DataType::Interval(IntervalUnit::MonthDayNano),
+            true,
+        ),
+        Field::new(
+            "interval_yearmonth",
+            DataType::Interval(IntervalUnit::MonthDayNano),
+            true,
+        ),
+    ]));
+
+    RecordBatch::try_new(
+        Arc::clone(&schema),
+        vec![Arc::new(col1), Arc::new(col2), Arc::new(col3)],
+    )
+    .expect("Failed to created arrow interval record batch")
 }
 
 // Reference: https://github.com/spiceai/datafusion-federation/blob/spiceai-41/datafusion-federation/src/schema_cast/record_convert.rs#L44

--- a/tests/arrow_record_batch_gen/mod.rs
+++ b/tests/arrow_record_batch_gen/mod.rs
@@ -502,6 +502,8 @@ pub(crate) fn get_arrow_bytea_array_record_batch() -> (RecordBatch, SchemaRef) {
     (record_batch, schema)
 }
 
+// Reference: https://github.com/spiceai/datafusion-federation/blob/spiceai-41/datafusion-federation/src/schema_cast/record_convert.rs#L44
+// TODO: Switch to use the try_cast_to in datafusion-federation when the function becomes public
 pub(crate) fn try_cast_to(
     record_batch: RecordBatch,
     expected_schema: SchemaRef,

--- a/tests/arrow_record_batch_gen/mod.rs
+++ b/tests/arrow_record_batch_gen/mod.rs
@@ -12,7 +12,7 @@ use std::sync::Arc;
 
 // Helper functions to create arrow record batches of different types
 
-// Binary/LargeBinary/FixedSizeBinaryå
+// Binary/LargeBinary/FixedSizeBinary
 pub(crate) fn get_arrow_binary_record_batch() -> (RecordBatch, SchemaRef) {
     // Binary/LargeBinary/FixedSizeBinary Array
     let values: Vec<&[u8]> = vec![b"one", b"two", b""];

--- a/tests/arrow_record_batch_gen/mod.rs
+++ b/tests/arrow_record_batch_gen/mod.rs
@@ -1,9 +1,10 @@
 use arrow::array::RecordBatch;
 use arrow::{
     array::*,
+    compute::cast,
     datatypes::{
         i256, DataType, Date32Type, Date64Type, Field, Fields, IntervalDayTime,
-        IntervalMonthDayNano, IntervalUnit, Schema, TimeUnit,
+        IntervalMonthDayNano, IntervalUnit, Schema, SchemaRef, TimeUnit,
     },
 };
 use chrono::NaiveDate;
@@ -11,8 +12,8 @@ use std::sync::Arc;
 
 // Helper functions to create arrow record batches of different types
 
-// Binary/LargeBinary/FixedSizeBinary
-pub(crate) fn get_arrow_binary_record_batch() -> RecordBatch {
+// Binary/LargeBinary/FixedSizeBinaryå
+pub(crate) fn get_arrow_binary_record_batch() -> (RecordBatch, SchemaRef) {
     // Binary/LargeBinary/FixedSizeBinary Array
     let values: Vec<&[u8]> = vec![b"one", b"two", b""];
     let binary_array = BinaryArray::from_vec(values.clone());
@@ -21,25 +22,27 @@ pub(crate) fn get_arrow_binary_record_batch() -> RecordBatch {
     let fixed_size_binary_array =
         FixedSizeBinaryArray::try_from_iter(input_arg.into_iter()).unwrap();
 
-    let schema = Schema::new(vec![
+    let schema = Arc::new(Schema::new(vec![
         Field::new("binary", DataType::Binary, false),
         Field::new("large_binary", DataType::LargeBinary, false),
         Field::new("fixed_size_binary", DataType::FixedSizeBinary(2), false),
-    ]);
+    ]));
 
-    RecordBatch::try_new(
-        Arc::new(schema),
+    let record_batch = RecordBatch::try_new(
+        Arc::clone(&schema),
         vec![
             Arc::new(binary_array),
             Arc::new(large_binary_array),
             Arc::new(fixed_size_binary_array),
         ],
     )
-    .expect("Failed to created arrow binary record batch")
+    .expect("Failed to created arrow binary record batch");
+
+    (record_batch, schema)
 }
 
 // All Int types
-pub(crate) fn get_arrow_int_record_batch() -> RecordBatch {
+pub(crate) fn get_arrow_int_record_batch() -> (RecordBatch, SchemaRef) {
     // Arrow Integer Types
     let int8_arr = Int8Array::from(vec![1, 2, 3]);
     let int16_arr = Int16Array::from(vec![1, 2, 3]);
@@ -50,7 +53,7 @@ pub(crate) fn get_arrow_int_record_batch() -> RecordBatch {
     let uint32_arr = UInt32Array::from(vec![1, 2, 3]);
     let uint64_arr = UInt64Array::from(vec![1, 2, 3]);
 
-    let schema = Schema::new(vec![
+    let schema = Arc::new(Schema::new(vec![
         Field::new("int8", DataType::Int8, false),
         Field::new("int16", DataType::Int16, false),
         Field::new("int32", DataType::Int32, false),
@@ -59,10 +62,10 @@ pub(crate) fn get_arrow_int_record_batch() -> RecordBatch {
         Field::new("uint16", DataType::UInt16, false),
         Field::new("uint32", DataType::UInt32, false),
         Field::new("uint64", DataType::UInt64, false),
-    ]);
+    ]));
 
-    RecordBatch::try_new(
-        Arc::new(schema),
+    let record_batch = RecordBatch::try_new(
+        Arc::clone(&schema),
         vec![
             Arc::new(int8_arr),
             Arc::new(int16_arr),
@@ -74,55 +77,61 @@ pub(crate) fn get_arrow_int_record_batch() -> RecordBatch {
             Arc::new(uint64_arr),
         ],
     )
-    .expect("Failed to created arrow int record batch")
+    .expect("Failed to created arrow binary record batch");
+
+    (record_batch, schema)
 }
 
 // All Float Types
-pub(crate) fn get_arrow_float_record_batch() -> RecordBatch {
+pub(crate) fn get_arrow_float_record_batch() -> (RecordBatch, SchemaRef) {
     // Arrow Float Types
     let float32_arr = Float32Array::from(vec![1.0, 2.0, 3.0]);
     let float64_arr = Float64Array::from(vec![1.0, 2.0, 3.0]);
 
-    let schema = Schema::new(vec![
+    let schema = Arc::new(Schema::new(vec![
         Field::new("float32", DataType::Float32, false),
         Field::new("float64", DataType::Float64, false),
-    ]);
+    ]));
 
-    RecordBatch::try_new(
-        Arc::new(schema),
+    let record_batch = RecordBatch::try_new(
+        Arc::clone(&schema),
         vec![Arc::new(float32_arr), Arc::new(float64_arr)],
     )
-    .expect("Failed to created arrow float record batch")
+    .expect("Failed to created arrow float record batch");
+
+    (record_batch, schema)
 }
 
 // Utf8/LargeUtf8
-pub(crate) fn get_arrow_utf8_record_batch() -> RecordBatch {
+pub(crate) fn get_arrow_utf8_record_batch() -> (RecordBatch, SchemaRef) {
     // Utf8, LargeUtf8 Types
     let string_arr = StringArray::from(vec!["foo", "bar", "baz"]);
     let large_string_arr = LargeStringArray::from(vec!["foo", "bar", "baz"]);
     let bool_arr: BooleanArray = vec![true, true, false].into();
 
-    let schema = Schema::new(vec![
+    let schema = Arc::new(Schema::new(vec![
         Field::new("utf8", DataType::Utf8, false),
         Field::new("largeutf8", DataType::LargeUtf8, false),
         Field::new("boolean", DataType::Boolean, false),
-    ]);
+    ]));
 
-    RecordBatch::try_new(
-        Arc::new(schema),
+    let record_batch = RecordBatch::try_new(
+        Arc::clone(&schema),
         vec![
             Arc::new(string_arr),
             Arc::new(large_string_arr),
             Arc::new(bool_arr),
         ],
     )
-    .expect("Failed to created arrow utf8 record batch")
+    .expect("Failed to created arrow utf8 record batch");
+
+    (record_batch, schema)
 }
 
 // Time32, Time64
 #[allow(clippy::identity_op)]
 #[allow(clippy::erasing_op)]
-pub(crate) fn get_arrow_time_record_batch() -> RecordBatch {
+pub(crate) fn get_arrow_time_record_batch() -> (RecordBatch, SchemaRef) {
     // Time32, Time64 Types
     let time32_milli_array: Time32MillisecondArray = vec![
         (10 * 3600 + 30 * 60) * 1_000,
@@ -149,7 +158,7 @@ pub(crate) fn get_arrow_time_record_batch() -> RecordBatch {
     ]
     .into();
 
-    let schema = Schema::new(vec![
+    let schema = Arc::new(Schema::new(vec![
         Field::new(
             "time32_milli",
             DataType::Time32(TimeUnit::Millisecond),
@@ -162,10 +171,10 @@ pub(crate) fn get_arrow_time_record_batch() -> RecordBatch {
             false,
         ),
         Field::new("time64_nano", DataType::Time64(TimeUnit::Nanosecond), false),
-    ]);
+    ]));
 
-    RecordBatch::try_new(
-        Arc::new(schema),
+    let record_batch = RecordBatch::try_new(
+        Arc::clone(&schema),
         vec![
             Arc::new(time32_milli_array),
             Arc::new(time32_sec_array),
@@ -173,11 +182,13 @@ pub(crate) fn get_arrow_time_record_batch() -> RecordBatch {
             Arc::new(time64_nano_array),
         ],
     )
-    .expect("Failed to created arrow time record batch")
+    .expect("Failed to created arrow time record batch");
+
+    (record_batch, schema)
 }
 
 // Timestamp (with/without TZ),
-pub(crate) fn get_arrow_timestamp_record_batch() -> RecordBatch {
+pub(crate) fn get_arrow_timestamp_record_batch() -> (RecordBatch, SchemaRef) {
     // Timestamp Types
     let timestamp_second_array =
         TimestampSecondArray::from(vec![1_680_000_000, 1_680_040_000, 1_680_080_000]);
@@ -186,7 +197,7 @@ pub(crate) fn get_arrow_timestamp_record_batch() -> RecordBatch {
         1_680_040_000_000,
         1_680_080_000_000,
     ])
-    .with_timezone("+10".to_string());
+    .with_timezone("+10:00".to_string());
     let timestamp_micro_array = TimestampMicrosecondArray::from(vec![
         1_680_000_000_000_000,
         1_680_040_000_000_000,
@@ -200,7 +211,7 @@ pub(crate) fn get_arrow_timestamp_record_batch() -> RecordBatch {
     ])
     .with_timezone("+10:00".to_string());
 
-    let schema = Schema::new(vec![
+    let schema = Arc::new(Schema::new(vec![
         Field::new(
             "timestamp_second",
             DataType::Timestamp(TimeUnit::Second, None),
@@ -208,7 +219,7 @@ pub(crate) fn get_arrow_timestamp_record_batch() -> RecordBatch {
         ),
         Field::new(
             "timestamp_milli",
-            DataType::Timestamp(TimeUnit::Millisecond, Some(Arc::from("+10".to_string()))),
+            DataType::Timestamp(TimeUnit::Millisecond, Some(Arc::from("+10:00".to_string()))),
             false,
         ),
         Field::new(
@@ -221,10 +232,10 @@ pub(crate) fn get_arrow_timestamp_record_batch() -> RecordBatch {
             DataType::Timestamp(TimeUnit::Nanosecond, Some(Arc::from("+10:00".to_string()))),
             false,
         ),
-    ]);
+    ]));
 
-    RecordBatch::try_new(
-        Arc::new(schema),
+    let record_batch = RecordBatch::try_new(
+        Arc::clone(&schema),
         vec![
             Arc::new(timestamp_second_array),
             Arc::new(timestamp_milli_array),
@@ -232,11 +243,13 @@ pub(crate) fn get_arrow_timestamp_record_batch() -> RecordBatch {
             Arc::new(timestamp_nano_array),
         ],
     )
-    .expect("Failed to created arrow timestamp record batch")
+    .expect("Failed to created arrow timestamp record batch");
+
+    (record_batch, schema)
 }
 
 // Date32, Date64
-pub(crate) fn get_arrow_date_record_batch() -> RecordBatch {
+pub(crate) fn get_arrow_date_record_batch() -> (RecordBatch, SchemaRef) {
     let date32_array = Date32Array::from(vec![
         Date32Type::from_naive_date(NaiveDate::from_ymd_opt(2015, 3, 14).unwrap_or_default()),
         Date32Type::from_naive_date(NaiveDate::from_ymd_opt(2016, 1, 12).unwrap_or_default()),
@@ -248,22 +261,22 @@ pub(crate) fn get_arrow_date_record_batch() -> RecordBatch {
         Date64Type::from_naive_date(NaiveDate::from_ymd_opt(2017, 9, 17).unwrap_or_default()),
     ]);
 
-    println!("{:?}", date32_array.value(0));
-
-    let schema = Schema::new(vec![
+    let schema = Arc::new(Schema::new(vec![
         Field::new("date32", DataType::Date32, false),
         Field::new("date64", DataType::Date64, false),
-    ]);
+    ]));
 
-    RecordBatch::try_new(
-        Arc::new(schema),
+    let record_batch = RecordBatch::try_new(
+        Arc::clone(&schema),
         vec![Arc::new(date32_array), Arc::new(date64_array)],
     )
-    .expect("Failed to created arrow date record batch")
+    .expect("Failed to created arrow date record batch");
+
+    (record_batch, schema)
 }
 
 // struct
-pub(crate) fn get_arrow_struct_record_batch() -> RecordBatch {
+pub(crate) fn get_arrow_struct_record_batch() -> (RecordBatch, SchemaRef) {
     let boolean = Arc::new(BooleanArray::from(vec![false, false, true, true]));
     let int = Arc::new(Int32Array::from(vec![42, 28, 19, 31]));
 
@@ -278,46 +291,50 @@ pub(crate) fn get_arrow_struct_record_batch() -> RecordBatch {
         ),
     ]);
 
-    let schema = Schema::new(vec![Field::new(
+    let schema = Arc::new(Schema::new(vec![Field::new(
         "struct",
         DataType::Struct(Fields::from(vec![
             Field::new("b", DataType::Boolean, false),
             Field::new("c", DataType::Int32, false),
         ])),
         false,
-    )]);
+    )]));
 
-    RecordBatch::try_new(Arc::new(schema), vec![Arc::new(struct_array)])
-        .expect("Failed to created arrow struct record batch")
+    let record_batch = RecordBatch::try_new(Arc::clone(&schema), vec![Arc::new(struct_array)])
+        .expect("Failed to created arrow struct record batch");
+
+    (record_batch, schema)
 }
 
 // Decimal128/Decimal256
-pub(crate) fn get_arrow_decimal_record_batch() -> RecordBatch {
+pub(crate) fn get_arrow_decimal_record_batch() -> (RecordBatch, SchemaRef) {
     let decimal128_array =
         Decimal128Array::from(vec![i128::from(123), i128::from(222), i128::from(321)]);
     let decimal256_array =
         Decimal256Array::from(vec![i256::from(-123), i256::from(222), i256::from(0)]);
 
-    let schema = Schema::new(vec![
+    let schema = Arc::new(Schema::new(vec![
         Field::new("decimal128", DataType::Decimal128(38, 10), false),
         Field::new("decimal256", DataType::Decimal256(76, 10), false),
-    ]);
+    ]));
 
-    RecordBatch::try_new(
-        Arc::new(schema),
+    let record_batch = RecordBatch::try_new(
+        Arc::clone(&schema),
         vec![Arc::new(decimal128_array), Arc::new(decimal256_array)],
     )
-    .expect("Failed to created arrow decimal record batch")
+    .expect("Failed to created arrow decimal record batch");
+
+    (record_batch, schema)
 }
 
 // Duration
-pub(crate) fn get_arrow_duration_record_batch() -> RecordBatch {
+pub(crate) fn get_arrow_duration_record_batch() -> (RecordBatch, SchemaRef) {
     let duration_nano_array = DurationNanosecondArray::from(vec![1, 2, 3]);
     let duration_micro_array = DurationMicrosecondArray::from(vec![1, 2, 3]);
     let duration_milli_array = DurationMillisecondArray::from(vec![1, 2, 3]);
     let duration_sec_array = DurationSecondArray::from(vec![1, 2, 3]);
 
-    let schema = Schema::new(vec![
+    let schema = Arc::new(Schema::new(vec![
         Field::new(
             "duration_nano",
             DataType::Duration(TimeUnit::Nanosecond),
@@ -334,10 +351,10 @@ pub(crate) fn get_arrow_duration_record_batch() -> RecordBatch {
             false,
         ),
         Field::new("duration_sec", DataType::Duration(TimeUnit::Second), false),
-    ]);
+    ]));
 
-    RecordBatch::try_new(
-        Arc::new(schema),
+    let record_batch = RecordBatch::try_new(
+        Arc::clone(&schema),
         vec![
             Arc::new(duration_nano_array),
             Arc::new(duration_micro_array),
@@ -345,11 +362,13 @@ pub(crate) fn get_arrow_duration_record_batch() -> RecordBatch {
             Arc::new(duration_sec_array),
         ],
     )
-    .expect("Failed to created arrow interval record batch")
+    .expect("Failed to created arrow interval record batch");
+
+    (record_batch, schema)
 }
 
 // Interval
-pub(crate) fn get_arrow_interval_record_batch() -> RecordBatch {
+pub(crate) fn get_arrow_interval_record_batch() -> (RecordBatch, SchemaRef) {
     let interval_daytime_array = IntervalDayTimeArray::from(vec![
         IntervalDayTime::new(1, 1000),
         IntervalDayTime::new(33, 0),
@@ -362,7 +381,7 @@ pub(crate) fn get_arrow_interval_record_batch() -> RecordBatch {
     ]);
     let interval_yearmonth_array = IntervalYearMonthArray::from(vec![2, 25, -1]);
 
-    let schema = Schema::new(vec![
+    let schema = Arc::new(Schema::new(vec![
         Field::new(
             "interval_daytime",
             DataType::Interval(IntervalUnit::DayTime),
@@ -378,21 +397,23 @@ pub(crate) fn get_arrow_interval_record_batch() -> RecordBatch {
             DataType::Interval(IntervalUnit::YearMonth),
             false,
         ),
-    ]);
+    ]));
 
-    RecordBatch::try_new(
-        Arc::new(schema),
+    let record_batch = RecordBatch::try_new(
+        Arc::clone(&schema),
         vec![
             Arc::new(interval_daytime_array),
             Arc::new(interval_monthday_nano_array),
             Arc::new(interval_yearmonth_array),
         ],
     )
-    .expect("Failed to created arrow interval record batch")
+    .expect("Failed to created arrow interval record batch");
+
+    (record_batch, schema)
 }
 
 //  List/FixedSizeList/LargeList
-pub(crate) fn get_arrow_list_record_batch() -> RecordBatch {
+pub(crate) fn get_arrow_list_record_batch() -> (RecordBatch, SchemaRef) {
     let mut list_builder = ListBuilder::new(Int32Builder::new());
     list_builder.append_value([Some(1), Some(2), Some(3)]);
     list_builder.append_value([Some(4)]);
@@ -420,7 +441,7 @@ pub(crate) fn get_arrow_list_record_batch() -> RecordBatch {
     fixed_size_list_builder.append(true);
     let fixed_size_list_array = fixed_size_list_builder.finish();
 
-    let schema = Schema::new(vec![
+    let schema = Arc::new(Schema::new(vec![
         Field::new(
             "list",
             DataType::List(Field::new("item", DataType::Int32, true).into()),
@@ -436,41 +457,73 @@ pub(crate) fn get_arrow_list_record_batch() -> RecordBatch {
             DataType::FixedSizeList(Field::new("item", DataType::Int32, true).into(), 3),
             false,
         ),
-    ]);
+    ]));
 
-    RecordBatch::try_new(
-        Arc::new(schema),
+    let record_batch = RecordBatch::try_new(
+        Arc::clone(&schema),
         vec![
             Arc::new(list_array),
             Arc::new(large_list_array),
             Arc::new(fixed_size_list_array),
         ],
     )
-    .expect("Failed to created arrow list record batch")
+    .expect("Failed to created arrow list record batch");
+
+    (record_batch, schema)
 }
 
 // Null
-pub(crate) fn get_arrow_null_record_batch() -> RecordBatch {
+pub(crate) fn get_arrow_null_record_batch() -> (RecordBatch, SchemaRef) {
     let null_arr = Int8Array::from(vec![Some(1), None, Some(3)]);
-    let schema = Schema::new(vec![Field::new("int8", DataType::Int8, true)]);
-    RecordBatch::try_new(Arc::new(schema), vec![Arc::new(null_arr)])
-        .expect("Failed to created arrow null record batch")
+    let schema = Arc::new(Schema::new(vec![Field::new("int8", DataType::Int8, true)]));
+    let record_batch = RecordBatch::try_new(Arc::clone(&schema), vec![Arc::new(null_arr)])
+        .expect("Failed to created arrow null record batch");
+    (record_batch, schema)
 }
 
 // BYTEA_ARRAY
-pub(crate) fn get_arrow_bytea_array_record_batch() -> RecordBatch {
+pub(crate) fn get_arrow_bytea_array_record_batch() -> (RecordBatch, SchemaRef) {
     let mut bytea_array_builder = ListBuilder::new(BinaryBuilder::new());
     bytea_array_builder.append_value([Some(b"1"), Some(b"2"), Some(b"3")]);
     bytea_array_builder.append_value([Some(b"4")]);
     bytea_array_builder.append_value([Some(b"6")]);
     let bytea_array_builder = bytea_array_builder.finish();
 
-    let schema = Schema::new(vec![Field::new(
+    let schema = Arc::new(Schema::new(vec![Field::new(
         "bytea_array",
         DataType::List(Field::new("item", DataType::Binary, true).into()),
         false,
-    )]);
+    )]));
 
-    RecordBatch::try_new(Arc::new(schema), vec![Arc::new(bytea_array_builder)])
-        .expect("Failed to created arrow bytea array record batch")
+    let record_batch =
+        RecordBatch::try_new(Arc::clone(&schema), vec![Arc::new(bytea_array_builder)])
+            .expect("Failed to created arrow bytea array record batch");
+
+    (record_batch, schema)
+}
+
+pub(crate) fn try_cast_to(
+    record_batch: RecordBatch,
+    expected_schema: SchemaRef,
+) -> Result<RecordBatch, String> {
+    let actual_schema = record_batch.schema();
+
+    if actual_schema.fields().len() != expected_schema.fields().len() {
+        return Err("Length mismatch".to_string());
+    }
+
+    let cols = expected_schema
+        .fields()
+        .iter()
+        .enumerate()
+        .map(|(i, expected_field)| {
+            let record_batch_col = record_batch.column(i);
+
+            return cast(&Arc::clone(record_batch_col), expected_field.data_type())
+                .map_err(|e| "Failed to cast".to_string());
+        })
+        .collect::<Result<Vec<Arc<dyn Array>>, String>>()?;
+
+    RecordBatch::try_new(expected_schema, cols)
+        .map_err(|e| "Fail to create casted record batch".to_string())
 }

--- a/tests/duckdb/mod.rs
+++ b/tests/duckdb/mod.rs
@@ -1,5 +1,6 @@
 use crate::arrow_record_batch_gen::*;
 use arrow::array::RecordBatch;
+use arrow::datatypes::SchemaRef;
 use datafusion::catalog::TableProviderFactory;
 use datafusion::common::{Constraints, ToDFSchema};
 use datafusion::execution::context::SessionContext;
@@ -11,7 +12,11 @@ use rstest::rstest;
 use std::collections::HashMap;
 use std::sync::Arc;
 
-async fn arrow_duckdb_round_trip(arrow_record: RecordBatch, table_name: &str) {
+async fn arrow_duckdb_round_trip(
+    arrow_record: RecordBatch,
+    source_schema: SchemaRef,
+    table_name: &str,
+) {
     let factory = DuckDBTableProviderFactory::new().access_mode(duckdb::AccessMode::ReadWrite);
     let ctx = SessionContext::new();
     let cmd = CreateExternalTable {
@@ -55,6 +60,7 @@ async fn arrow_duckdb_round_trip(arrow_record: RecordBatch, table_name: &str) {
         .expect("DataFrame should be created from query");
 
     let record_batch = df.collect().await.expect("RecordBatch should be collected");
+    let casted_record = try_cast_to(record_batch[0].clone(), source_schema).unwrap();
 
     tracing::debug!("Original Arrow Record Batch: {:?}", arrow_record.columns());
     tracing::debug!(
@@ -66,6 +72,7 @@ async fn arrow_duckdb_round_trip(arrow_record: RecordBatch, table_name: &str) {
     assert_eq!(record_batch.len(), 1);
     assert_eq!(record_batch[0].num_rows(), arrow_record.num_rows());
     assert_eq!(record_batch[0].num_columns(), arrow_record.num_columns());
+    assert_eq!(casted_record, arrow_record);
 }
 
 #[rstest]
@@ -88,6 +95,14 @@ async fn arrow_duckdb_round_trip(arrow_record: RecordBatch, table_name: &str) {
 #[case::list(get_arrow_list_record_batch(), "list")]
 #[case::null(get_arrow_null_record_batch(), "null")]
 #[test_log::test(tokio::test)]
-async fn test_arrow_duckdb_roundtrip(#[case] arrow_record: RecordBatch, #[case] table_name: &str) {
-    arrow_duckdb_round_trip(arrow_record, &format!("{table_name}_types")).await;
+async fn test_arrow_duckdb_roundtrip(
+    #[case] arrow_result: (RecordBatch, SchemaRef),
+    #[case] table_name: &str,
+) {
+    arrow_duckdb_round_trip(
+        arrow_result.0,
+        arrow_result.1,
+        &format!("{table_name}_types"),
+    )
+    .await;
 }

--- a/tests/postgres/common.rs
+++ b/tests/postgres/common.rs
@@ -13,32 +13,6 @@ use crate::{
 const PG_PASSWORD: &str = "runtime-integration-test-pw";
 const PG_DOCKER_CONTAINER: &str = "runtime-integration-test-postgres";
 
-// fn get_pg_params(port: usize) -> HashMap<String, SecretString> {
-//     let mut params = HashMap::new();
-//     params.insert(
-//         "pg_host".to_string(),
-//         SecretString::from("localhost".to_string()),
-//     );
-//     params.insert("pg_port".to_string(), SecretString::from(port.to_string()));
-//     params.insert(
-//         "pg_user".to_string(),
-//         SecretString::from("postgres".to_string()),
-//     );
-//     params.insert(
-//         "pg_pass".to_string(),
-//         SecretString::from(PG_PASSWORD.to_string()),
-//     );
-//     params.insert(
-//         "pg_db".to_string(),
-//         SecretString::from("postgres".to_string()),
-//     );
-//     params.insert(
-//         "pg_sslmode".to_string(),
-//         SecretString::from("disable".to_string()),
-//     );
-//     params
-// }
-
 pub(super) fn get_pg_params(port: usize) -> HashMap<String, String> {
     let mut params = HashMap::new();
     params.insert("pg_host".to_string(), "localhost".to_string());
@@ -86,12 +60,3 @@ pub(super) async fn start_postgres_docker_container(
     tokio::time::sleep(std::time::Duration::from_millis(5000)).await;
     Ok(running_container)
 }
-
-// #[instrument]
-// pub(super) async fn get_postgres_connection_pool(
-//     port: usize,
-// ) -> Result<PostgresConnectionPool, anyhow::Error> {
-//     let pool = PostgresConnectionPool::new(get_pg_params(port)).await?;
-
-//     Ok(pool)
-// }

--- a/tests/postgres/common.rs
+++ b/tests/postgres/common.rs
@@ -13,29 +13,40 @@ use crate::{
 const PG_PASSWORD: &str = "runtime-integration-test-pw";
 const PG_DOCKER_CONTAINER: &str = "runtime-integration-test-postgres";
 
-fn get_pg_params(port: usize) -> HashMap<String, SecretString> {
+// fn get_pg_params(port: usize) -> HashMap<String, SecretString> {
+//     let mut params = HashMap::new();
+//     params.insert(
+//         "pg_host".to_string(),
+//         SecretString::from("localhost".to_string()),
+//     );
+//     params.insert("pg_port".to_string(), SecretString::from(port.to_string()));
+//     params.insert(
+//         "pg_user".to_string(),
+//         SecretString::from("postgres".to_string()),
+//     );
+//     params.insert(
+//         "pg_pass".to_string(),
+//         SecretString::from(PG_PASSWORD.to_string()),
+//     );
+//     params.insert(
+//         "pg_db".to_string(),
+//         SecretString::from("postgres".to_string()),
+//     );
+//     params.insert(
+//         "pg_sslmode".to_string(),
+//         SecretString::from("disable".to_string()),
+//     );
+//     params
+// }
+
+pub(super) fn get_pg_params(port: usize) -> HashMap<String, String> {
     let mut params = HashMap::new();
-    params.insert(
-        "pg_host".to_string(),
-        SecretString::from("localhost".to_string()),
-    );
-    params.insert("pg_port".to_string(), SecretString::from(port.to_string()));
-    params.insert(
-        "pg_user".to_string(),
-        SecretString::from("postgres".to_string()),
-    );
-    params.insert(
-        "pg_pass".to_string(),
-        SecretString::from(PG_PASSWORD.to_string()),
-    );
-    params.insert(
-        "pg_db".to_string(),
-        SecretString::from("postgres".to_string()),
-    );
-    params.insert(
-        "pg_sslmode".to_string(),
-        SecretString::from("disable".to_string()),
-    );
+    params.insert("pg_host".to_string(), "localhost".to_string());
+    params.insert("pg_port".to_string(), port.to_string());
+    params.insert("pg_user".to_string(), "postgres".to_string());
+    params.insert("pg_pass".to_string(), PG_PASSWORD.to_string());
+    params.insert("pg_db".to_string(), "postgres".to_string());
+    params.insert("pg_sslmode".to_string(), "disable".to_string());
     params
 }
 
@@ -76,11 +87,11 @@ pub(super) async fn start_postgres_docker_container(
     Ok(running_container)
 }
 
-#[instrument]
-pub(super) async fn get_postgres_connection_pool(
-    port: usize,
-) -> Result<PostgresConnectionPool, anyhow::Error> {
-    let pool = PostgresConnectionPool::new(get_pg_params(port)).await?;
+// #[instrument]
+// pub(super) async fn get_postgres_connection_pool(
+//     port: usize,
+// ) -> Result<PostgresConnectionPool, anyhow::Error> {
+//     let pool = PostgresConnectionPool::new(get_pg_params(port)).await?;
 
-    Ok(pool)
-}
+//     Ok(pool)
+// }


### PR DESCRIPTION
* Preserve timezone information when converting arrow timestamp(timeunit, timezone) type to sql rows
* Correctly convert Postgres Timestamptz type back to arrow type with time zone information, this fixes the incorrect conversion from pg row -> arrow caused by neglecting timezone information
* Refactor the roundtrip integration test to values check using try_cast_to