### PR TITLE
feat: Add DuckDB data directory

### DIFF
--- a/src/duckdb.rs
+++ b/src/duckdb.rs
@@ -114,26 +114,24 @@ type Result<T, E = Error> = std::result::Result<T, E>;
 
 pub struct DuckDBTableProviderFactory {
     access_mode: AccessMode,
-    db_path_param: String,
-    db_base_folder_param: String,
-    attach_databases_param: String,
 }
+
+const DUCKDB_DB_PATH_PARAM: &str = "open";
+const DUCKDB_DB_BASE_FOLDER_PARAM: &str = "data_directory";
+const DUCKDB_ATTACH_DATABASES_PARAM: &str = "attach_databases";
 
 impl DuckDBTableProviderFactory {
     #[must_use]
     pub fn new() -> Self {
         Self {
             access_mode: AccessMode::ReadOnly,
-            db_path_param: "open".to_string(),
-            db_base_folder_param: "data_directory".to_string(),
-            attach_databases_param: "attach_databases".to_string(),
         }
     }
 
     #[must_use]
     pub fn attach_databases(&self, options: &HashMap<String, String>) -> Vec<Arc<str>> {
         options
-            .get(&self.attach_databases_param)
+            .get(DUCKDB_ATTACH_DATABASES_PARAM)
             .map(|attach_databases| {
                 attach_databases
                     .split(';')
@@ -154,13 +152,13 @@ impl DuckDBTableProviderFactory {
         let options = util::remove_prefix_from_hashmap_keys(options.clone(), "duckdb_");
 
         let db_base_folder = options
-            .get(&self.db_base_folder_param)
+            .get(DUCKDB_DB_BASE_FOLDER_PARAM)
             .cloned()
             .unwrap_or(".".to_string()); // default to the current directory
         let default_filepath = format!("{db_base_folder}/{name}.db");
 
         options
-            .get(&self.db_path_param)
+            .get(DUCKDB_DB_PATH_PARAM)
             .cloned()
             .unwrap_or(default_filepath)
     }

--- a/src/sqlite.rs
+++ b/src/sqlite.rs
@@ -84,25 +84,21 @@ pub enum Error {
 
 type Result<T, E = Error> = std::result::Result<T, E>;
 
-pub struct SqliteTableProviderFactory {
-    db_path_param: String,
-    db_base_folder_param: String,
-    attach_databases_param: String,
-}
+pub struct SqliteTableProviderFactory {}
+
+const SQLITE_DB_PATH_PARAM: &str = "file";
+const SQLITE_DB_BASE_FOLDER_PARAM: &str = "data_directory";
+const SQLITE_ATTACH_DATABASES_PARAM: &str = "attach_databases";
 
 impl SqliteTableProviderFactory {
     #[must_use]
     pub fn new() -> Self {
-        Self {
-            db_path_param: "file".to_string(),
-            db_base_folder_param: "data_directory".to_string(),
-            attach_databases_param: "attach_databases".to_string(),
-        }
+        Self {}
     }
 
     #[must_use]
     pub fn attach_databases(&self, options: &HashMap<String, String>) -> Option<Vec<Arc<str>>> {
-        options.get(&self.attach_databases_param).map(|databases| {
+        options.get(SQLITE_ATTACH_DATABASES_PARAM).map(|databases| {
             databases
                 .split(';')
                 .map(Arc::from)
@@ -115,13 +111,13 @@ impl SqliteTableProviderFactory {
         let options = util::remove_prefix_from_hashmap_keys(options.clone(), "sqlite_");
 
         let db_base_folder = options
-            .get(&self.db_base_folder_param)
+            .get(SQLITE_DB_BASE_FOLDER_PARAM)
             .cloned()
             .unwrap_or(".".to_string()); // default to the current directory
         let default_filepath = format!("{db_base_folder}/{name}_sqlite.db");
 
         options
-            .get(&self.db_path_param)
+            .get(SQLITE_DB_PATH_PARAM)
             .cloned()
             .unwrap_or(default_filepath)
     }


### PR DESCRIPTION
## 🗣 Description

* Adds an option to specify a data directory to store DuckDB database files.
* Removes the ability to change parameters for `DuckDBTableProviderFactory`, aligning with the SQLite factory behavior.