### PR TITLE
Use GHCR for postgres/mysql images

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -53,6 +53,10 @@ jobs:
     name: Integration Test
     runs-on: ubuntu-latest
 
+    env:
+      PG_DOCKER_IMAGE: ghcr.io/cloudnative-pg/postgresql:16-bookworm
+      MYSQL_DOCKER_IMAGE: ghcr.io/mirrorshub/docker/mysql:8-debian
+
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -62,5 +62,10 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@stable
 
+      - name: Pull the Postgres/MySQL images
+        run: |
+          docker pull ${{ env.PG_DOCKER_IMAGE }}
+          docker pull ${{ env.MYSQL_DOCKER_IMAGE }}
+
       - name: Run integration test
         run: make test-integration

--- a/tests/mysql/common.rs
+++ b/tests/mysql/common.rs
@@ -51,8 +51,11 @@ pub async fn start_mysql_docker_container(port: usize) -> Result<RunningContaine
         15432
     };
 
+    let mysql_docker_image = std::env::var("MYSQL_DOCKER_IMAGE")
+        .unwrap_or_else(|_| format!("{}mysql:latest", container_registry()));
+
     let running_container = ContainerRunnerBuilder::new(container_name)
-        .image(format!("{}mysql:latest", container_registry()))
+        .image(mysql_docker_image)
         .add_port_binding(3306, port)
         .add_env_var("MYSQL_ROOT_PASSWORD", MYSQL_ROOT_PASSWORD)
         .add_env_var("MYSQL_DATABASE", "mysqldb")

--- a/tests/postgres/common.rs
+++ b/tests/postgres/common.rs
@@ -50,8 +50,11 @@ pub(super) async fn start_postgres_docker_container(
         15432
     };
 
+    let pg_docker_image = std::env::var("PG_DOCKER_IMAGE")
+        .unwrap_or_else(|_| format!("{}postgres:latest", container_registry()));
+
     let running_container = ContainerRunnerBuilder::new(container_name)
-        .image(format!("{}postgres:latest", container_registry()))
+        .image(pg_docker_image)
         .add_port_binding(5432, port)
         .add_env_var("POSTGRES_PASSWORD", PG_PASSWORD)
         .healthcheck(HealthConfig {


### PR DESCRIPTION
Use GHCR for the postgres/mysql images in the CI runner to prevent rate-limiting errors from ECR/Docker Hub.