### PR TITLE
Add support for arrow <-> pg/sqlite row conversion for Duration type

### DIFF
--- a/src/sql/arrow_sql_gen/statement.rs
+++ b/src/sql/arrow_sql_gen/statement.rs
@@ -309,6 +309,20 @@ impl InsertBuilder {
                         }
                         _ => unreachable!(),
                     },
+                    DataType::Duration(time_unit) => match time_unit {
+                        TimeUnit::Second => {
+                            push_value!(row_values, column, row, DurationSecondArray);
+                        }
+                        TimeUnit::Microsecond => {
+                            push_value!(row_values, column, row, DurationMicrosecondArray);
+                        }
+                        TimeUnit::Millisecond => {
+                            push_value!(row_values, column, row, DurationMillisecondArray);
+                        }
+                        TimeUnit::Nanosecond => {
+                            push_value!(row_values, column, row, DurationNanosecondArray);
+                        }
+                    },
                     DataType::Time64(time_unit) => match time_unit {
                         TimeUnit::Nanosecond => {
                             let array = column
@@ -1008,7 +1022,7 @@ pub(crate) fn map_data_type_to_column_type(data_type: &DataType) -> ColumnType {
         DataType::Int8 => ColumnType::TinyInteger,
         DataType::Int16 => ColumnType::SmallInteger,
         DataType::Int32 => ColumnType::Integer,
-        DataType::Int64 => ColumnType::BigInteger,
+        DataType::Int64 | DataType::Duration(_) => ColumnType::BigInteger,
         DataType::UInt8 => ColumnType::TinyUnsigned,
         DataType::UInt16 => ColumnType::SmallUnsigned,
         DataType::UInt32 => ColumnType::Unsigned,

--- a/tests/postgres/mod.rs
+++ b/tests/postgres/mod.rs
@@ -110,7 +110,6 @@ async fn start_container(manager: &MutexGuard<'_, ContainerManager>) {
 #[case::struct_type(get_arrow_struct_record_batch(), "struct")]
 #[case::decimal(get_arrow_decimal_record_batch(), "decimal")]
 #[case::interval(get_arrow_interval_record_batch(), "interval")]
-#[ignore] // TODO: duration types are broken in Postgres
 #[case::duration(get_arrow_duration_record_batch(), "duration")]
 #[case::list(get_arrow_list_record_batch(), "list")]
 #[case::null(get_arrow_null_record_batch(), "null")]

--- a/tests/sqlite/mod.rs
+++ b/tests/sqlite/mod.rs
@@ -80,15 +80,14 @@ async fn arrow_sqlite_round_trip(arrow_record: RecordBatch, table_name: &str) {
 #[case::time(get_arrow_time_record_batch(), "time")]
 #[case::timestamp(get_arrow_timestamp_record_batch(), "timestamp")]
 #[case::date(get_arrow_date_record_batch(), "date")]
-#[ignore] // TODO: struct types are broken in SQLite
+#[ignore] // TODO: struct types are broken in SQLite - Data type mapping not implemented for Struct
 #[case::struct_type(get_arrow_struct_record_batch(), "struct")]
-#[ignore] // TODO: decimal types are broken in SQLite
+#[ignore] // TODO: decimal types are broken in SQLite - precision cannot be larger than 16
 #[case::decimal(get_arrow_decimal_record_batch(), "decimal")]
-#[ignore] // TODO: interval types are broken in SQLite
+#[ignore] // TODO: interval types are broken in SQLite - Interval is not available in Sqlite.
 #[case::interval(get_arrow_interval_record_batch(), "interval")]
-#[ignore] // TODO: duration types are broken in SQLite
 #[case::duration(get_arrow_duration_record_batch(), "duration")]
-#[ignore] // TODO: list types are broken in SQLite
+#[ignore] // TODO: list types are broken in SQLite - Array is not available in Sqlite.
 #[case::list(get_arrow_list_record_batch(), "list")]
 #[case::null(get_arrow_null_record_batch(), "null")]
 #[test_log::test(tokio::test)]


### PR DESCRIPTION
* Support arrow duration type in arrow <-> pg/sqlite row conversion. Arrow duration type is supported as i64 to preserve the value integrity.