### PR TITLE
Support arrow time32 & time64 correctly

### DIFF
--- a/tests/sqlite/mod.rs
+++ b/tests/sqlite/mod.rs
@@ -83,7 +83,6 @@ async fn arrow_sqlite_round_trip(
 #[case::int(get_arrow_int_record_batch(), "int")]
 #[case::float(get_arrow_float_record_batch(), "float")]
 #[case::utf8(get_arrow_utf8_record_batch(), "utf8")]
-#[ignore] // TODO: Time types are broken in SQLite
 #[case::time(get_arrow_time_record_batch(), "time")]
 #[case::timestamp(get_arrow_timestamp_record_batch(), "timestamp")]
 #[case::date(get_arrow_date_record_batch(), "date")]


### PR DESCRIPTION
* Convert arrow time32 & time64 to time type instead of timestamp type, this will help fix the sqlite incorrect conversion of arrow time32 & time64 type