### PR TITLE
Add support for writing Lists/Arrays to SQLite via JSON conversion

### DIFF
--- a/src/sql/arrow_sql_gen/statement.rs
+++ b/src/sql/arrow_sql_gen/statement.rs
@@ -1,5 +1,9 @@
 use arrow::{
-    array::{array, Array, RecordBatch},
+    array::{
+        array, Array, BooleanArray, Float32Array, Float64Array, Int16Array, Int32Array, Int64Array,
+        Int8Array, LargeStringArray, RecordBatch, StringArray, UInt16Array, UInt32Array,
+        UInt64Array, UInt8Array,
+    },
     datatypes::{DataType, Field, IntervalUnit, SchemaRef, TimeUnit},
     util::display::array_value_to_string,
 };
@@ -11,7 +15,7 @@ use sea_query::{
     QueryBuilder, SimpleExpr, SqliteQueryBuilder, StringLen, Table,
 };
 use snafu::Snafu;
-use std::sync::Arc;
+use std::{any::Any, sync::Arc};
 use time::{OffsetDateTime, PrimitiveDateTime};
 
 #[derive(Debug, Snafu)]
@@ -87,6 +91,12 @@ impl CreateTableBuilder {
     #[must_use]
     pub fn build_sqlite(self) -> String {
         self.build(SqliteQueryBuilder, &|f: &Arc<Field>| -> ColumnType {
+            // Sqlite does not natively support Arrays, Structs, etc
+            // so we use JSON column type for List, FixedSizeList, LargeList, Struct, etc
+            if f.data_type().is_nested() {
+                return ColumnType::JsonBinary;
+            }
+
             map_data_type_to_column_type(f.data_type())
         })
     }
@@ -165,6 +175,20 @@ pub struct InsertBuilder {
     record_batches: Vec<RecordBatch>,
 }
 
+pub fn use_json_insert_for_type<T: QueryBuilder + 'static>(
+    data_type: &DataType,
+    query_builder: &T,
+) -> bool {
+    #[cfg(feature = "sqlite")]
+    if (query_builder as &dyn Any)
+        .downcast_ref::<SqliteQueryBuilder>()
+        .is_some()
+    {
+        return data_type.is_nested();
+    }
+    false
+}
+
 impl InsertBuilder {
     #[must_use]
     pub fn new(table_name: &str, record_batches: Vec<RecordBatch>) -> Self {
@@ -180,7 +204,7 @@ impl InsertBuilder {
     ///
     /// Returns an error if a column's data type is not supported, or its conversion failed.
     #[allow(clippy::too_many_lines)]
-    pub fn construct_insert_stmt<T: QueryBuilder>(
+    pub fn construct_insert_stmt<T: QueryBuilder + 'static>(
         &self,
         insert_stmt: &mut InsertStatement,
         record_batch: &RecordBatch,
@@ -190,8 +214,9 @@ impl InsertBuilder {
             let mut row_values: Vec<SimpleExpr> = vec![];
             for col in 0..record_batch.num_columns() {
                 let column = record_batch.column(col);
+                let column_data_type = column.data_type();
 
-                match column.data_type() {
+                match column_data_type {
                     DataType::Int8 => push_value!(row_values, column, row, Int8Array),
                     DataType::Int16 => push_value!(row_values, column, row, Int16Array),
                     DataType::Int32 => push_value!(row_values, column, row, Int32Array),
@@ -424,7 +449,16 @@ impl InsertBuilder {
                                 continue;
                             }
                             let list_array = valid_array.value(row);
-                            insert_list_into_row_values(list_array, list_type, &mut row_values);
+
+                            if use_json_insert_for_type(column_data_type, query_builder) {
+                                insert_list_into_row_values_json(
+                                    list_array,
+                                    list_type,
+                                    &mut row_values,
+                                )?;
+                            } else {
+                                insert_list_into_row_values(list_array, list_type, &mut row_values);
+                            }
                         }
                     }
                     DataType::LargeList(list_type) => {
@@ -435,7 +469,16 @@ impl InsertBuilder {
                                 continue;
                             }
                             let list_array = valid_array.value(row);
-                            insert_list_into_row_values(list_array, list_type, &mut row_values);
+
+                            if use_json_insert_for_type(column_data_type, query_builder) {
+                                insert_list_into_row_values_json(
+                                    list_array,
+                                    list_type,
+                                    &mut row_values,
+                                )?;
+                            } else {
+                                insert_list_into_row_values(list_array, list_type, &mut row_values);
+                            }
                         }
                     }
                     DataType::FixedSizeList(list_type, _) => {
@@ -446,7 +489,16 @@ impl InsertBuilder {
                                 continue;
                             }
                             let list_array = valid_array.value(row);
-                            insert_list_into_row_values(list_array, list_type, &mut row_values);
+
+                            if use_json_insert_for_type(column_data_type, query_builder) {
+                                insert_list_into_row_values_json(
+                                    list_array,
+                                    list_type,
+                                    &mut row_values,
+                                )?;
+                            } else {
+                                insert_list_into_row_values(list_array, list_type, &mut row_values);
+                            }
                         }
                     }
                     DataType::Binary => {
@@ -794,7 +846,7 @@ impl InsertBuilder {
     ///
     /// Returns an error if any `RecordBatch` fails to convert into a valid insert statement. Upon
     /// error, no further `RecordBatch` is processed.
-    pub fn build<T: GenericBuilder>(
+    pub fn build<T: GenericBuilder + 'static>(
         &self,
         query_builder: T,
         on_conflict: Option<OnConflict>,
@@ -1035,6 +1087,56 @@ pub(crate) fn map_data_type_to_column_type(data_type: &DataType) -> ColumnType {
         // Add more mappings here as needed
         _ => unimplemented!("Data type mapping not implemented for {:?}", data_type),
     }
+}
+
+macro_rules! serialize_list_values {
+    ($data_type:expr, $list_array:expr, $array_type:ty, $vec_type:ty) => {{
+        let mut list_values: Vec<$vec_type> = vec![];
+        if let Some(array) = $list_array.as_any().downcast_ref::<$array_type>() {
+            for i in 0..array.len() {
+                list_values.push(array.value(i).into());
+            }
+        }
+
+        serde_json::to_string(&list_values).map_err(|e| Error::FailedToCreateInsertStatement {
+            source: Box::new(e),
+        })?
+    }};
+}
+
+fn insert_list_into_row_values_json(
+    list_array: Arc<dyn Array>,
+    list_type: &Arc<Field>,
+    row_values: &mut Vec<SimpleExpr>,
+) -> Result<()> {
+    let data_type = list_type.data_type();
+
+    let json_string: String = match data_type {
+        DataType::Int8 => serialize_list_values!(data_type, list_array, Int8Array, i8),
+        DataType::Int16 => serialize_list_values!(data_type, list_array, Int16Array, i16),
+        DataType::Int32 => serialize_list_values!(data_type, list_array, Int32Array, i32),
+        DataType::Int64 => serialize_list_values!(data_type, list_array, Int64Array, i64),
+        DataType::UInt8 => serialize_list_values!(data_type, list_array, UInt8Array, u8),
+        DataType::UInt16 => serialize_list_values!(data_type, list_array, UInt16Array, u16),
+        DataType::UInt32 => serialize_list_values!(data_type, list_array, UInt32Array, u32),
+        DataType::UInt64 => serialize_list_values!(data_type, list_array, UInt64Array, u64),
+        DataType::Float32 => serialize_list_values!(data_type, list_array, Float32Array, f32),
+        DataType::Float64 => serialize_list_values!(data_type, list_array, Float64Array, f64),
+        DataType::Utf8 => serialize_list_values!(data_type, list_array, StringArray, String),
+        DataType::LargeUtf8 => {
+            serialize_list_values!(data_type, list_array, LargeStringArray, String)
+        }
+        DataType::Boolean => serialize_list_values!(data_type, list_array, BooleanArray, bool),
+        _ => unimplemented!(
+            "List to json conversion is not implemented for {}",
+            list_type.data_type()
+        ),
+    };
+
+    let expr: SimpleExpr = Expr::value(json_string);
+    row_values.push(expr);
+
+    Ok(())
 }
 
 #[cfg(test)]


### PR DESCRIPTION
SQLite does not support Arrays natively so PRs adds fallback on using JSON column type and serialization to JSON string for Arrow List types. With this change previously unsupported types will be stored and retrieved as Ut8 string when queried directly or automatically converted back to Arrow List type when using casting layer:  [Add List types parsing support to schema cast](https://github.com/spiceai/datafusion-federation/pull/13)


List, LargeList, FixedSizeList are supported