### PR TITLE
Custom decimal test case for sqlite

### DIFF
--- a/tests/arrow_record_batch_gen/mod.rs
+++ b/tests/arrow_record_batch_gen/mod.rs
@@ -571,3 +571,29 @@ pub(crate) fn try_cast_to(
     RecordBatch::try_new(expected_schema, cols)
         .map_err(|e| "Fail to create casted record batch".to_string())
 }
+
+// Custom Test Case for Sqlite <-> Arrow Decimal Roundtrip
+// SQLite supports up to 16 precision for decimal numbers through REAL type, conforming to IEEE 754 Binary-64 format - https://www.sqlite.org/floatingpoint.html
+pub(crate) fn get_sqlite_arrow_decimal_record_batch() -> (RecordBatch, SchemaRef) {
+    let decimal128_array =
+        Decimal128Array::from(vec![i128::from(123), i128::from(222), i128::from(321)])
+            .with_precision_and_scale(16, 10)
+            .expect("Fail to create Decimal128 array");
+    let decimal256_array =
+        Decimal256Array::from(vec![i256::from(-123), i256::from(222), i256::from(0)])
+            .with_precision_and_scale(16, 10)
+            .expect("Fail to create Decimal256 array");
+
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("decimal128", DataType::Decimal128(16, 10), false),
+        Field::new("decimal256", DataType::Decimal256(16, 10), false),
+    ]));
+
+    let record_batch = RecordBatch::try_new(
+        Arc::clone(&schema),
+        vec![Arc::new(decimal128_array), Arc::new(decimal256_array)],
+    )
+    .expect("Failed to created arrow decimal record batch");
+
+    (record_batch, schema)
+}

--- a/tests/sqlite/mod.rs
+++ b/tests/sqlite/mod.rs
@@ -88,8 +88,8 @@ async fn arrow_sqlite_round_trip(
 #[case::date(get_arrow_date_record_batch(), "date")]
 #[ignore] // TODO: struct types are broken in SQLite - Data type mapping not implemented for Struct
 #[case::struct_type(get_arrow_struct_record_batch(), "struct")]
-#[ignore] // TODO: decimal types are broken in SQLite - precision cannot be larger than 16
-#[case::decimal(get_arrow_decimal_record_batch(), "decimal")]
+// SQLite only supports up to 16 precision for decimal through REAL type.
+#[case::decimal(get_sqlite_arrow_decimal_record_batch(), "decimal")]
 #[ignore] // TODO: interval types are broken in SQLite - Interval is not available in Sqlite.
 #[case::interval(get_arrow_interval_record_batch(), "interval")]
 #[case::duration(get_arrow_duration_record_batch(), "duration")]


### PR DESCRIPTION
SQLite only supports up to 16 precision for decimal through REAL type. Update the SQLite test case using 16 precision of Decimal128 & Decimal256, and document the limitation