### PR TITLE
Add Structs support for SQLite

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ url = "2.5.1"
 pem = { version = "3.0.4", optional = true }
 tokio-rusqlite = { version = "0.5.1", optional = true }
 datafusion-federation = "0.1"
-datafusion-federation-sql = { git = "https://github.com/spiceai/datafusion-federation.git", rev = "ae9da45f8b90451119f3ca032b75ad82a28d7547" }
+datafusion-federation-sql = { git = "https://github.com/spiceai/datafusion-federation.git", rev = "e0a4eaef873949c4f4bb3edf64e411821e62dcb2" }
 itertools = "0.13.0"
 geo-types = "0.7.13"
 
@@ -67,4 +67,4 @@ sqlite = ["dep:rusqlite", "dep:tokio-rusqlite"]
 duckdb = ["dep:duckdb", "dep:r2d2", "dep:uuid"]
 
 [patch.crates-io]
-datafusion-federation = { git = "https://github.com/spiceai/datafusion-federation.git", rev = "ae9da45f8b90451119f3ca032b75ad82a28d7547" }
+datafusion-federation = { git = "https://github.com/spiceai/datafusion-federation.git", rev = "e0a4eaef873949c4f4bb3edf64e411821e62dcb2" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ repository = "https://github.com/datafusion-contrib/datafusion-table-providers"
 
 [dependencies]
 arrow = "52.0.0"
+arrow-json = "52.2.0"
 async-stream = { version = "0.3.5", optional = true }
 async-trait = "0.1.80"
 num-bigint = "0.4.4"

--- a/src/sql/arrow_sql_gen/statement.rs
+++ b/src/sql/arrow_sql_gen/statement.rs
@@ -1335,8 +1335,10 @@ fn insert_struct_into_row_values_json(
         .map(|i| array.column(i).slice(row_index, 1))
         .collect();
 
-    let batch =
-        RecordBatch::try_new(Arc::new(Schema::new(fields.clone())), single_row_columns).unwrap();
+    let batch = RecordBatch::try_new(Arc::new(Schema::new(fields.clone())), single_row_columns)
+        .map_err(|e| Error::FailedToCreateInsertStatement {
+            source: Box::new(e),
+        })?;
 
     let mut writer = arrow_json::LineDelimitedWriter::new(Vec::new());
     writer.write(&batch).map_err(|e| Error::FailedToCreateInsertStatement {

--- a/tests/duckdb/mod.rs
+++ b/tests/duckdb/mod.rs
@@ -7,6 +7,7 @@ use datafusion::execution::context::SessionContext;
 use datafusion::logical_expr::CreateExternalTable;
 use datafusion::physical_plan::collect;
 use datafusion::physical_plan::memory::MemoryExec;
+use datafusion_federation::schema_cast::record_convert::try_cast_to;
 use datafusion_table_providers::duckdb::DuckDBTableProviderFactory;
 use rstest::rstest;
 use std::collections::HashMap;

--- a/tests/postgres/mod.rs
+++ b/tests/postgres/mod.rs
@@ -8,6 +8,7 @@ use datafusion::execution::context::SessionContext;
 use datafusion::logical_expr::CreateExternalTable;
 use datafusion::physical_plan::collect;
 use datafusion::physical_plan::memory::MemoryExec;
+use datafusion_federation::schema_cast::record_convert::try_cast_to;
 use datafusion_table_providers::sql::arrow_sql_gen::statement::{
     CreateTableBuilder, InsertBuilder,
 };

--- a/tests/sqlite/mod.rs
+++ b/tests/sqlite/mod.rs
@@ -94,7 +94,6 @@ async fn arrow_sqlite_round_trip(
 #[ignore] // TODO: interval types are broken in SQLite - Interval is not available in Sqlite.
 #[case::interval(get_arrow_interval_record_batch(), "interval")]
 #[case::duration(get_arrow_duration_record_batch(), "duration")]
-#[ignore] // TODO: list types are broken in SQLite - Array is not available in Sqlite.
 #[case::list(get_arrow_list_record_batch(), "list")]
 #[case::null(get_arrow_null_record_batch(), "null")]
 #[test_log::test(tokio::test)]

--- a/tests/sqlite/mod.rs
+++ b/tests/sqlite/mod.rs
@@ -2,6 +2,7 @@ use crate::arrow_record_batch_gen::*;
 use arrow::array::RecordBatch;
 use arrow::datatypes::SchemaRef;
 use datafusion::execution::context::SessionContext;
+use datafusion_federation::schema_cast::record_convert::try_cast_to;
 use datafusion_table_providers::sql::arrow_sql_gen::statement::{
     CreateTableBuilder, InsertBuilder,
 };


### PR DESCRIPTION
SQLite does not support  Structs natively so PRs adds fallback on using JSON column type and serialization to JSON string for Arrow struct type. 

With this change previously unsupported Arrow Struct type will be stored and retrieved as Utf8 string when queried directly or automatically converted to Arrow Struct type when using casting layer:  https://github.com/spiceai/datafusion-federation/pull/16

Integration tests for struct will be enabled after casting PR is merged and reference is updated: https://github.com/spiceai/datafusion-federation/pull/16

PR also switches from own `try_cast_to` implementation to`try_cast_to` exposed by datafusion-federation