### PR TITLE
fix: CHECKPOINT DuckDB after finishing writing

### DIFF
--- a/src/duckdb.rs
+++ b/src/duckdb.rs
@@ -85,6 +85,11 @@ pub enum Error {
     #[snafu(display("Unable to commit transaction: {source}"))]
     UnableToCommitTransaction { source: duckdb::Error },
 
+    #[snafu(display("Unable to checkpoint duckdb: {source}"))]
+    UnableToCheckpoint {
+        source: Box<dyn std::error::Error + Send + Sync>,
+    },
+
     #[snafu(display("Unable to begin duckdb transaction: {source}"))]
     UnableToBeginTransaction { source: duckdb::Error },
 


### PR DESCRIPTION
## 🗣 Description

* Runs [`CHECKPOINT` for DuckDB](https://duckdb.org/docs/sql/statements/checkpoint.html) after finishing writing. This flushes the Write-Ahead Log to the database.

This is a requirement for connections that have attachments configured, observed on Linux. Without flushing the write-ahead log, the log file locks to the writer process. This prevents the reader from reading the WAL file, causing query errors due for `Failure while replaying WAL file.`