### PR TITLE
Bump datafusion-federation version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ url = "2.5.1"
 pem = { version = "3.0.4", optional = true }
 tokio-rusqlite = { version = "0.5.1", optional = true }
 datafusion-federation = "0.1"
-datafusion-federation-sql = { git = "https://github.com/spiceai/datafusion-federation.git", rev = "e0a4eaef873949c4f4bb3edf64e411821e62dcb2" }
+datafusion-federation-sql = { git = "https://github.com/spiceai/datafusion-federation.git", rev = "21f07bec7284bcbff2bf4e570008290b66e3dc6f" }
 itertools = "0.13.0"
 geo-types = "0.7.13"
 
@@ -68,4 +68,4 @@ sqlite = ["dep:rusqlite", "dep:tokio-rusqlite"]
 duckdb = ["dep:duckdb", "dep:r2d2", "dep:uuid"]
 
 [patch.crates-io]
-datafusion-federation = { git = "https://github.com/spiceai/datafusion-federation.git", rev = "e0a4eaef873949c4f4bb3edf64e411821e62dcb2" }
+datafusion-federation = { git = "https://github.com/spiceai/datafusion-federation.git", rev = "21f07bec7284bcbff2bf4e570008290b66e3dc6f" }

--- a/tests/sqlite/mod.rs
+++ b/tests/sqlite/mod.rs
@@ -87,7 +87,6 @@ async fn arrow_sqlite_round_trip(
 #[case::time(get_arrow_time_record_batch(), "time")]
 #[case::timestamp(get_arrow_timestamp_record_batch(), "timestamp")]
 #[case::date(get_arrow_date_record_batch(), "date")]
-#[ignore] // TODO: struct types are broken in SQLite - Data type mapping not implemented for Struct
 #[case::struct_type(get_arrow_struct_record_batch(), "struct")]
 // SQLite only supports up to 16 precision for decimal through REAL type.
 #[case::decimal(get_sqlite_arrow_decimal_record_batch(), "decimal")]


### PR DESCRIPTION
Bumps the datafusion-federation version to include the following change: https://github.com/spiceai/datafusion-federation/pull/16

With this change integration tests for structs support for SQLite could be enabled.