### PR TITLE
fix: Use feature flag to disable DuckDB and SQLite federation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,6 +67,7 @@ postgres = ["dep:tokio-postgres", "dep:uuid", "dep:postgres-native-tls", "dep:bb
 sqlite = ["dep:rusqlite", "dep:tokio-rusqlite"]
 duckdb = ["dep:duckdb", "dep:r2d2", "dep:uuid"]
 duckdb-federation = ["duckdb"]
+sqlite-federation = ["sqlite"]
 
 [patch.crates-io]
 datafusion-federation = { git = "https://github.com/spiceai/datafusion-federation.git", rev = "e0a4eaef873949c4f4bb3edf64e411821e62dcb2" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,6 +65,7 @@ mysql = ["dep:mysql_async", "dep:async-stream"]
 postgres = ["dep:tokio-postgres", "dep:uuid", "dep:postgres-native-tls", "dep:bb8", "dep:bb8-postgres", "dep:native-tls", "dep:pem", "dep:async-stream"]
 sqlite = ["dep:rusqlite", "dep:tokio-rusqlite"]
 duckdb = ["dep:duckdb", "dep:r2d2", "dep:uuid"]
+duckdb-federation = ["duckdb"]
 
 [patch.crates-io]
 datafusion-federation = { git = "https://github.com/spiceai/datafusion-federation.git", rev = "e0a4eaef873949c4f4bb3edf64e411821e62dcb2" }

--- a/src/duckdb.rs
+++ b/src/duckdb.rs
@@ -32,8 +32,10 @@ use std::{cmp, collections::HashMap, sync::Arc};
 
 use self::{creator::TableCreator, sql_table::DuckDBTable, write::DuckDBTableWriter};
 
-mod creator;
+#[cfg(feature = "duckdb-federation")]
 mod federation;
+
+mod creator;
 mod sql_table;
 pub mod write;
 
@@ -265,7 +267,9 @@ impl TableProviderFactory for DuckDBTableProviderFactory {
             None,
         ));
 
+        #[cfg(feature = "duckdb-federation")]
         let read_provider = Arc::new(read_provider.create_federated_table_provider()?);
+
         Ok(DuckDBTableWriter::create(
             read_provider,
             duckdb,
@@ -438,7 +442,10 @@ impl DuckDBTableFactory {
         let table_provider = Arc::new(DuckDBTable::new_with_schema(
             "duckdb", &dyn_pool, schema, tbl_ref, None, cte,
         ));
+
+        #[cfg(feature = "duckdb-federation")]
         let table_provider = Arc::new(table_provider.create_federated_table_provider()?);
+
         Ok(table_provider)
     }
 

--- a/src/sql/db_connection_pool/duckdbpool.rs
+++ b/src/sql/db_connection_pool/duckdbpool.rs
@@ -154,6 +154,7 @@ impl DbConnectionPool<r2d2::PooledConnection<DuckdbConnectionManager>, &'static 
         let conn: r2d2::PooledConnection<DuckdbConnectionManager> =
             pool.get().context(ConnectionPoolSnafu)?;
 
+        #[cfg(feature = "duckdb-federation")]
         if !self.attached_databases.is_empty() {
             for (i, db) in self.attached_databases.iter().enumerate() {
                 // check the db file exists

--- a/src/sqlite.rs
+++ b/src/sqlite.rs
@@ -258,7 +258,9 @@ impl TableProviderFactory for SqliteTableProviderFactory {
             .context(DanglingReferenceToSqliteSnafu)
             .map_err(to_datafusion_error)?;
 
+        #[cfg(feature = "sqlite-federation")]
         let read_provider = Arc::new(read_provider.create_federated_table_provider()?);
+
         Ok(SqliteTableWriter::create(
             read_provider,
             sqlite,


### PR DESCRIPTION
## 🗣 Description

* Locks DuckDB federation functionality behind `duckdb-federation` due to DuckDB federation instability.
* Locks SQLite federation functionality behind `sqlite-federation` due to SQLite federation instability.