### PR TITLE
Don't open the DuckDB file twice

### DIFF
--- a/src/sql/db_connection_pool/duckdbpool.rs
+++ b/src/sql/db_connection_pool/duckdbpool.rs
@@ -29,6 +29,7 @@ pub enum Error {
     },
 }
 
+#[derive(Clone)]
 pub struct DuckDbConnectionPool {
     path: Arc<str>,
     pool: Arc<r2d2::Pool<DuckdbConnectionManager>>,


### PR DESCRIPTION
This caused a subtle issue that was probably due to a race condition of trying to open the same file twice around the same time. The read pool wasn't properly opening, leading to queries failing.