### PR TITLE
Use correct search path for duckdb pool

### DIFF
--- a/src/sql/db_connection_pool/duckdbpool.rs
+++ b/src/sql/db_connection_pool/duckdbpool.rs
@@ -157,9 +157,10 @@ impl DbConnectionPool<r2d2::PooledConnection<DuckdbConnectionManager>, &'static 
             pool.get().context(ConnectionPoolSnafu)?;
 
         #[cfg(feature = "duckdb-federation")]
-        let mut db_ids = Vec::new();
-        db_ids.push(extract_db_name(Arc::clone(&self.path))?);
         if !self.attached_databases.is_empty() {
+            let mut db_ids = Vec::new();
+            db_ids.push(extract_db_name(Arc::clone(&self.path))?);
+
             for (i, db) in self.attached_databases.iter().enumerate() {
                 // check the db file exists
                 std::fs::metadata(db.as_ref()).context(UnableToAttachDatabaseSnafu {

--- a/src/sql/db_connection_pool/duckdbpool.rs
+++ b/src/sql/db_connection_pool/duckdbpool.rs
@@ -159,7 +159,6 @@ impl DbConnectionPool<r2d2::PooledConnection<DuckdbConnectionManager>, &'static 
         #[cfg(feature = "duckdb-federation")]
         let mut db_ids = Vec::new();
         db_ids.push(extract_db_name(Arc::clone(&self.path))?);
-
         if !self.attached_databases.is_empty() {
             for (i, db) in self.attached_databases.iter().enumerate() {
                 // check the db file exists


### PR DESCRIPTION
Use the correct search paths when executing `SET search_path = \"{}\""` in connecting to duckdb.
Put the main database at first, and all the attached databases in the following, instead of just using the results of `SHOW DATABASES`, which is essentially in the alphabetic order.
This will make sure that statements always first evaluated against the main database, so that the write operations won't be evaluated against the attached databases.