### PR TITLE
Fix SQLite empty response (unexpected number of columns)

### DIFF
--- a/src/sql/db_connection_pool/dbconnection/sqliteconn.rs
+++ b/src/sql/db_connection_pool/dbconnection/sqliteconn.rs
@@ -102,7 +102,11 @@ impl AsyncDbConnection<Connection, &'static (dyn ToSql + Sync)> for SqliteConnec
             .context(ConnectionSnafu)?;
 
         let schema = rec.schema();
-        let recs = vec![rec];
+        let recs = if rec.num_rows() > 0 {
+            vec![rec]
+        } else {
+            vec![]
+        };
         Ok(Box::pin(MemoryStream::try_new(recs, schema, None)?))
     }
 


### PR DESCRIPTION
Should return empty vector instead if vector with empty record batch. This fixes 
>Query Error Unexpected number of columns. Expected: 4, Found: 0