### PR TITLE
refactor: Create an SQLiteTable for SQLite SQLExec

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ pem = { version = "3.0.4", optional = true }
 tokio-rusqlite = { version = "0.5.1", optional = true }
 tonic = { version = "0.11", optional = true } # pinned for arrow-flight compat
 datafusion-federation = "0.1"
-datafusion-federation-sql = { git = "https://github.com/spiceai/datafusion-federation.git", rev = "21f07bec7284bcbff2bf4e570008290b66e3dc6f" }
+datafusion-federation-sql = { git = "https://github.com/spiceai/datafusion-federation.git", rev = "b6682948d07cc3155edb3dfbf03f8b55570fc1d2" }
 itertools = "0.13.0"
 geo-types = "0.7.13"
 
@@ -97,4 +97,4 @@ duckdb-federation = ["duckdb"]
 sqlite-federation = ["sqlite"]
 
 [patch.crates-io]
-datafusion-federation = { git = "https://github.com/spiceai/datafusion-federation.git", rev = "21f07bec7284bcbff2bf4e570008290b66e3dc6f" }
+datafusion-federation = { git = "https://github.com/spiceai/datafusion-federation.git", rev = "b6682948d07cc3155edb3dfbf03f8b55570fc1d2" }

--- a/src/duckdb.rs
+++ b/src/duckdb.rs
@@ -258,11 +258,9 @@ impl TableProviderFactory for DuckDBTableProviderFactory {
         let dyn_pool: Arc<DynDuckDbConnectionPool> = Arc::new(read_pool);
 
         let read_provider = Arc::new(DuckDBTable::new_with_schema(
-            "duckdb",
             &dyn_pool,
             Arc::clone(&schema),
             TableReference::bare(name.clone()),
-            Some(Engine::DuckDB),
             None,
         ));
 
@@ -439,7 +437,7 @@ impl DuckDBTableFactory {
         };
 
         let table_provider = Arc::new(DuckDBTable::new_with_schema(
-            "duckdb", &dyn_pool, schema, tbl_ref, None, cte,
+            &dyn_pool, schema, tbl_ref, cte,
         ));
 
         #[cfg(feature = "duckdb-federation")]

--- a/src/duckdb.rs
+++ b/src/duckdb.rs
@@ -7,7 +7,7 @@ use crate::sql::db_connection_pool::{
     duckdbpool::DuckDbConnectionPool,
     DbConnectionPool, Mode,
 };
-use crate::sql::sql_provider_datafusion::{self, expr::Engine};
+use crate::sql::sql_provider_datafusion;
 use crate::util::{
     self,
     column_reference::{self, ColumnReference},

--- a/src/duckdb/sql_table.rs
+++ b/src/duckdb/sql_table.rs
@@ -8,7 +8,7 @@ use std::fmt::Display;
 use std::{any::Any, fmt, sync::Arc};
 
 use crate::sql::sql_provider_datafusion::{
-    expr, get_stream, to_execution_error, Result as SqlResult, SqlExec, SqlTable,
+    get_stream, to_execution_error, Result as SqlResult, SqlExec, SqlTable,
 };
 use datafusion::{
     arrow::datatypes::SchemaRef,

--- a/src/duckdb/sql_table.rs
+++ b/src/duckdb/sql_table.rs
@@ -32,14 +32,18 @@ pub struct DuckDBTable<T: 'static, P: 'static> {
 
 impl<T, P> DuckDBTable<T, P> {
     pub fn new_with_schema(
-        name: &'static str,
         pool: &Arc<dyn DbConnectionPool<T, P> + Send + Sync>,
         schema: impl Into<SchemaRef>,
         table_reference: impl Into<TableReference>,
-        engine: Option<expr::Engine>,
         table_functions: Option<HashMap<String, String>>,
     ) -> Self {
-        let base_table = SqlTable::new_with_schema(name, pool, schema, table_reference, engine);
+        let base_table = SqlTable::new_with_schema(
+            "duckdb",
+            pool,
+            schema,
+            table_reference,
+            Some(Engine::DuckDB),
+        );
 
         Self {
             base_table,

--- a/src/sqlite.rs
+++ b/src/sqlite.rs
@@ -247,11 +247,9 @@ impl TableProviderFactory for SqliteTableProviderFactory {
         let dyn_pool: Arc<DynSqliteConnectionPool> = read_pool;
 
         let read_provider = Arc::new(SQLiteTable::new_with_schema(
-            "sqlite",
             &dyn_pool,
             Arc::clone(&schema),
             TableReference::bare(name.clone()),
-            Some(Engine::SQLite),
         ));
 
         let sqlite = Arc::into_inner(sqlite)
@@ -293,11 +291,9 @@ impl SqliteTableFactory {
         let dyn_pool: Arc<DynSqliteConnectionPool> = pool;
 
         let read_provider = Arc::new(SQLiteTable::new_with_schema(
-            "sqlite",
             &dyn_pool,
             Arc::clone(&schema),
             table_reference,
-            Some(Engine::SQLite),
         ));
 
         Ok(read_provider)

--- a/src/sqlite.rs
+++ b/src/sqlite.rs
@@ -7,7 +7,7 @@ use crate::sql::db_connection_pool::{
     sqlitepool::SqliteConnectionPool,
     DbConnectionPool, Mode,
 };
-use crate::sql::sql_provider_datafusion::{self, expr::Engine};
+use crate::sql::sql_provider_datafusion;
 use arrow::{array::RecordBatch, datatypes::SchemaRef};
 use async_trait::async_trait;
 use datafusion::catalog::Session;

--- a/src/sqlite/federation.rs
+++ b/src/sqlite/federation.rs
@@ -1,0 +1,95 @@
+use crate::sql::db_connection_pool::dbconnection::{get_schema, Error as DbError};
+use crate::sql::sql_provider_datafusion::{get_stream, to_execution_error};
+use arrow::datatypes::SchemaRef;
+use datafusion::sql::unparser::dialect::Dialect;
+use datafusion_federation::{FederatedTableProviderAdaptor, FederatedTableSource};
+use datafusion_federation_sql::{SQLExecutor, SQLFederationProvider, SQLTableSource};
+use futures::TryStreamExt;
+use snafu::ResultExt;
+
+use async_trait::async_trait;
+use std::sync::Arc;
+
+use super::sql_table::SQLiteTable;
+use datafusion::{
+    datasource::TableProvider,
+    error::{DataFusionError, Result as DataFusionResult},
+    execution::SendableRecordBatchStream,
+    physical_plan::stream::RecordBatchStreamAdapter,
+    sql::TableReference,
+};
+
+impl<T, P> SQLiteTable<T, P> {
+    fn create_federated_table_source(
+        self: Arc<Self>,
+    ) -> DataFusionResult<Arc<dyn FederatedTableSource>> {
+        let table_name = self.base_table.table_reference.to_quoted_string();
+        let schema = Arc::clone(&Arc::clone(&self).base_table.schema());
+        let fed_provider = Arc::new(SQLFederationProvider::new(self));
+        Ok(Arc::new(SQLTableSource::new_with_schema(
+            fed_provider,
+            table_name,
+            schema,
+        )?))
+    }
+
+    pub fn create_federated_table_provider(
+        self: Arc<Self>,
+    ) -> DataFusionResult<FederatedTableProviderAdaptor> {
+        let table_source = Self::create_federated_table_source(Arc::clone(&self))?;
+        Ok(FederatedTableProviderAdaptor::new_with_provider(
+            table_source,
+            self,
+        ))
+    }
+}
+
+#[async_trait]
+impl<T, P> SQLExecutor for SQLiteTable<T, P> {
+    fn name(&self) -> &str {
+        self.base_table.name()
+    }
+
+    fn compute_context(&self) -> Option<String> {
+        self.base_table.compute_context()
+    }
+
+    fn dialect(&self) -> Arc<dyn Dialect> {
+        self.base_table.dialect()
+    }
+
+    fn execute(
+        &self,
+        query: &str,
+        schema: SchemaRef,
+    ) -> DataFusionResult<SendableRecordBatchStream> {
+        let fut = get_stream(
+            self.base_table.clone_pool(),
+            query.to_string(),
+            Arc::clone(&schema),
+        );
+
+        let stream = futures::stream::once(fut).try_flatten();
+        Ok(Box::pin(RecordBatchStreamAdapter::new(schema, stream)))
+    }
+
+    async fn table_names(&self) -> DataFusionResult<Vec<String>> {
+        Err(DataFusionError::NotImplemented(
+            "table inference not implemented".to_string(),
+        ))
+    }
+
+    async fn get_table_schema(&self, table_name: &str) -> DataFusionResult<SchemaRef> {
+        let conn = self
+            .base_table
+            .clone_pool()
+            .connect()
+            .await
+            .map_err(to_execution_error)?;
+        get_schema(conn, &TableReference::from(table_name))
+            .await
+            .boxed()
+            .map_err(|e| DbError::UnableToGetSchema { source: e })
+            .map_err(to_execution_error)
+    }
+}

--- a/src/sqlite/sql_table.rs
+++ b/src/sqlite/sql_table.rs
@@ -8,7 +8,7 @@ use std::fmt::Display;
 use std::{any::Any, fmt, sync::Arc};
 
 use crate::sql::sql_provider_datafusion::{
-    expr, get_stream, to_execution_error, Result as SqlResult, SqlExec, SqlTable,
+    get_stream, to_execution_error, Result as SqlResult, SqlExec, SqlTable,
 };
 use datafusion::{
     arrow::datatypes::SchemaRef,

--- a/src/sqlite/sql_table.rs
+++ b/src/sqlite/sql_table.rs
@@ -1,0 +1,188 @@
+use crate::sql::db_connection_pool::DbConnectionPool;
+use crate::sql::sql_provider_datafusion::expr::Engine;
+use async_trait::async_trait;
+use datafusion::catalog::Session;
+use datafusion::sql::unparser::dialect::SqliteDialect;
+use futures::TryStreamExt;
+use std::fmt::Display;
+use std::{any::Any, fmt, sync::Arc};
+
+use crate::sql::sql_provider_datafusion::{
+    expr, get_stream, to_execution_error, Result as SqlResult, SqlExec, SqlTable,
+};
+use datafusion::{
+    arrow::datatypes::SchemaRef,
+    datasource::TableProvider,
+    error::Result as DataFusionResult,
+    execution::TaskContext,
+    logical_expr::{Expr, TableProviderFilterPushDown, TableType},
+    physical_plan::{
+        stream::RecordBatchStreamAdapter, DisplayAs, DisplayFormatType, ExecutionPlan,
+        PlanProperties, SendableRecordBatchStream,
+    },
+    sql::TableReference,
+};
+
+pub struct SQLiteTable<T: 'static, P: 'static> {
+    pub(crate) base_table: SqlTable<T, P>,
+}
+
+impl<T, P> SQLiteTable<T, P> {
+    pub fn new_with_schema(
+        name: &'static str,
+        pool: &Arc<dyn DbConnectionPool<T, P> + Send + Sync>,
+        schema: impl Into<SchemaRef>,
+        table_reference: impl Into<TableReference>,
+        engine: Option<expr::Engine>,
+    ) -> Self {
+        let base_table = SqlTable::new_with_schema(name, pool, schema, table_reference, engine)
+            .with_dialect(Arc::new(SqliteDialect {}));
+
+        Self { base_table }
+    }
+
+    fn create_physical_plan(
+        &self,
+        projections: Option<&Vec<usize>>,
+        schema: &SchemaRef,
+        filters: &[Expr],
+        limit: Option<usize>,
+    ) -> DataFusionResult<Arc<dyn ExecutionPlan>> {
+        Ok(Arc::new(SQLiteSqlExec::new(
+            projections,
+            schema,
+            &self.base_table.table_reference,
+            self.base_table.clone_pool(),
+            filters,
+            limit,
+        )?))
+    }
+}
+
+#[async_trait]
+impl<T, P> TableProvider for SQLiteTable<T, P> {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn schema(&self) -> SchemaRef {
+        self.base_table.schema()
+    }
+
+    fn table_type(&self) -> TableType {
+        self.base_table.table_type()
+    }
+
+    fn supports_filters_pushdown(
+        &self,
+        filters: &[&Expr],
+    ) -> DataFusionResult<Vec<TableProviderFilterPushDown>> {
+        self.base_table.supports_filters_pushdown(filters)
+    }
+
+    async fn scan(
+        &self,
+        _state: &dyn Session,
+        projection: Option<&Vec<usize>>,
+        filters: &[Expr],
+        limit: Option<usize>,
+    ) -> DataFusionResult<Arc<dyn ExecutionPlan>> {
+        return self.create_physical_plan(projection, &self.schema(), filters, limit);
+    }
+}
+
+impl<T, P> Display for SQLiteTable<T, P> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "SQLiteTable {}", self.base_table.name())
+    }
+}
+
+#[derive(Clone)]
+struct SQLiteSqlExec<T, P> {
+    base_exec: SqlExec<T, P>,
+}
+
+impl<T, P> SQLiteSqlExec<T, P> {
+    fn new(
+        projections: Option<&Vec<usize>>,
+        schema: &SchemaRef,
+        table_reference: &TableReference,
+        pool: Arc<dyn DbConnectionPool<T, P> + Send + Sync>,
+        filters: &[Expr],
+        limit: Option<usize>,
+    ) -> DataFusionResult<Self> {
+        let base_exec = SqlExec::new(
+            projections,
+            schema,
+            table_reference,
+            pool,
+            filters,
+            limit,
+            Some(Engine::SQLite),
+        )?;
+
+        Ok(Self { base_exec })
+    }
+
+    fn sql(&self) -> SqlResult<String> {
+        self.base_exec.sql()
+    }
+}
+
+impl<T, P> std::fmt::Debug for SQLiteSqlExec<T, P> {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        let sql = self.sql().unwrap_or_default();
+        write!(f, "SQLiteSqlExec sql={sql}")
+    }
+}
+
+impl<T, P> DisplayAs for SQLiteSqlExec<T, P> {
+    fn fmt_as(&self, _t: DisplayFormatType, f: &mut fmt::Formatter) -> std::fmt::Result {
+        let sql = self.sql().unwrap_or_default();
+        write!(f, "SQLiteSqlExec sql={sql}")
+    }
+}
+
+impl<T: 'static, P: 'static> ExecutionPlan for SQLiteSqlExec<T, P> {
+    fn name(&self) -> &'static str {
+        "SQLiteSqlExec"
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn schema(&self) -> SchemaRef {
+        self.base_exec.schema()
+    }
+
+    fn properties(&self) -> &PlanProperties {
+        self.base_exec.properties()
+    }
+
+    fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {
+        self.base_exec.children()
+    }
+
+    fn with_new_children(
+        self: Arc<Self>,
+        _children: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> DataFusionResult<Arc<dyn ExecutionPlan>> {
+        Ok(self)
+    }
+
+    fn execute(
+        &self,
+        _partition: usize,
+        _context: Arc<TaskContext>,
+    ) -> DataFusionResult<SendableRecordBatchStream> {
+        let sql = self.sql().map_err(to_execution_error)?;
+        tracing::debug!("SQLiteSqlExec sql: {sql}");
+
+        let fut = get_stream(self.base_exec.clone_pool(), sql, Arc::clone(&self.schema()));
+
+        let stream = futures::stream::once(fut).try_flatten();
+        let schema = Arc::clone(&self.schema());
+        Ok(Box::pin(RecordBatchStreamAdapter::new(schema, stream)))
+    }
+}

--- a/src/sqlite/sql_table.rs
+++ b/src/sqlite/sql_table.rs
@@ -29,14 +29,18 @@ pub struct SQLiteTable<T: 'static, P: 'static> {
 
 impl<T, P> SQLiteTable<T, P> {
     pub fn new_with_schema(
-        name: &'static str,
         pool: &Arc<dyn DbConnectionPool<T, P> + Send + Sync>,
         schema: impl Into<SchemaRef>,
         table_reference: impl Into<TableReference>,
-        engine: Option<expr::Engine>,
     ) -> Self {
-        let base_table = SqlTable::new_with_schema(name, pool, schema, table_reference, engine)
-            .with_dialect(Arc::new(SqliteDialect {}));
+        let base_table = SqlTable::new_with_schema(
+            "sqlite",
+            pool,
+            schema,
+            table_reference,
+            Some(Engine::SQLite),
+        )
+        .with_dialect(Arc::new(SqliteDialect {}));
 
         Self { base_table }
     }


### PR DESCRIPTION
## 🗣 Description

* Creates a struct, `SQLiteTable`, for creating an SQLite table provider. This follows the existing behavior for `DuckDBTable`, instead of using the generic base `SQLTable`.