### PR TITLE
SQLite: Validate expected indexes when attaching local datasets

### DIFF
--- a/src/sqlite.rs
+++ b/src/sqlite.rs
@@ -251,7 +251,7 @@ impl TableProviderFactory for SqliteTableProviderFactory {
                 .map_err(to_datafusion_error)?;
         } else if !sqlite.verify_indexes_match(sqlite_conn, &indexes).await? {
             tracing::warn!(
-                "The schema of the local copy of table '{name}' does not match the expected configuration. To correct this, you can drop the existing local copy at '{db_path}'. A new table will be automatically created with the correct schema upon the first access.",
+                "The local table definition at '{db_path}' for '{name}' does not match the expected configuration. To fix this, drop the existing local copy. A new table with the correct schema will be automatically created upon first access.",
                 name = name
             );
         }
@@ -508,14 +508,14 @@ impl Sqlite {
 
         if !missing_in_actual.is_empty() {
             tracing::warn!(
-                "Schema mismatch detected for table '{name}'. The following expected indexes are missing: {:?}.",
+                "Missing indexes detected for the table '{name}': {:?}.",
                 missing_in_actual,
                 name = self.table_name
             );
         }
         if !extra_in_actual.is_empty() {
             tracing::warn!(
-                "Schema mismatch detected for table '{name}'. The table contains unexpected indexes not defined in the configuration: {:?}.",
+                "The table '{name}' contains unexpected indexes not presented in the configuration: {:?}.",
                 extra_in_actual,
                 name = self.table_name
             );


### PR DESCRIPTION
PRs adds verification of expected indexes when attaching local datasets to SQLite. This change ensures that the schema of the local copy of a table matches the expected configuration.

Note: created composite indexes can have complex names, produced index name information is easy to troubleshoot IMO so converting index name back to original configuration for tracing has not been added (NOTE: it is  also not always possible or trivial, for example I have the following index `i_taxi_trips_fare_amount_passenger_count_total_amount_tpep_dropoff_datetime_tpep_pickup_datetime_trip_distance`) generated from test configuration `'(tpep_pickup_datetime, tpep_dropoff_datetime, trip_distance, fare_amount, passenger_count, total_amount)': unique`

Sample output:

```shell
2024-09-06T21:46:12.752546Z  WARN datafusion_table_providers::sqlite: Schema mismatch detected for table 'taxi_trips'. The following expected indexes are missing: ["i_taxi_trips_passenger_count"].
2024-09-06T21:46:12.752596Z  WARN datafusion_table_providers::sqlite: Schema mismatch detected for table 'taxi_trips'. The table contains unexpected indexes not defined in the configuration: ["i_taxi_trips_VendorID"].
2024-09-06T21:46:12.752620Z  WARN datafusion_table_providers::sqlite: The schema of the local copy of table 'taxi_trips' does not match the expected configuration. To correct this, you can drop the existing local copy at '/Users/sg/spice/spiceai/.spice/data/taxi_trips_sqlite.db'. A new table will be automatically created with the correct schema upon the first access.
2024-09-06T21:46:12.753283Z  INFO runtime: Dataset taxi_trips registered (s3://spiceai-demo-datasets/taxi_trips/2024/), acceleration (sqlite:file), results cache enabled.
```

In progress: unit test for `get_indexes`


Note: similar improvement must be done for `primary_key`