### PR TITLE
Change to use Spice AI fork of sea_query for SQLite decimal support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,6 @@ num-bigint = "0.4.4"
 base64 = { version = "0.22.1", optional = true }
 bytes = { version = "1.7.1", optional = true }
 bigdecimal = "0.4.5"
-bigdecimal_0_3_0 = { package = "bigdecimal", version = "0.3.0" }
 byteorder = "1.5.0"
 chrono = "0.4.38"
 datafusion = "41.0.0"
@@ -38,7 +37,7 @@ mysql_async = { version = "0.34.1", features = ["native-tls-tls", "chrono"], opt
 prost = { version = "0.12" , optional = true } # pinned for arrow-flight compat
 r2d2 = { version = "0.8.10", optional = true }
 rusqlite = { version = "0.31.0", optional = true }
-sea-query = { version = "0.31.0", features = ["backend-sqlite", "backend-postgres", "postgres-array", "with-rust_decimal", "with-bigdecimal", "with-time", "with-chrono"] }
+sea-query = { git = "https://github.com/spiceai/sea-query.git", rev = "213b6b876068f58159ebdd5852604a021afaebf9", features = ["backend-sqlite", "backend-postgres", "postgres-array", "with-rust_decimal", "with-bigdecimal", "with-time", "with-chrono"] }
 secrecy = "0.8.0"
 serde = { version = "1.0.209", optional = true }
 serde_json = "1.0.124"

--- a/src/sql/arrow_sql_gen/statement.rs
+++ b/src/sql/arrow_sql_gen/statement.rs
@@ -7,7 +7,7 @@ use arrow::{
     datatypes::{DataType, Field, Fields, IntervalUnit, Schema, SchemaRef, TimeUnit},
     util::display::array_value_to_string,
 };
-use bigdecimal_0_3_0::BigDecimal;
+use bigdecimal::BigDecimal;
 use chrono::{DateTime, FixedOffset};
 use num_bigint::BigInt;
 use sea_query::{


### PR DESCRIPTION
Includes the following PR to use the Spice AI fork of sea_query for SQLite decimal support:

https://github.com/spiceai/sea-query/pull/1