### PR TITLE
fix: Don't silence blocking task errors

### DIFF
--- a/src/duckdb/write.rs
+++ b/src/duckdb/write.rs
@@ -191,6 +191,11 @@ impl DataSink for DuckDBDataSink {
                             "Error writing to DuckDB: {e}"
                         )));
                     }
+                    Ok(Err(e)) => {
+                        return Err(DataFusionError::Execution(format!(
+                            "Error writing to DuckDB: {e}"
+                        )));
+                    }
                     _ => {
                         return Err(DataFusionError::Execution(format!(
                             "Unable to send RecordBatch to duckdb writer: {e}"

--- a/src/sql/db_connection_pool/dbconnection/duckdbconn.rs
+++ b/src/sql/db_connection_pool/dbconnection/duckdbconn.rs
@@ -151,10 +151,18 @@ impl SyncDbConnection<r2d2::PooledConnection<DuckdbConnectionManager>, DuckDBPar
                 yield Ok(batch);
             }
 
-            if let Err(e) = join_handle.await {
-                yield Err(DataFusionError::Execution(format!(
-                    "Failed to execute DuckDB query: {e}"
-                )))
+            match join_handle.await {
+                Ok(Err(e)) => {
+                    yield Err(DataFusionError::Execution(format!(
+                        "Failed to execute DuckDB query: {e}"
+                    )))
+                },
+                Err(e) => {
+                    yield Err(DataFusionError::Execution(format!(
+                        "Failed to execute DuckDB query: {e}"
+                    )))
+                },
+                _ => {}
             }
         };
 

--- a/src/sql/db_connection_pool/dbconnection/duckdbconn.rs
+++ b/src/sql/db_connection_pool/dbconnection/duckdbconn.rs
@@ -152,14 +152,14 @@ impl SyncDbConnection<r2d2::PooledConnection<DuckdbConnectionManager>, DuckDBPar
             }
 
             match join_handle.await {
-                Ok(Err(e)) => {
+                Ok(Err(task_error)) => {
                     yield Err(DataFusionError::Execution(format!(
-                        "Failed to execute DuckDB query: {e}"
+                        "Failed to execute DuckDB query: {task_error}"
                     )))
                 },
-                Err(e) => {
+                Err(join_error) => {
                     yield Err(DataFusionError::Execution(format!(
-                        "Failed to execute DuckDB query: {e}"
+                        "Failed to execute DuckDB query: {join_error}"
                     )))
                 },
                 _ => {}

--- a/src/sql/db_connection_pool/duckdbpool.rs
+++ b/src/sql/db_connection_pool/duckdbpool.rs
@@ -186,6 +186,7 @@ impl DbConnectionPool<r2d2::PooledConnection<DuckdbConnectionManager>, DuckDBPar
                 .context(DuckDBSnafu)?;
                 db_ids.push(db_id);
             }
+
             conn.execute(&format!("SET search_path = \"{}\"", db_ids.join(",")), [])
                 .context(DuckDBSnafu)?;
         }
@@ -247,7 +248,7 @@ mod test {
             name.push(rng.gen_range(b'a'..=b'z') as char);
         }
 
-        format!("./{name}.sqlite")
+        format!("./{name}.duckdb")
     }
 
     #[tokio::test]


### PR DESCRIPTION
## 🗣 Description

* Ensures that errors from within blocking tasks don't get silenced, as the return type from `JoinHandle` is `Result<T, JoinError>`. If the inner blocking tasks return a `Result<>` themselves, we need to ensure we match for `Ok(Err(e)` to get the inner error, or `Err(e)` to get the `JoinError`.

