### PR TITLE
Fix SQLite `Invalid column type Real` error

### DIFF
--- a/src/sql/arrow_sql_gen/sqlite.rs
+++ b/src/sql/arrow_sql_gen/sqlite.rs
@@ -29,6 +29,7 @@ use arrow::array::StringBuilder;
 use arrow::datatypes::DataType;
 use arrow::datatypes::Field;
 use arrow::datatypes::Schema;
+use arrow::datatypes::SchemaRef;
 use rusqlite::types::Type;
 use rusqlite::Row;
 use rusqlite::Rows;
@@ -60,7 +61,7 @@ pub type Result<T, E = Error> = std::result::Result<T, E>;
 /// # Errors
 ///
 /// Returns an error if there is a failure in converting the rows to a `RecordBatch`.
-pub fn rows_to_arrow(mut rows: Rows, num_cols: usize) -> Result<RecordBatch> {
+pub fn rows_to_arrow(mut rows: Rows, num_cols: usize, projected_schema: Option<SchemaRef>) -> Result<RecordBatch> {
     let mut arrow_fields: Vec<Field> = Vec::new();
     let mut arrow_columns_builders: Vec<Box<dyn ArrayBuilder>> = Vec::new();
     let mut sqlite_types: Vec<Type> = Vec::new();
@@ -68,7 +69,7 @@ pub fn rows_to_arrow(mut rows: Rows, num_cols: usize) -> Result<RecordBatch> {
 
     if let Ok(Some(row)) = rows.next() {
         for i in 0..num_cols {
-            let column_type = row
+            let mut column_type = row
                 .get_ref(i)
                 .context(FailedToExtractRowValueSnafu)?
                 .data_type();
@@ -77,6 +78,30 @@ pub fn rows_to_arrow(mut rows: Rows, num_cols: usize) -> Result<RecordBatch> {
                 .column_name(i)
                 .context(FailedToExtractColumnNameSnafu)?
                 .to_string();
+
+            // SQLite can store floating point values without a fractional component as integers.
+            // Therefore, we need to verify if the column is actually a floating point type 
+            // by examining the projected schema. 
+            // Note: The same column may contain both integer and floating point values. 
+            // Reading values as Float is safe even if the value is stored as an integer.
+            // Refer to the rusqlite type handling documentation for more details:
+            // https://github.com/rusqlite/rusqlite/blob/95680270eca6f405fb51f5fbe6a214aac5fdce58/src/types/mod.rs#L21C1-L22C75
+            //
+            // `REAL` to integer: always returns an [`Error::InvalidColumnType`](crate::Error::InvalidColumnType) error.
+            // `INTEGER` to float: casts using `as` operator. Never fails.
+            // `REAL` to float: casts using `as` operator. Never fails.
+
+            if column_type == Type::Integer {
+                if let Some(projected_schema) = projected_schema.as_ref() {
+                    match projected_schema.fields[i].data_type() {
+                        DataType::Decimal128(..) | DataType::Float16 | DataType::Float32 | DataType::Float64 => {
+                            column_type = Type::Real;
+                        }
+                        _ => {}
+                    }
+                }
+            }
+
             let data_type = map_column_type_to_data_type(column_type);
 
             arrow_fields.push(Field::new(column_name, data_type.clone(), true));

--- a/src/sql/db_connection_pool/dbconnection/sqliteconn.rs
+++ b/src/sql/db_connection_pool/dbconnection/sqliteconn.rs
@@ -63,7 +63,7 @@ impl AsyncDbConnection<Connection, &'static (dyn ToSql + Sync)> for SqliteConnec
                 let mut stmt = conn.prepare(&format!("SELECT * FROM {table_reference} LIMIT 1"))?;
                 let column_count = stmt.column_count();
                 let rows = stmt.query([])?;
-                let rec = rows_to_arrow(rows, column_count)
+                let rec = rows_to_arrow(rows, column_count, None)
                     .context(ConversionSnafu)
                     .map_err(to_tokio_rusqlite_error)?;
                 let schema = rec.schema();
@@ -80,7 +80,7 @@ impl AsyncDbConnection<Connection, &'static (dyn ToSql + Sync)> for SqliteConnec
         &self,
         sql: &str,
         params: &[&'static (dyn ToSql + Sync)],
-        _projected_schema: Option<SchemaRef>,
+        projected_schema: Option<SchemaRef>,
     ) -> Result<SendableRecordBatchStream> {
         let sql = sql.to_string();
         let params = params.to_vec();
@@ -94,7 +94,8 @@ impl AsyncDbConnection<Connection, &'static (dyn ToSql + Sync)> for SqliteConnec
                 }
                 let column_count = stmt.column_count();
                 let rows = stmt.raw_query();
-                let rec = rows_to_arrow(rows, column_count)
+
+                let rec = rows_to_arrow(rows, column_count, projected_schema)
                     .context(ConversionSnafu)
                     .map_err(to_tokio_rusqlite_error)?;
                 Ok(rec)


### PR DESCRIPTION
As detailed at [Bug: SQLite acceleration fails with Invalid column type Real TPCH Q10 and Q19](https://github.com/spiceai/spiceai/issues/2638) the SQLite Table Provider was failing with the following error when attempting to read a Float value as an Integer. This issue occurs when a query returns the first row for a Float column with a value without a fractional component, which SQLite represents as an Integer.

>Execution error: Unable to query arrow: ConnectionError Other("Failed to convert query result to Arrow: Failed to extract row value: Invalid column type Real at index: 3, name: l_discount")

The PR updated the schema inference to use the projected schema to accurately determine if the column is actually a Float.

Note: The error has a stable repro but occurs only in in-memory mode.