### PR TITLE
Postgres enum support

### DIFF
--- a/src/sql/arrow_sql_gen/arrow.rs
+++ b/src/sql/arrow_sql_gen/arrow.rs
@@ -1,12 +1,13 @@
 use arrow::{
     array::{
-        ArrayBuilder, BinaryBuilder, BooleanBuilder, Date32Builder, Date64Builder,
+        types::Int8Type, ArrayBuilder, BinaryBuilder, BooleanBuilder, Date32Builder, Date64Builder,
         Decimal128Builder, Decimal256Builder, FixedSizeBinaryBuilder, FixedSizeListBuilder,
         Float32Builder, Float64Builder, Int16Builder, Int32Builder, Int64Builder, Int8Builder,
         IntervalMonthDayNanoBuilder, LargeBinaryBuilder, LargeStringBuilder, ListBuilder,
-        NullBuilder, StringBuilder, StructBuilder, Time64NanosecondBuilder,
-        TimestampMicrosecondBuilder, TimestampMillisecondBuilder, TimestampNanosecondBuilder,
-        TimestampSecondBuilder, UInt16Builder, UInt32Builder, UInt64Builder, UInt8Builder,
+        NullBuilder, StringBuilder, StringDictionaryBuilder, StructBuilder,
+        Time64NanosecondBuilder, TimestampMicrosecondBuilder, TimestampMillisecondBuilder,
+        TimestampNanosecondBuilder, TimestampSecondBuilder, UInt16Builder, UInt32Builder,
+        UInt64Builder, UInt8Builder,
     },
     datatypes::{DataType, TimeUnit},
 };
@@ -61,6 +62,12 @@ pub fn map_data_type_to_array_builder(data_type: &DataType) -> Box<dyn ArrayBuil
             TimeUnit::Nanosecond => {
                 Box::new(TimestampNanosecondBuilder::new().with_timezone_opt(time_zone.clone()))
             }
+        },
+        DataType::Dictionary(ref key_type, ref value_type) => match (&**key_type, &**value_type) {
+            (DataType::Int8, DataType::Utf8) => {
+                Box::new(StringDictionaryBuilder::<Int8Type>::new())
+            }
+            _ => unimplemented!("Unimplemented dictionary type"),
         },
         DataType::Date32 => Box::new(Date32Builder::new()),
         DataType::Date64 => Box::new(Date64Builder::new()),

--- a/src/sql/arrow_sql_gen/postgres.rs
+++ b/src/sql/arrow_sql_gen/postgres.rs
@@ -1047,7 +1047,7 @@ impl<'a> FromSql<'a> for EnumValueFromSql {
     fn from_sql(
         _ty: &Type,
         raw: &'a [u8],
-    ) -> std::prelude::v1::Result<Self, Box<dyn std::error::Error + Sync + Send>> {
+    ) -> Result<Self, Box<dyn std::error::Error + Sync + Send>> {
         let mut cursor = std::io::Cursor::new(raw);
         let mut enum_value = String::new();
         cursor.read_to_string(&mut enum_value)?;

--- a/src/sql/arrow_sql_gen/postgres.rs
+++ b/src/sql/arrow_sql_gen/postgres.rs
@@ -1,4 +1,5 @@
 use std::convert;
+use std::io::Read;
 use std::sync::Arc;
 
 use crate::sql::arrow_sql_gen::arrow::map_data_type_to_array_builder_optional;
@@ -7,11 +8,11 @@ use arrow::array::{
     ArrayBuilder, ArrayRef, BinaryBuilder, BooleanBuilder, Date32Builder, Decimal128Builder,
     FixedSizeListBuilder, Float32Builder, Float64Builder, Int16Builder, Int32Builder, Int64Builder,
     Int8Builder, IntervalMonthDayNanoBuilder, LargeBinaryBuilder, LargeStringBuilder, ListBuilder,
-    RecordBatch, RecordBatchOptions, StringBuilder, StructBuilder, Time64NanosecondBuilder,
-    TimestampNanosecondBuilder, UInt32Builder,
+    RecordBatch, RecordBatchOptions, StringBuilder, StringDictionaryBuilder, StructBuilder,
+    Time64NanosecondBuilder, TimestampNanosecondBuilder, UInt32Builder,
 };
 use arrow::datatypes::{
-    DataType, Date32Type, Field, IntervalMonthDayNanoType, IntervalUnit, Schema, TimeUnit,
+    DataType, Date32Type, Field, Int8Type, IntervalMonthDayNanoType, IntervalUnit, Schema, TimeUnit,
 };
 use bigdecimal::num_bigint::BigInt;
 use bigdecimal::num_bigint::Sign;
@@ -745,6 +746,31 @@ pub fn rows_to_arrow(rows: &[Row]) -> Result<RecordBatch> {
                             );
                         }
                     }
+                    Kind::Enum(_) => {
+                        let Some(builder) = builder else {
+                            return NoBuilderForIndexSnafu { index: i }.fail();
+                        };
+                        let Some(builder) = builder
+                            .as_any_mut()
+                            .downcast_mut::<StringDictionaryBuilder<Int8Type>>()
+                        else {
+                            return FailedToDowncastBuilderSnafu {
+                                postgres_type: format!("{postgres_type}"),
+                            }
+                            .fail();
+                        };
+
+                        let v = row.try_get::<usize, Option<EnumValueFromSql>>(i).context(
+                            FailedToGetRowValueSnafu {
+                                pg_type: postgres_type.clone(),
+                            },
+                        )?;
+
+                        match v {
+                            Some(v) => builder.append_value(v.enum_value),
+                            None => builder.append_null(),
+                        }
+                    }
                     _ => {
                         unimplemented!("Unsupported type {:?} for column index {i}", postgres_type,)
                     }
@@ -850,6 +876,10 @@ fn map_column_type_to_data_type(column_type: &Type) -> Option<DataType> {
                 }
                 Some(DataType::Struct(arrow_fields.into()))
             }
+            Kind::Enum(_) => Some(DataType::Dictionary(
+                Box::new(DataType::Int8),
+                Box::new(DataType::Utf8),
+            )),
             _ => unimplemented!("Unsupported column type {:?}", column_type),
         },
     }
@@ -1006,6 +1036,26 @@ impl<'a> FromSql<'a> for MoneyFromSql {
 
     fn accepts(ty: &Type) -> bool {
         matches!(*ty, Type::MONEY)
+    }
+}
+
+struct EnumValueFromSql {
+    enum_value: String,
+}
+
+impl<'a> FromSql<'a> for EnumValueFromSql {
+    fn from_sql(
+        _ty: &Type,
+        raw: &'a [u8],
+    ) -> std::prelude::v1::Result<Self, Box<dyn std::error::Error + Sync + Send>> {
+        let mut cursor = std::io::Cursor::new(raw);
+        let mut enum_value = String::new();
+        cursor.read_to_string(&mut enum_value)?;
+        Ok(EnumValueFromSql { enum_value })
+    }
+
+    fn accepts(ty: &Type) -> bool {
+        matches!(*ty.kind(), Kind::Enum(_))
     }
 }
 

--- a/tests/arrow_record_batch_gen/mod.rs
+++ b/tests/arrow_record_batch_gen/mod.rs
@@ -2,7 +2,7 @@ use arrow::array::RecordBatch;
 use arrow::{
     array::*,
     datatypes::{
-        i256, DataType, Date32Type, Date64Type, Field, Fields, IntervalDayTime,
+        i256, DataType, Date32Type, Date64Type, Field, Fields, Int8Type, IntervalDayTime,
         IntervalMonthDayNano, IntervalUnit, IntervalYearMonthType, Schema, SchemaRef, TimeUnit,
     },
 };
@@ -531,6 +531,26 @@ pub(crate) fn get_arrow_bytea_array_record_batch() -> (RecordBatch, SchemaRef) {
     let record_batch =
         RecordBatch::try_new(Arc::clone(&schema), vec![Arc::new(bytea_array_builder)])
             .expect("Failed to created arrow bytea array record batch");
+
+    (record_batch, schema)
+}
+
+// DICTIONARY_ARRAY
+pub(crate) fn get_arrow_dictionary_array_record_batch() -> (RecordBatch, SchemaRef) {
+    let mut builder = StringDictionaryBuilder::<Int8Type>::new();
+    builder.append_value("happy");
+    builder.append_value("sad");
+    builder.append_value("neutral");
+    let array: DictionaryArray<Int8Type> = builder.finish();
+
+    let schema = Arc::new(Schema::new(vec![Field::new(
+        "mood_status",
+        DataType::Dictionary(Box::new(DataType::Int8), Box::new(DataType::Utf8)),
+        true,
+    )]));
+
+    let record_batch = RecordBatch::try_new(Arc::clone(&schema), vec![Arc::new(array)])
+        .expect("Failed to created arrow dictionary array record batch");
 
     (record_batch, schema)
 }

--- a/tests/postgres/common.rs
+++ b/tests/postgres/common.rs
@@ -60,3 +60,38 @@ pub(super) async fn start_postgres_docker_container(
     tokio::time::sleep(std::time::Duration::from_millis(5000)).await;
     Ok(running_container)
 }
+
+fn get_pg_params_secrets(port: usize) -> HashMap<String, SecretString> {
+    let mut params = HashMap::new();
+    params.insert(
+        "pg_host".to_string(),
+        SecretString::from("localhost".to_string()),
+    );
+    params.insert("pg_port".to_string(), SecretString::from(port.to_string()));
+    params.insert(
+        "pg_user".to_string(),
+        SecretString::from("postgres".to_string()),
+    );
+    params.insert(
+        "pg_pass".to_string(),
+        SecretString::from(PG_PASSWORD.to_string()),
+    );
+    params.insert(
+        "pg_db".to_string(),
+        SecretString::from("postgres".to_string()),
+    );
+    params.insert(
+        "pg_sslmode".to_string(),
+        SecretString::from("disable".to_string()),
+    );
+    params
+}
+
+#[instrument]
+pub(super) async fn get_postgres_connection_pool(
+    port: usize,
+) -> Result<PostgresConnectionPool, anyhow::Error> {
+    let pool = PostgresConnectionPool::new(get_pg_params_secrets(port)).await?;
+
+    Ok(pool)
+}


### PR DESCRIPTION
This PR enables the support for Postgres enum types
* Create EnumValueFromSql to parse Postgres enum types
* Parse Postgres enum types into arrow StringDictionary
* Add a postgres row -> arrow test to validate the cast