### PR TITLE
DuckDBTableProviderFactory keeps track of opened instances

### DIFF
--- a/examples/duckdb_external_table.rs
+++ b/examples/duckdb_external_table.rs
@@ -12,7 +12,7 @@ use duckdb::AccessMode;
 /// DuckDB-backed tables can be created at runtime.
 #[tokio::main]
 async fn main() {
-    let duckdb = Arc::new(DuckDBTableProviderFactory::new().access_mode(AccessMode::ReadWrite));
+    let duckdb = Arc::new(DuckDBTableProviderFactory::new(AccessMode::ReadWrite));
 
     let runtime = Arc::new(RuntimeEnv::default());
     let state = SessionStateBuilder::new()

--- a/src/duckdb.rs
+++ b/src/duckdb.rs
@@ -7,7 +7,7 @@ use crate::sql::db_connection_pool::{
         get_schema, DbConnection,
     },
     duckdbpool::DuckDbConnectionPool,
-    DbConnectionPool, Mode,
+    DbConnectionPool, DbInstanceKey, Mode,
 };
 use crate::sql::sql_provider_datafusion;
 use crate::util::{
@@ -31,6 +31,7 @@ use duckdb::{AccessMode, DuckdbConnectionManager, Transaction};
 use itertools::Itertools;
 use snafu::prelude::*;
 use std::{cmp, collections::HashMap, sync::Arc};
+use tokio::sync::Mutex;
 
 use self::{creator::TableCreator, sql_table::DuckDBTable, write::DuckDBTableWriter};
 
@@ -123,6 +124,7 @@ type Result<T, E = Error> = std::result::Result<T, E>;
 
 pub struct DuckDBTableProviderFactory {
     access_mode: AccessMode,
+    instances: Arc<Mutex<HashMap<DbInstanceKey, DuckDbConnectionPool>>>,
 }
 
 const DUCKDB_DB_PATH_PARAM: &str = "open";
@@ -131,9 +133,10 @@ const DUCKDB_ATTACH_DATABASES_PARAM: &str = "attach_databases";
 
 impl DuckDBTableProviderFactory {
     #[must_use]
-    pub fn new() -> Self {
+    pub fn new(access_mode: AccessMode) -> Self {
         Self {
-            access_mode: AccessMode::ReadOnly,
+            access_mode,
+            instances: Arc::new(Mutex::new(HashMap::new())),
         }
     }
 
@@ -151,12 +154,6 @@ impl DuckDBTableProviderFactory {
     }
 
     #[must_use]
-    pub fn access_mode(mut self, access_mode: AccessMode) -> Self {
-        self.access_mode = access_mode;
-        self
-    }
-
-    #[must_use]
     pub fn duckdb_file_path(&self, name: &str, options: &mut HashMap<String, String>) -> String {
         let options = util::remove_prefix_from_hashmap_keys(options.clone(), "duckdb_");
 
@@ -171,11 +168,40 @@ impl DuckDBTableProviderFactory {
             .cloned()
             .unwrap_or(default_filepath)
     }
-}
 
-impl Default for DuckDBTableProviderFactory {
-    fn default() -> Self {
-        Self::new()
+    pub async fn get_or_init_memory_instance(&self) -> Result<DuckDbConnectionPool> {
+        let key = DbInstanceKey::memory();
+        let mut instances = self.instances.lock().await;
+
+        if let Some(instance) = instances.get(&key) {
+            return Ok(instance.clone());
+        }
+
+        let pool = DuckDbConnectionPool::new_memory().context(DbConnectionPoolSnafu)?;
+
+        instances.insert(key, pool.clone());
+
+        Ok(pool)
+    }
+
+    pub async fn get_or_init_file_instance(
+        &self,
+        db_path: impl Into<Arc<str>>,
+    ) -> Result<DuckDbConnectionPool> {
+        let db_path = db_path.into();
+        let key = DbInstanceKey::file(Arc::clone(&db_path));
+        let mut instances = self.instances.lock().await;
+
+        if let Some(instance) = instances.get(&key) {
+            return Ok(instance.clone());
+        }
+
+        let pool = DuckDbConnectionPool::new_file(&db_path, &self.access_mode)
+            .context(DbConnectionPoolSnafu)?;
+
+        instances.insert(key, pool.clone());
+
+        Ok(pool)
     }
 }
 
@@ -231,12 +257,13 @@ impl TableProviderFactory for DuckDBTableProviderFactory {
                 // open duckdb at given path or create a new one
                 let db_path = self.duckdb_file_path(&name, &mut options);
 
-                DuckDbConnectionPool::new_file(&db_path, &self.access_mode)
-                    .context(DbConnectionPoolSnafu)
+                self.get_or_init_file_instance(db_path)
+                    .await
                     .map_err(to_datafusion_error)?
             }
-            Mode::Memory => DuckDbConnectionPool::new_memory()
-                .context(DbConnectionPoolSnafu)
+            Mode::Memory => self
+                .get_or_init_memory_instance()
+                .await
                 .map_err(to_datafusion_error)?,
         };
 

--- a/src/sql/db_connection_pool/mod.rs
+++ b/src/sql/db_connection_pool/mod.rs
@@ -1,5 +1,6 @@
 use async_trait::async_trait;
 use dbconnection::DbConnection;
+use std::sync::Arc;
 
 pub mod dbconnection;
 #[cfg(feature = "duckdb")]
@@ -46,5 +47,24 @@ impl From<&str> for Mode {
             "memory" => Mode::Memory,
             _ => Mode::default(),
         }
+    }
+}
+
+/// A key that uniquely identifies a database instance.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum DbInstanceKey {
+    /// The database is a file on disk, with the given path.
+    File(Arc<str>),
+    /// The database is in memory.
+    Memory,
+}
+
+impl DbInstanceKey {
+    pub fn memory() -> Self {
+        DbInstanceKey::Memory
+    }
+
+    pub fn file(path: Arc<str>) -> Self {
+        DbInstanceKey::File(path)
     }
 }

--- a/tests/arrow_record_batch_gen/mod.rs
+++ b/tests/arrow_record_batch_gen/mod.rs
@@ -2,13 +2,12 @@ use arrow::array::RecordBatch;
 use arrow::{
     array::*,
     datatypes::{
-        i256, DataType, Date32Type, Date64Type, Field, Fields, Int8Type, IntervalDayTime,
-        IntervalMonthDayNano, IntervalUnit, IntervalYearMonthType, Schema, SchemaRef, TimeUnit,
+        i256, DataType, Date32Type, Date64Type, Field, Int8Type, IntervalDayTime,
+        IntervalMonthDayNano, IntervalUnit, Schema, SchemaRef, TimeUnit,
     },
 };
 use chrono::NaiveDate;
 use std::sync::Arc;
-use types::IntervalDayTimeType;
 
 // Helper functions to create arrow record batches of different types
 

--- a/tests/duckdb/mod.rs
+++ b/tests/duckdb/mod.rs
@@ -18,7 +18,7 @@ async fn arrow_duckdb_round_trip(
     source_schema: SchemaRef,
     table_name: &str,
 ) {
-    let factory = DuckDBTableProviderFactory::new().access_mode(duckdb::AccessMode::ReadWrite);
+    let factory = DuckDBTableProviderFactory::new(duckdb::AccessMode::ReadWrite);
     let ctx = SessionContext::new();
     let cmd = CreateExternalTable {
         schema: Arc::new(arrow_record.schema().to_dfschema().expect("to df schema")),

--- a/tests/mysql/common.rs
+++ b/tests/mysql/common.rs
@@ -45,11 +45,7 @@ fn get_mysql_params(port: usize) -> HashMap<String, SecretString> {
 pub async fn start_mysql_docker_container(port: usize) -> Result<RunningContainer, anyhow::Error> {
     let container_name = format!("{MYSQL_DOCKER_CONTAINER}-{port}");
 
-    let port = if let Ok(port) = port.try_into() {
-        port
-    } else {
-        15432
-    };
+    let port = port.try_into().unwrap_or(15432);
 
     let mysql_docker_image = std::env::var("MYSQL_DOCKER_IMAGE")
         .unwrap_or_else(|_| format!("{}mysql:latest", container_registry()));

--- a/tests/mysql/mod.rs
+++ b/tests/mysql/mod.rs
@@ -17,7 +17,6 @@ use crate::docker::RunningContainer;
 mod common;
 
 async fn test_mysql_decimal_types(port: usize) {
-    let table_name = "decimal_table";
     let create_table_stmt = "
         CREATE TABLE IF NOT EXISTS decimal_table (decimal_col DECIMAL(10, 2));
         ";
@@ -41,7 +40,7 @@ async fn test_mysql_decimal_types(port: usize) {
     )
     .expect("Failed to created arrow record batch");
 
-    let decimal_record = arrow_mysql_one_way(
+    let _ = arrow_mysql_one_way(
         port,
         "decimal_table",
         create_table_stmt,
@@ -289,7 +288,7 @@ async fn arrow_mysql_one_way(
     assert_eq!(record_batch.len(), 1);
     assert_eq!(record_batch[0], expected_record);
 
-    return record_batch;
+    record_batch
 }
 
 async fn start_mysql_container(port: usize) -> RunningContainer {

--- a/tests/postgres/common.rs
+++ b/tests/postgres/common.rs
@@ -29,11 +29,7 @@ pub(super) async fn start_postgres_docker_container(
     port: usize,
 ) -> Result<RunningContainer, anyhow::Error> {
     let container_name = format!("{PG_DOCKER_CONTAINER}-{port}");
-    let port = if let Ok(port) = port.try_into() {
-        port
-    } else {
-        15432
-    };
+    let port = port.try_into().unwrap_or(15432);
 
     let pg_docker_image = std::env::var("PG_DOCKER_IMAGE")
         .unwrap_or_else(|_| format!("{}postgres:latest", container_registry()));

--- a/tests/postgres/mod.rs
+++ b/tests/postgres/mod.rs
@@ -1,7 +1,5 @@
 use crate::arrow_record_batch_gen::*;
-use arrow::array::new_null_array;
-use arrow::array::Array;
-use arrow::{array::RecordBatch, compute::cast, datatypes::SchemaRef};
+use arrow::{array::RecordBatch, datatypes::SchemaRef};
 use datafusion::catalog::TableProviderFactory;
 use datafusion::common::{Constraints, ToDFSchema};
 use datafusion::execution::context::SessionContext;
@@ -9,9 +7,6 @@ use datafusion::logical_expr::CreateExternalTable;
 use datafusion::physical_plan::collect;
 use datafusion::physical_plan::memory::MemoryExec;
 use datafusion_federation::schema_cast::record_convert::try_cast_to;
-use datafusion_table_providers::sql::arrow_sql_gen::statement::{
-    CreateTableBuilder, InsertBuilder,
-};
 use datafusion_table_providers::{
     postgres::{DynPostgresConnectionPool, PostgresTableProviderFactory},
     sql::sql_provider_datafusion::SqlTable,


### PR DESCRIPTION
When the `DuckDBTableProviderFactory` is now asked to create a new table, and the file path is for an instances we've already created a table for, instead of opening a new connection to the file it will reuse the existing connection. Similar for memory instances, only a single memory instance will be created instead of a new one for each table.