### PR TITLE
Ignore CHECKPOINT errors for DuckDB

### DIFF
--- a/src/duckdb.rs
+++ b/src/duckdb.rs
@@ -90,11 +90,6 @@ pub enum Error {
     #[snafu(display("Unable to commit transaction: {source}"))]
     UnableToCommitTransaction { source: duckdb::Error },
 
-    #[snafu(display("Unable to checkpoint duckdb: {source}"))]
-    UnableToCheckpoint {
-        source: Box<dyn std::error::Error + Send + Sync>,
-    },
-
     #[snafu(display("Unable to begin duckdb transaction: {source}"))]
     UnableToBeginTransaction { source: duckdb::Error },
 


### PR DESCRIPTION
Ignore CHECKPOINT errors since they are expected if there are multiple active transactions, which can happen if there are two transactions writing data at the same time.