### PR TITLE
SqliteTableProviderFactory keeps track of opened instances

### DIFF
--- a/src/sql/db_connection_pool/sqlitepool.rs
+++ b/src/sql/db_connection_pool/sqlitepool.rs
@@ -90,13 +90,24 @@ impl SqliteConnectionPoolFactory {
     }
 }
 
-#[derive(Clone)]
 pub struct SqliteConnectionPool {
     conn: Connection,
     join_push_down: JoinPushDown,
     mode: Mode,
     path: Arc<str>,
     attach_databases: Vec<Arc<str>>,
+}
+
+impl Clone for SqliteConnectionPool {
+    fn clone(&self) -> Self {
+        SqliteConnectionPool {
+            conn: self.conn.clone(),
+            join_push_down: self.join_push_down.clone(),
+            mode: self.mode.clone(),
+            path: Arc::clone(&self.path),
+            attach_databases: self.attach_databases.clone(),
+        }
+    }
 }
 
 impl SqliteConnectionPool {

--- a/src/sql/db_connection_pool/sqlitepool.rs
+++ b/src/sql/db_connection_pool/sqlitepool.rs
@@ -98,18 +98,6 @@ pub struct SqliteConnectionPool {
     attach_databases: Vec<Arc<str>>,
 }
 
-impl Clone for SqliteConnectionPool {
-    fn clone(&self) -> Self {
-        SqliteConnectionPool {
-            conn: self.conn.clone(),
-            join_push_down: self.join_push_down.clone(),
-            mode: self.mode.clone(),
-            path: Arc::clone(&self.path),
-            attach_databases: self.attach_databases.clone(),
-        }
-    }
-}
-
 impl SqliteConnectionPool {
     /// Creates a new instance of `SqliteConnectionPool`.
     ///
@@ -209,6 +197,35 @@ impl SqliteConnectionPool {
     #[must_use]
     pub fn connect_sync(&self) -> Box<dyn DbConnection<Connection, &'static (dyn ToSql + Sync)>> {
         Box::new(SqliteConnection::new(self.conn.clone()))
+    }
+
+    /// Will attempt to clone the connection pool. This will always succeed for in-memory mode.
+    /// For file-mode, it will attempt to create a new connection pool with the same configuration.
+    ///
+    /// Due to the way the connection pool is implemented, it doesn't allow multiple concurrent reads/writes
+    /// using the same connection pool instance.
+    pub async fn try_clone(&self) -> Result<Self> {
+        match self.mode {
+            Mode::Memory => Ok(SqliteConnectionPool {
+                conn: self.conn.clone(),
+                join_push_down: self.join_push_down.clone(),
+                mode: self.mode,
+                path: Arc::clone(&self.path),
+                attach_databases: self.attach_databases.clone(),
+            }),
+            Mode::File => {
+                let attach_databases = if self.attach_databases.is_empty() {
+                    None
+                } else {
+                    Some(self.attach_databases.clone())
+                };
+
+                SqliteConnectionPoolFactory::new(&self.path, self.mode)
+                    .with_databases(attach_databases)
+                    .build()
+                    .await
+            }
+        }
     }
 }
 

--- a/src/sql/db_connection_pool/sqlitepool.rs
+++ b/src/sql/db_connection_pool/sqlitepool.rs
@@ -90,6 +90,7 @@ impl SqliteConnectionPoolFactory {
     }
 }
 
+#[derive(Clone)]
 pub struct SqliteConnectionPool {
     conn: Connection,
     join_push_down: JoinPushDown,

--- a/src/sqlite.rs
+++ b/src/sqlite.rs
@@ -636,7 +636,6 @@ impl Sqlite {
 
 #[cfg(test)]
 pub(crate) mod tests {
-
     use arrow::datatypes::{DataType, Schema};
     use datafusion::{
         common::ToDFSchema, prelude::SessionContext, sql::sqlparser::ast::TableConstraint,


### PR DESCRIPTION
Similar to https://github.com/datafusion-contrib/datafusion-table-providers/pull/105, this PR now will keep track of the instances it has opened via the SqliteTableProviderFactory::create method, and re-use connections where possible.