### PR TITLE
Propagate MySQL wrong table error

### DIFF
--- a/src/mysql.rs
+++ b/src/mysql.rs
@@ -55,7 +55,7 @@ impl MySQLTableFactory {
         let table_provider = Arc::new(
             SqlTable::new("mysql", &pool, table_reference, None)
                 .await
-                .context(UnableToConstructSQLTableSnafu)?
+                .map_err(|e| Box::new(e) as Box<dyn std::error::Error + Send + Sync>)?
                 .with_dialect(Arc::new(MySqlDialect {})),
         );
 

--- a/src/postgres.rs
+++ b/src/postgres.rs
@@ -8,7 +8,6 @@ use crate::sql::db_connection_pool::{
     DbConnectionPool,
 };
 use crate::sql::sql_provider_datafusion::{
-    self,
     expr::{self, Engine},
     SqlTable,
 };
@@ -88,13 +87,6 @@ pub enum Error {
     #[snafu(display("Unable to commit the Postgres transaction: {source}"))]
     UnableToCommitPostgresTransaction {
         source: tokio_postgres::error::Error,
-    },
-
-    #[snafu(display(
-        "Unable to construct the DataFusion SQL Table Provider for Postgres: {source}"
-    ))]
-    UnableToConstructSqlTable {
-        source: sql_provider_datafusion::Error,
     },
 
     #[snafu(display("Unable to generate SQL: {source}"))]


### PR DESCRIPTION
Propaget MySQL invalid table name using dbconnection::Error, this will make MySQL errors consistent with other dbconnection error 