### PR TITLE
Use Decimal256 instead of Decimal128 for MySQL decimal type

### DIFF
--- a/tests/mysql/mod.rs
+++ b/tests/mysql/mod.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 
 use arrow::{
     array::*,
-    datatypes::{DataType, Field, Schema, TimeUnit},
+    datatypes::{i256, DataType, Field, Schema, TimeUnit},
 };
 
 use datafusion_table_providers::sql::db_connection_pool::dbconnection::AsyncDbConnection;
@@ -15,40 +15,6 @@ use datafusion_table_providers::sql::db_connection_pool::dbconnection::AsyncDbCo
 use crate::docker::RunningContainer;
 
 mod common;
-
-async fn test_mysql_decimal_types(port: usize) {
-    let create_table_stmt = "
-        CREATE TABLE IF NOT EXISTS decimal_table (decimal_col DECIMAL(10, 2));
-        ";
-    let insert_table_stmt = "
-        INSERT INTO decimal_table (decimal_col) VALUES (NULL), (12);
-        ";
-
-    let schema = Arc::new(Schema::new(vec![Field::new(
-        "decimal_col",
-        DataType::Decimal128(10, 2),
-        true,
-    )]));
-
-    let expected_record = RecordBatch::try_new(
-        Arc::clone(&schema),
-        vec![Arc::new(
-            Decimal128Array::from(vec![None, Some(i128::from(1200))])
-                .with_precision_and_scale(10, 2)
-                .unwrap(),
-        )],
-    )
-    .expect("Failed to created arrow record batch");
-
-    let _ = arrow_mysql_one_way(
-        port,
-        "decimal_table",
-        create_table_stmt,
-        insert_table_stmt,
-        expected_record,
-    )
-    .await;
-}
 
 async fn test_mysql_timestamp_types(port: usize) {
     let create_table_stmt = "
@@ -234,7 +200,7 @@ VALUES (
     .await;
 }
 
-async fn test_time_types(port: usize) {
+async fn test_mysql_time_types(port: usize) {
     let create_table_stmt = "
 CREATE TABLE time_table (
     t0 TIME(0),  
@@ -299,6 +265,61 @@ VALUES
     arrow_mysql_one_way(
         port,
         "time_table",
+        create_table_stmt,
+        insert_table_stmt,
+        expected_record,
+    )
+    .await;
+}
+
+async fn test_mysql_decimal_types(port: usize) {
+    let create_table_stmt = "
+CREATE TABLE high_precision_decimal (
+    decimal_values DECIMAL(50, 10)
+);
+        ";
+    let insert_table_stmt = "
+INSERT INTO high_precision_decimal (decimal_values) VALUES
+(NULL),
+(1234567890123456789012345678901234567890.1234567890),
+(-9876543210987654321098765432109876543210.9876543210),
+(0.0000000001),
+(-0.000000001),
+(0);
+        ";
+
+    let schema = Arc::new(Schema::new(vec![Field::new(
+        "decimal_values",
+        DataType::Decimal256(50, 10),
+        true,
+    )]));
+
+    let expected_record = RecordBatch::try_new(
+        Arc::clone(&schema),
+        vec![Arc::new(
+            Decimal256Array::from(vec![
+                None,
+                Some(
+                    i256::from_string("12345678901234567890123456789012345678901234567890")
+                        .unwrap(),
+                ),
+                Some(
+                    i256::from_string("-98765432109876543210987654321098765432109876543210")
+                        .unwrap(),
+                ),
+                Some(i256::from_string("1").unwrap()),
+                Some(i256::from_string("-10").unwrap()),
+                Some(i256::from_string("0").unwrap()),
+            ])
+            .with_precision_and_scale(50, 10)
+            .expect("Failed to create decimal256 array"),
+        )],
+    )
+    .expect("Failed to created arrow record batch");
+
+    arrow_mysql_one_way(
+        port,
+        "high_precision_decimal",
         create_table_stmt,
         insert_table_stmt,
         expected_record,
@@ -379,10 +400,10 @@ async fn test_mysql_arrow_oneway() {
     let port = crate::get_random_port();
     let mysql_container = start_mysql_container(port).await;
 
-    test_mysql_decimal_types(port).await;
     test_mysql_timestamp_types(port).await;
     test_mysql_datetime_types(port).await;
-    test_time_types(port).await;
+    test_mysql_time_types(port).await;
+    test_mysql_decimal_types(port).await;
 
     mysql_container.remove().await.expect("container to stop");
 }


### PR DESCRIPTION
MySQL supports up to [65 decimal digits](https://dev.mysql.com/doc/refman/8.4/en/fixed-point-types.html#:~:text=The%20maximum%20number%20of%20digits,scale%20for%20a%20given%20column.), use decimal128 for mysql decimal type will cause error in values that have more than 38 digits. Use Decimal256 instead in this PR.