### PR TITLE
Support retries when writing data to SQLite

### DIFF
--- a/src/util/retriable_error.rs
+++ b/src/util/retriable_error.rs
@@ -1,3 +1,5 @@
+use std::error::Error;
+
 use datafusion::error::DataFusionError;
 use snafu::Snafu;
 
@@ -6,6 +8,11 @@ pub enum RetriableError {
     #[snafu(display("{source}"))]
     DataRetrievalError {
         source: datafusion::error::DataFusionError,
+    },
+
+    #[snafu(display("{source}"))]
+    DataWriteError {
+        source: Box<dyn Error + Send + Sync>
     },
 }
 
@@ -34,6 +41,15 @@ pub fn check_and_mark_retriable_error(err: DataFusionError) -> DataFusionError {
     }
 
     DataFusionError::External(Box::new(RetriableError::DataRetrievalError { source: err }))
+}
+
+// Wraps error as `RetriableError::DataWriteError` so we can detect this error and retry later at a higher level
+#[must_use]
+pub fn to_retriable_data_write_error<E>(error: E) -> DataFusionError
+where
+    E: Error + Send + Sync + 'static,
+{
+    DataFusionError::External(Box::new(RetriableError::DataWriteError { source: error.into() }))
 }
 
 fn is_invalid_query_error(error: &DataFusionError) -> bool {


### PR DESCRIPTION
When multiple accelerated dataset refreshes start at the same time, writing data to SQLite fails due to database locks. This PR improves the existing dataset refresh retry logic by allowing retries on dataset write issues. An example trace demonstrates this issue and a successful dataset update after updates for other datasets have completed.

Similar logic will be applied to other engines supporting write after this PR is reviewed.

```shell
2024-10-01T05:48:39.436005Z  INFO runtime::accelerated_table::refresh_task: Loading data for dataset catalog_returns
2024-10-01T05:48:39.436032Z  INFO runtime::accelerated_table::refresh_task: Loading data for dataset ship_mode
2024-10-01T05:48:39.436057Z  INFO runtime::accelerated_table::refresh_task: Loading data for dataset reason
2024-10-01T05:48:39.436717Z  INFO runtime::accelerated_table::refresh_task: Loading data for dataset customer_demographics
2024-10-01T05:48:39.436872Z  INFO runtime::accelerated_table::refresh_task: Loading data for dataset catalog_sales
2024-10-01T05:48:39.459650Z  INFO runtime::accelerated_table::refresh_task: Loaded 3 rows (2.62 kiB) for dataset promotion in 30ms.
2024-10-01T05:48:39.461940Z  INFO runtime::accelerated_table::refresh_task: Loaded 20 rows (528.00 B) for dataset income_band in 26ms.
2024-10-01T05:48:39.464171Z  INFO runtime::accelerated_table::refresh_task: Loaded 20 rows (2.09 kiB) for dataset ship_mode in 28ms.
2024-10-01T05:48:39.468492Z  INFO runtime::accelerated_table::refresh_task: Loaded 1 rows (1.52 kiB) for dataset web_page in 34ms.
2024-10-01T05:48:39.468815Z  INFO runtime::accelerated_table::refresh_task: Loaded 180 rows (59.50 kiB) for dataset item in 38ms.
2024-10-01T05:48:39.471284Z  INFO runtime::accelerated_table::refresh_task: Loaded 679 rows (139.35 kiB) for dataset web_returns in 60ms.
2024-10-01T05:48:39.477377Z  INFO runtime::accelerated_table::refresh_task: Loaded 1 rows (391.00 B) for dataset reason in 40ms.
2024-10-01T05:48:39.498744Z  INFO runtime::accelerated_table::refresh_task: Loaded 7,200 rows (195.34 kiB) for dataset household_demographics in 92ms.
2024-10-01T05:48:39.500593Z  INFO runtime::accelerated_table::refresh_task: Loaded 1,000 rows (139.27 kiB) for dataset customer in 72ms.
2024-10-01T05:48:39.517618Z  INFO runtime::accelerated_table::refresh_task: Loaded 500 rows (76.79 kiB) for dataset customer_address in 88ms.
2024-10-01T05:48:39.544979Z  INFO runtime::accelerated_table::refresh_task: Loaded 2,810 rows (525.84 kiB) for dataset store_returns in 133ms.
2024-10-01T05:48:39.545171Z  INFO runtime::accelerated_table::refresh_task: Loaded 1,358 rows (292.80 kiB) for dataset catalog_returns in 109ms.
2024-10-01T05:48:39.573649Z  INFO runtime::accelerated_table::refresh_task: Loaded 23,490 rows (374.40 kiB) for dataset inventory in 165ms.
2024-10-01T05:48:39.791995Z  INFO runtime::accelerated_table::refresh_task: Loaded 11,718 rows (1.62 MiB) for dataset catalog_page in 363ms.
2024-10-01T05:48:39.812383Z  INFO runtime: Dataset region registered (s3://spiceai-demo-datasets/tpch/region/), acceleration (sqlite:file).
2024-10-01T05:48:39.812647Z  INFO runtime: Dataset nation registered (s3://spiceai-demo-datasets/tpch/nation/), acceleration (sqlite:file).
2024-10-01T05:48:39.813853Z  INFO runtime::accelerated_table::refresh_task: Loading data for dataset nation
2024-10-01T05:48:39.813863Z  INFO runtime::accelerated_table::refresh_task: Loading data for dataset region
2024-10-01T05:48:39.863376Z  INFO runtime::accelerated_table::refresh_task: Loaded 7,212 rows (2.20 MiB) for dataset web_sales in 457ms.
2024-10-01T05:48:39.866368Z  INFO runtime::accelerated_table::refresh_task: Loaded 19,208 rows (1.01 MiB) for dataset customer_demographics in 429ms.
2024-10-01T05:48:39.895618Z  INFO runtime: Dataset supplier registered (s3://spiceai-demo-datasets/tpch/supplier/), acceleration (sqlite:file).
2024-10-01T05:48:39.895860Z  INFO runtime: Dataset partsupp registered (s3://spiceai-demo-datasets/tpch/partsupp/), acceleration (sqlite:file).
2024-10-01T05:48:39.896042Z  INFO runtime: Dataset part registered (s3://spiceai-demo-datasets/tpch/part/), acceleration (sqlite:file).
2024-10-01T05:48:39.896789Z  INFO runtime::accelerated_table::refresh_task: Loading data for dataset supplier
2024-10-01T05:48:39.898302Z  INFO runtime::accelerated_table::refresh_task: Loading data for dataset part
2024-10-01T05:48:39.898324Z  INFO runtime::accelerated_table::refresh_task: Loading data for dataset partsupp
2024-10-01T05:48:39.926167Z  INFO runtime: Dataset customer registered (s3://spiceai-demo-datasets/tpch/customer/), acceleration (sqlite:file).
2024-10-01T05:48:39.926860Z  INFO runtime::accelerated_table::refresh_task: Loading data for dataset customer
2024-10-01T05:48:39.959420Z  INFO runtime: Dataset lineitem registered (s3://spiceai-demo-datasets/tpch/lineitem/), acceleration (sqlite:file).
2024-10-01T05:48:39.960614Z  INFO runtime::accelerated_table::refresh_task: Loading data for dataset lineitem
2024-10-01T05:48:40.024649Z  INFO runtime: Dataset orders registered (s3://spiceai-demo-datasets/tpch/orders/), acceleration (sqlite:file).
2024-10-01T05:48:40.025526Z  INFO runtime::accelerated_table::refresh_task: Loading data for dataset orders
2024-10-01T05:48:40.235803Z  INFO runtime::accelerated_table::refresh_task: Loaded 14,313 rows (4.38 MiB) for dataset catalog_sales in 798ms.
2024-10-01T05:48:40.652360Z  INFO runtime::accelerated_table::refresh_task: Loaded 28,810 rows (6.59 MiB) for dataset store_sales in 1s 246ms.
2024-10-01T05:48:40.694059Z  INFO runtime::accelerated_table::refresh_task: Loaded 25 rows (3.10 kiB) for dataset nation in 880ms.
2024-10-01T05:48:41.119008Z  INFO runtime::accelerated_table::refresh_task: Loaded 86,400 rows (6.07 MiB) for dataset time_dim in 1s 689ms.
2024-10-01T05:48:42.943045Z  INFO runtime::accelerated_table::refresh_task: Loaded 73,049 rows (10.49 MiB) for dataset date_dim in 3s 538ms.
2024-10-01T05:48:44.408160Z  INFO runtime::accelerated_table::refresh_task: Loaded 5 rows (944.00 B) for dataset region in 4s 594ms.
2024-10-01T05:48:44.410397Z  INFO runtime::accelerated_table::refresh_task: Loaded 200,000 rows (34.61 MiB) for dataset part in 4s 512ms.
2024-10-01T05:48:48.872753Z  WARN runtime::accelerated_table::refresh_task: Failed to update dataset partsupp: External error: Unable to insert data into the Sqlite table: Rusqlite("database is locked")
2024-10-01T05:48:54.511693Z  WARN runtime::accelerated_table::refresh_task: Failed to update dataset supplier: External error: Unable to insert data into the Sqlite table: Rusqlite("database is locked")
2024-10-01T05:48:54.511714Z  WARN runtime::accelerated_table::refresh_task: Failed to update dataset customer: External error: Unable to insert data into the Sqlite table: Rusqlite("database is locked")
2024-10-01T05:49:01.230441Z  WARN runtime::accelerated_table::refresh_task: Failed to update dataset orders: External error: Unable to insert data into the Sqlite table: Rusqlite("database is locked")
2024-10-01T05:49:01.230955Z  INFO runtime::accelerated_table::refresh_task: Loading data for dataset customer
2024-10-01T05:49:01.231194Z  INFO runtime::accelerated_table::refresh_task: Loading data for dataset partsupp
2024-10-01T05:49:02.001627Z  INFO runtime::accelerated_table::refresh_task: Loading data for dataset supplier
2024-10-01T05:49:02.325512Z  INFO runtime::accelerated_table::refresh_task: Loading data for dataset orders
2024-10-01T05:49:06.793599Z  WARN runtime::accelerated_table::refresh_task: Failed to update dataset customer: External error: Unable to insert data into the Sqlite table: Rusqlite("database is locked")
2024-10-01T05:49:06.801402Z  WARN runtime::accelerated_table::refresh_task: Failed to update dataset partsupp: External error: Unable to insert data into the Sqlite table: Rusqlite("database is locked")
2024-10-01T05:49:07.531590Z  WARN runtime::accelerated_table::refresh_task: Failed to update dataset supplier: External error: Unable to insert data into the Sqlite table: Rusqlite("database is locked")
2024-10-01T05:49:07.853378Z  WARN runtime::accelerated_table::refresh_task: Failed to update dataset orders: External error: Unable to insert data into the Sqlite table: Rusqlite("database is locked")
2024-10-01T05:49:08.557017Z  INFO runtime::accelerated_table::refresh_task: Loading data for dataset partsupp
2024-10-01T05:49:09.082467Z  INFO runtime::accelerated_table::refresh_task: Loading data for dataset supplier
2024-10-01T05:49:09.196884Z  INFO runtime::accelerated_table::refresh_task: Loading data for dataset customer
2024-10-01T05:49:09.840721Z  INFO runtime::accelerated_table::refresh_task: Loading data for dataset orders
2024-10-01T05:49:14.132095Z  WARN runtime::accelerated_table::refresh_task: Failed to update dataset partsupp: External error: Unable to insert data into the Sqlite table: Rusqlite("database is locked")
2024-10-01T05:49:14.239391Z  WARN runtime::accelerated_table::refresh_task: Failed to update dataset lineitem: External error: Unable to insert data into the Sqlite table: Other("No message to commit transaction has been received.")
2024-10-01T05:49:14.652358Z  WARN runtime::accelerated_table::refresh_task: Failed to update dataset supplier: External error: Unable to insert data into the Sqlite table: Rusqlite("database is locked")
2024-10-01T05:49:15.357096Z  INFO runtime::accelerated_table::refresh_task: Loading data for dataset lineitem
2024-10-01T05:49:15.432589Z  WARN runtime::accelerated_table::refresh_task: Failed to update dataset orders: External error: Unable to insert data into the Sqlite table: Rusqlite("database is locked")
2024-10-01T05:49:15.790715Z  INFO runtime::accelerated_table::refresh_task: Loaded 150,000 rows (32.10 MiB) for dataset customer in 6s 593ms.
2024-10-01T05:49:17.241113Z  INFO runtime::accelerated_table::refresh_task: Loading data for dataset partsupp
2024-10-01T05:49:18.288915Z  INFO runtime::accelerated_table::refresh_task: Loading data for dataset supplier
2024-10-01T05:49:18.382954Z  INFO runtime::accelerated_table::refresh_task: Loading data for dataset orders
2024-10-01T05:49:20.992061Z  WARN runtime::accelerated_table::refresh: Failed to checkpoint dataset customer: Rusqlite("database is locked")
2024-10-01T05:49:22.838150Z  WARN runtime::accelerated_table::refresh_task: Failed to update dataset partsupp: External error: Unable to insert data into the Sqlite table: Rusqlite("database is locked")
2024-10-01T05:49:23.881198Z  WARN runtime::accelerated_table::refresh_task: Failed to update dataset supplier: External error: Unable to insert data into the Sqlite table: Rusqlite("database is locked")
2024-10-01T05:49:23.973830Z  WARN runtime::accelerated_table::refresh_task: Failed to update dataset orders: External error: Unable to insert data into the Sqlite table: Rusqlite("database is locked")
2024-10-01T05:49:28.834496Z  INFO runtime::accelerated_table::refresh_task: Loading data for dataset supplier
2024-10-01T05:49:29.026243Z  INFO runtime::accelerated_table::refresh_task: Loading data for dataset partsupp
2024-10-01T05:49:30.418852Z  INFO runtime::accelerated_table::refresh_task: Loading data for dataset orders
2024-10-01T05:49:34.402724Z  WARN runtime::accelerated_table::refresh_task: Failed to update dataset supplier: External error: Unable to insert data into the Sqlite table: Rusqlite("database is locked")
2024-10-01T05:49:34.603752Z  WARN runtime::accelerated_table::refresh_task: Failed to update dataset partsupp: External error: Unable to insert data into the Sqlite table: Rusqlite("database is locked")
2024-10-01T05:49:36.012946Z  WARN runtime::accelerated_table::refresh_task: Failed to update dataset orders: External error: Unable to insert data into the Sqlite table: Rusqlite("database is locked")
2024-10-01T05:49:44.138819Z  INFO runtime::accelerated_table::refresh_task: Loading data for dataset orders
2024-10-01T05:49:44.379463Z  INFO runtime::accelerated_table::refresh_task: Loading data for dataset supplier
2024-10-01T05:49:44.688244Z  INFO runtime::accelerated_table::refresh_task: Loading data for dataset partsupp
2024-10-01T05:49:49.989509Z  WARN runtime::accelerated_table::refresh_task: Failed to update dataset supplier: External error: Unable to insert data into the Sqlite table: Rusqlite("database is locked")
2024-10-01T05:49:50.006456Z  WARN runtime::accelerated_table::refresh_task: Failed to update dataset orders: External error: Unable to insert data into the Sqlite table: Rusqlite("database is locked")
2024-10-01T05:49:50.271556Z  WARN runtime::accelerated_table::refresh_task: Failed to update dataset partsupp: External error: Unable to insert data into the Sqlite table: Rusqlite("database is locked")
2024-10-01T05:49:59.313118Z  INFO runtime::accelerated_table::refresh_task: Loading data for dataset supplier
2024-10-01T05:50:01.822889Z  INFO runtime::accelerated_table::refresh_task: Loading data for dataset partsupp
2024-10-01T05:50:04.913466Z  WARN runtime::accelerated_table::refresh_task: Failed to update dataset supplier: External error: Unable to insert data into the Sqlite table: Rusqlite("database is locked")
2024-10-01T05:50:05.820977Z  INFO runtime::accelerated_table::refresh_task: Loading data for dataset orders
2024-10-01T05:50:07.402519Z  WARN runtime::accelerated_table::refresh_task: Failed to update dataset partsupp: External error: Unable to insert data into the Sqlite table: Rusqlite("database is locked")
2024-10-01T05:50:11.400244Z  WARN runtime::accelerated_table::refresh_task: Failed to update dataset orders: External error: Unable to insert data into the Sqlite table: Rusqlite("database is locked")
2024-10-01T05:50:24.428867Z  INFO runtime::accelerated_table::refresh_task: Loading data for dataset supplier
2024-10-01T05:50:26.920157Z  INFO runtime::accelerated_table::refresh_task: Loading data for dataset partsupp
2024-10-01T05:50:30.053511Z  WARN runtime::accelerated_table::refresh_task: Failed to update dataset supplier: External error: Unable to insert data into the Sqlite table: Rusqlite("database is locked")
2024-10-01T05:50:32.513158Z  WARN runtime::accelerated_table::refresh_task: Failed to update dataset partsupp: External error: Unable to insert data into the Sqlite table: Rusqlite("database is locked")
2024-10-01T05:50:34.790133Z  INFO runtime::accelerated_table::refresh_task: Loading data for dataset orders
2024-10-01T05:50:40.379881Z  WARN runtime::accelerated_table::refresh_task: Failed to update dataset orders: External error: Unable to insert data into the Sqlite table: Rusqlite("database is locked")
2024-10-01T05:51:04.063125Z  INFO runtime::accelerated_table::refresh_task: Loading data for dataset supplier
2024-10-01T05:51:09.668329Z  WARN runtime::accelerated_table::refresh_task: Failed to update dataset supplier: External error: Unable to insert data into the Sqlite table: Rusqlite("database is locked")
2024-10-01T05:51:09.965399Z  INFO runtime::accelerated_table::refresh_task: Loading data for dataset partsupp
2024-10-01T05:51:14.971585Z  INFO runtime::accelerated_table::refresh_task: Loading data for dataset orders
2024-10-01T05:51:15.557744Z  WARN runtime::accelerated_table::refresh_task: Failed to update dataset partsupp: External error: Unable to insert data into the Sqlite table: Rusqlite("database is locked")
2024-10-01T05:51:20.552376Z  WARN runtime::accelerated_table::refresh_task: Failed to update dataset orders: External error: Unable to insert data into the Sqlite table: Rusqlite("database is locked")
2024-10-01T05:51:27.071631Z  INFO runtime::accelerated_table::refresh_task: Loaded 6,001,215 rows (1.05 GiB) for dataset lineitem in 2m 11s 714ms.
2024-10-01T05:52:01.538491Z  INFO runtime::accelerated_table::refresh_task: Loading data for dataset partsupp
2024-10-01T05:52:08.278225Z  INFO runtime::accelerated_table::refresh_task: Loading data for dataset supplier
2024-10-01T05:52:10.146446Z  INFO runtime::accelerated_table::refresh_task: Loaded 10,000 rows (1.80 MiB) for dataset supplier in 1s 868ms.
2024-10-01T05:52:10.169351Z  INFO runtime::accelerated_table::refresh_task: Loaded 800,000 rows (138.95 MiB) for dataset partsupp in 8s 630ms.
2024-10-01T05:52:24.719020Z  INFO runtime::accelerated_table::refresh_task: Loading data for dataset orders
2024-10-01T05:52:44.204769Z  INFO runtime::accelerated_table::refresh_task: Loaded 1,500,000 rows (206.69 MiB) for dataset orders in 19s 485ms.
```