### PR TITLE
Preserve records batch order (update datafusion-federation)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,7 @@ pem = { version = "3.0.4", optional = true }
 tokio-rusqlite = { version = "0.5.1", optional = true }
 tonic = { version = "0.12.2", optional = true }
 datafusion-federation = "0.1"
-datafusion-federation-sql = { git = "https://github.com/spiceai/datafusion-federation.git", rev = "7c69f7bc5d4f67469aaa215650e89000941d6915" }
+datafusion-federation-sql = { git = "https://github.com/spiceai/datafusion-federation.git", rev = "f1e7b17755d96b30bafb4d185467ca4c55f85aec" }
 itertools = "0.13.0"
 dyn-clone = { version = "1.0.17", optional = true }
 geo-types = "0.7.13"
@@ -99,5 +99,5 @@ sqlite-federation = ["sqlite"]
 postgres-federation = ["postgres"]
 
 [patch.crates-io]
-datafusion-federation = { git = "https://github.com/spiceai/datafusion-federation.git", rev = "7c69f7bc5d4f67469aaa215650e89000941d6915" }
+datafusion-federation = { git = "https://github.com/spiceai/datafusion-federation.git", rev = "f1e7b17755d96b30bafb4d185467ca4c55f85aec" }
 duckdb = { git = "https://github.com/spiceai/duckdb-rs.git", rev = "5b98603705a381ceeb5cc371e4f606b7332b57ce" }


### PR DESCRIPTION
Update `datafusion-federation` crate version to include the following improvements:
[Preserve records batch order when SchemaCastScanExec is involved](https://github.com/spiceai/datafusion-federation/pull/20)