### PR TITLE
fix: add ast analyzer for mysql rank

### DIFF
--- a/examples/sqlite.rs
+++ b/examples/sqlite.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::{sync::Arc, time::Duration};
 
 use datafusion::{prelude::SessionContext, sql::TableReference};
 use datafusion_table_providers::{
@@ -11,10 +11,14 @@ use datafusion_table_providers::{
 #[tokio::main]
 async fn main() {
     let sqlite_pool = Arc::new(
-        SqliteConnectionPoolFactory::new("examples/sqlite_example.db", Mode::File)
-            .build()
-            .await
-            .expect("unable to create Sqlite connection pool"),
+        SqliteConnectionPoolFactory::new(
+            "examples/sqlite_example.db",
+            Mode::File,
+            Duration::from_millis(5000),
+        )
+        .build()
+        .await
+        .expect("unable to create Sqlite connection pool"),
     );
 
     let sqlite_table_factory = SqliteTableFactory::new(sqlite_pool);

--- a/src/mysql/federation.rs
+++ b/src/mysql/federation.rs
@@ -1,0 +1,115 @@
+use crate::sql::db_connection_pool::dbconnection::{get_schema, Error as DbError};
+use crate::sql::sql_provider_datafusion::{get_stream, to_execution_error};
+use arrow::datatypes::SchemaRef;
+use async_trait::async_trait;
+use datafusion::sql::sqlparser::ast::{self, VisitMut};
+use datafusion::sql::unparser::dialect::Dialect;
+use datafusion_federation::{FederatedTableProviderAdaptor, FederatedTableSource};
+use datafusion_federation_sql::{AstAnalyzer, SQLExecutor, SQLFederationProvider, SQLTableSource};
+use futures::TryStreamExt;
+use snafu::ResultExt;
+use std::sync::Arc;
+
+use super::mysql_rank::MySQLRankVisitor;
+use super::sql_table::MySQLTable;
+use datafusion::{
+    datasource::TableProvider,
+    error::{DataFusionError, Result as DataFusionResult},
+    execution::SendableRecordBatchStream,
+    physical_plan::stream::RecordBatchStreamAdapter,
+    sql::TableReference,
+};
+
+impl<T, P> MySQLTable<T, P> {
+    fn create_federated_table_source(
+        self: Arc<Self>,
+    ) -> DataFusionResult<Arc<dyn FederatedTableSource>> {
+        let table_name = self.base_table.table_reference.to_quoted_string();
+        let schema = Arc::clone(&Arc::clone(&self).base_table.schema());
+        let fed_provider = Arc::new(SQLFederationProvider::new(self));
+        Ok(Arc::new(SQLTableSource::new_with_schema(
+            fed_provider,
+            table_name,
+            schema,
+        )?))
+    }
+
+    pub fn create_federated_table_provider(
+        self: Arc<Self>,
+    ) -> DataFusionResult<FederatedTableProviderAdaptor> {
+        let table_source = Self::create_federated_table_source(Arc::clone(&self))?;
+        Ok(FederatedTableProviderAdaptor::new_with_provider(
+            table_source,
+            self,
+        ))
+    }
+}
+
+#[allow(clippy::unnecessary_wraps)]
+fn mysql_ast_analyzer(ast: ast::Statement) -> Result<ast::Statement, DataFusionError> {
+    match ast {
+        ast::Statement::Query(query) => {
+            let mut new_query = query.clone();
+
+            let mut rank_visitor = MySQLRankVisitor::default();
+            new_query.visit(&mut rank_visitor);
+
+            Ok(ast::Statement::Query(new_query))
+        }
+        _ => Ok(ast),
+    }
+}
+
+#[async_trait]
+impl<T, P> SQLExecutor for MySQLTable<T, P> {
+    fn name(&self) -> &str {
+        self.base_table.name()
+    }
+
+    fn compute_context(&self) -> Option<String> {
+        self.base_table.compute_context()
+    }
+
+    fn dialect(&self) -> Arc<dyn Dialect> {
+        self.base_table.dialect()
+    }
+
+    fn ast_analyzer(&self) -> Option<AstAnalyzer> {
+        Some(Box::new(mysql_ast_analyzer))
+    }
+
+    fn execute(
+        &self,
+        query: &str,
+        schema: SchemaRef,
+    ) -> DataFusionResult<SendableRecordBatchStream> {
+        let fut = get_stream(
+            self.base_table.clone_pool(),
+            query.to_string(),
+            Arc::clone(&schema),
+        );
+
+        let stream = futures::stream::once(fut).try_flatten();
+        Ok(Box::pin(RecordBatchStreamAdapter::new(schema, stream)))
+    }
+
+    async fn table_names(&self) -> DataFusionResult<Vec<String>> {
+        Err(DataFusionError::NotImplemented(
+            "table inference not implemented".to_string(),
+        ))
+    }
+
+    async fn get_table_schema(&self, table_name: &str) -> DataFusionResult<SchemaRef> {
+        let conn = self
+            .base_table
+            .clone_pool()
+            .connect()
+            .await
+            .map_err(to_execution_error)?;
+        get_schema(conn, &TableReference::from(table_name))
+            .await
+            .boxed()
+            .map_err(|e| DbError::UnableToGetSchema { source: e })
+            .map_err(to_execution_error)
+    }
+}

--- a/src/mysql/mysql_rank.rs
+++ b/src/mysql/mysql_rank.rs
@@ -12,7 +12,7 @@ impl VisitorMut for MySQLRankVisitor {
             // match only for RANK()
             if let Some(Ident { value, .. }) = func.name.0.first() {
                 if value.to_uppercase() == "RANK" {
-                    Self::replace_rank_window(func);
+                    Self::replace_rank(func);
                 }
             }
         }
@@ -22,7 +22,7 @@ impl VisitorMut for MySQLRankVisitor {
 }
 
 impl MySQLRankVisitor {
-    pub fn replace_rank_window(func: &mut Function) {
+    pub fn replace_rank(func: &mut Function) {
         if let Some(WindowType::WindowSpec(spec)) = func.over.as_mut() {
             spec.window_frame = None; // frame (window) clauses are ignored in MySQL: https://dev.mysql.com/doc/refman/8.4/en/window-functions-frames.html
 
@@ -30,5 +30,62 @@ impl MySQLRankVisitor {
                 order_by.nulls_first = None; // nulls first/last are not supported in MySQL
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use datafusion_expr::sqlparser::ast::{ObjectName, WindowFrame};
+
+    use super::*;
+
+    #[test]
+    fn test_replace_rank() {
+        let mut func = Function {
+            name: ObjectName(vec![Ident {
+                value: "RANK".to_string(),
+                quote_style: None,
+            }]),
+            args: datafusion_expr::sqlparser::ast::FunctionArguments::None,
+            over: Some(WindowType::WindowSpec(
+                datafusion_expr::sqlparser::ast::WindowSpec {
+                    window_name: None,
+                    partition_by: vec![],
+                    order_by: vec![datafusion_expr::sqlparser::ast::OrderByExpr {
+                        expr: datafusion_expr::sqlparser::ast::Expr::Wildcard,
+                        asc: None,
+                        nulls_first: Some(true),
+                        with_fill: None,
+                    }],
+                    window_frame: Some(WindowFrame {
+                        units: datafusion_expr::sqlparser::ast::WindowFrameUnits::Rows,
+                        start_bound: datafusion_expr::sqlparser::ast::WindowFrameBound::CurrentRow,
+                        end_bound: None,
+                    }),
+                },
+            )),
+            parameters: datafusion_expr::sqlparser::ast::FunctionArguments::None,
+            null_treatment: None,
+            filter: None,
+            within_group: vec![],
+        };
+
+        let expected = Some(WindowType::WindowSpec(
+            datafusion_expr::sqlparser::ast::WindowSpec {
+                window_name: None,
+                partition_by: vec![],
+                order_by: vec![datafusion_expr::sqlparser::ast::OrderByExpr {
+                    expr: datafusion_expr::sqlparser::ast::Expr::Wildcard,
+                    asc: None,
+                    nulls_first: None,
+                    with_fill: None,
+                }],
+                window_frame: None,
+            },
+        ));
+
+        MySQLRankVisitor::replace_rank(&mut func);
+
+        assert_eq!(func.over, expected);
     }
 }

--- a/src/mysql/mysql_rank.rs
+++ b/src/mysql/mysql_rank.rs
@@ -1,0 +1,34 @@
+use datafusion::sql::sqlparser::ast::{Expr, Function, Ident, VisitorMut, WindowType};
+use std::ops::ControlFlow;
+
+#[derive(Default)]
+pub struct MySQLRankVisitor {}
+
+impl VisitorMut for MySQLRankVisitor {
+    type Break = ();
+
+    fn pre_visit_expr(&mut self, expr: &mut Expr) -> ControlFlow<Self::Break> {
+        if let Expr::Function(func) = expr {
+            // match only for RANK()
+            if let Some(Ident { value, .. }) = func.name.0.first() {
+                if value.to_uppercase() == "RANK" {
+                    Self::replace_rank_window(func);
+                }
+            }
+        }
+
+        ControlFlow::Continue(())
+    }
+}
+
+impl MySQLRankVisitor {
+    pub fn replace_rank_window(func: &mut Function) {
+        if let Some(WindowType::WindowSpec(spec)) = func.over.as_mut() {
+            spec.window_frame = None; // frame (window) clauses are ignored in MySQL: https://dev.mysql.com/doc/refman/8.4/en/window-functions-frames.html
+
+            if let Some(order_by) = spec.order_by.first_mut() {
+                order_by.nulls_first = None; // nulls first/last are not supported in MySQL
+            }
+        }
+    }
+}

--- a/src/mysql/mysql_rank.rs
+++ b/src/mysql/mysql_rank.rs
@@ -1,4 +1,5 @@
 use datafusion::sql::sqlparser::ast::{Expr, Function, Ident, VisitorMut, WindowType};
+use datafusion_expr::sqlparser::ast::WindowFrameBound;
 use std::ops::ControlFlow;
 
 #[derive(Default)]
@@ -24,7 +25,7 @@ impl VisitorMut for MySQLRankVisitor {
 impl MySQLRankVisitor {
     pub fn replace_rank(func: &mut Function) {
         if let Some(WindowType::WindowSpec(spec)) = func.over.as_mut() {
-            spec.window_frame = None; // frame (window) clauses are ignored in MySQL: https://dev.mysql.com/doc/refman/8.4/en/window-functions-frames.html
+            spec.window_frame = None; // frame (window) clauses are ignored for rank() in MySQL: https://dev.mysql.com/doc/refman/8.4/en/window-functions-frames.html
 
             if let Some(order_by) = spec.order_by.first_mut() {
                 order_by.nulls_first = None; // nulls first/last are not supported in MySQL

--- a/src/mysql/sql_table.rs
+++ b/src/mysql/sql_table.rs
@@ -1,0 +1,185 @@
+use crate::sql::db_connection_pool::DbConnectionPool;
+use async_trait::async_trait;
+use datafusion::catalog::Session;
+use datafusion::sql::unparser::dialect::MySqlDialect;
+use futures::TryStreamExt;
+use std::fmt::Display;
+use std::{any::Any, fmt, sync::Arc};
+
+use crate::sql::sql_provider_datafusion::{
+    self, get_stream, to_execution_error, Result as SqlResult, SqlExec, SqlTable,
+};
+use datafusion::{
+    arrow::datatypes::SchemaRef,
+    datasource::TableProvider,
+    error::Result as DataFusionResult,
+    execution::TaskContext,
+    logical_expr::{Expr, TableProviderFilterPushDown, TableType},
+    physical_plan::{
+        stream::RecordBatchStreamAdapter, DisplayAs, DisplayFormatType, ExecutionPlan,
+        PlanProperties, SendableRecordBatchStream,
+    },
+    sql::TableReference,
+};
+
+pub struct MySQLTable<T: 'static, P: 'static> {
+    pub(crate) base_table: SqlTable<T, P>,
+}
+
+impl<T, P> MySQLTable<T, P> {
+    pub async fn new(
+        pool: &Arc<dyn DbConnectionPool<T, P> + Send + Sync>,
+        table_reference: impl Into<TableReference>,
+    ) -> Result<Self, sql_provider_datafusion::Error> {
+        let base_table = SqlTable::new("mysql", pool, table_reference, None)
+            .await?
+            .with_dialect(Arc::new(MySqlDialect {}));
+
+        Ok(Self { base_table })
+    }
+
+    fn create_physical_plan(
+        &self,
+        projections: Option<&Vec<usize>>,
+        schema: &SchemaRef,
+        filters: &[Expr],
+        limit: Option<usize>,
+    ) -> DataFusionResult<Arc<dyn ExecutionPlan>> {
+        Ok(Arc::new(MySQLSQLExec::new(
+            projections,
+            schema,
+            &self.base_table.table_reference,
+            self.base_table.clone_pool(),
+            filters,
+            limit,
+        )?))
+    }
+}
+
+#[async_trait]
+impl<T, P> TableProvider for MySQLTable<T, P> {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn schema(&self) -> SchemaRef {
+        self.base_table.schema()
+    }
+
+    fn table_type(&self) -> TableType {
+        self.base_table.table_type()
+    }
+
+    fn supports_filters_pushdown(
+        &self,
+        filters: &[&Expr],
+    ) -> DataFusionResult<Vec<TableProviderFilterPushDown>> {
+        self.base_table.supports_filters_pushdown(filters)
+    }
+
+    async fn scan(
+        &self,
+        _state: &dyn Session,
+        projection: Option<&Vec<usize>>,
+        filters: &[Expr],
+        limit: Option<usize>,
+    ) -> DataFusionResult<Arc<dyn ExecutionPlan>> {
+        return self.create_physical_plan(projection, &self.schema(), filters, limit);
+    }
+}
+
+impl<T, P> Display for MySQLTable<T, P> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "MySQLTable {}", self.base_table.name())
+    }
+}
+
+#[derive(Clone)]
+struct MySQLSQLExec<T, P> {
+    base_exec: SqlExec<T, P>,
+}
+
+impl<T, P> MySQLSQLExec<T, P> {
+    fn new(
+        projections: Option<&Vec<usize>>,
+        schema: &SchemaRef,
+        table_reference: &TableReference,
+        pool: Arc<dyn DbConnectionPool<T, P> + Send + Sync>,
+        filters: &[Expr],
+        limit: Option<usize>,
+    ) -> DataFusionResult<Self> {
+        let base_exec = SqlExec::new(
+            projections,
+            schema,
+            table_reference,
+            pool,
+            filters,
+            limit,
+            None,
+        )?;
+
+        Ok(Self { base_exec })
+    }
+
+    fn sql(&self) -> SqlResult<String> {
+        self.base_exec.sql()
+    }
+}
+
+impl<T, P> std::fmt::Debug for MySQLSQLExec<T, P> {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        let sql = self.sql().unwrap_or_default();
+        write!(f, "MySQLSQLExec sql={sql}")
+    }
+}
+
+impl<T, P> DisplayAs for MySQLSQLExec<T, P> {
+    fn fmt_as(&self, _t: DisplayFormatType, f: &mut fmt::Formatter) -> std::fmt::Result {
+        let sql = self.sql().unwrap_or_default();
+        write!(f, "MySQLSQLExec sql={sql}")
+    }
+}
+
+impl<T: 'static, P: 'static> ExecutionPlan for MySQLSQLExec<T, P> {
+    fn name(&self) -> &'static str {
+        "MySQLSQLExec"
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn schema(&self) -> SchemaRef {
+        self.base_exec.schema()
+    }
+
+    fn properties(&self) -> &PlanProperties {
+        self.base_exec.properties()
+    }
+
+    fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {
+        self.base_exec.children()
+    }
+
+    fn with_new_children(
+        self: Arc<Self>,
+        _children: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> DataFusionResult<Arc<dyn ExecutionPlan>> {
+        Ok(self)
+    }
+
+    fn execute(
+        &self,
+        _partition: usize,
+        _context: Arc<TaskContext>,
+    ) -> DataFusionResult<SendableRecordBatchStream> {
+        let sql = self.sql().map_err(to_execution_error)?;
+        tracing::debug!("MySQLSQLExec sql: {sql}");
+
+        let fut = get_stream(self.base_exec.clone_pool(), sql, Arc::clone(&self.schema()));
+
+        let stream = futures::stream::once(fut).try_flatten();
+        let schema = Arc::clone(&self.schema());
+        Ok(Box::pin(RecordBatchStreamAdapter::new(schema, stream)))
+    }
+}

--- a/src/sql/db_connection_pool/sqlitepool.rs
+++ b/src/sql/db_connection_pool/sqlitepool.rs
@@ -282,7 +282,8 @@ mod tests {
     #[tokio::test]
     async fn test_sqlite_connection_pool_factory() {
         let db_name = random_db_name();
-        let factory = SqliteConnectionPoolFactory::new(&db_name, Mode::File, None);
+        let factory =
+            SqliteConnectionPoolFactory::new(&db_name, Mode::File, Duration::from_secs(5));
         let pool = factory.build().await.unwrap();
 
         assert!(pool.join_push_down == JoinPushDown::AllowedFor(db_name.clone()));


### PR DESCRIPTION
## 🗣 Description

* Adds an AST Analyzer for MySQL to remove frame clauses from `rank()` statements, because MySQL ignores them anyway (and as provided, they're formatted incorrectly for what the MySQL frame clause syntax supports)
* In the same AST Analyzer, removes any `NULLS FIRST/LAST` from sorts inside `rank()` statements, because MySQL doesn't support `NULLS FIRST`.

Changes:

```
RANK() OVER (ORDER BY v1.rank_col ASC NULLS LAST RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)
```

to a syntax that MySQL supports:

```
RANK() OVER (ORDER BY v1.rank_col ASC)
```