### PR TITLE
[Flight] Enable TLS for tonic 0.12 and make gRPC size limits configurable

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,7 +68,7 @@ trust-dns-resolver = "0.23.2"
 url = "2.5.1"
 pem = { version = "3.0.4", optional = true }
 tokio-rusqlite = { version = "0.5.1", optional = true }
-tonic = { version = "0.12.2", optional = true }
+tonic = { version = "0.12", optional = true, features = ["tls-native-roots", "tls-webpki-roots"] }
 itertools = "0.13.0"
 dyn-clone = { version = "1.0.17", optional = true }
 geo-types = "0.7.13"

--- a/src/flight/codec.rs
+++ b/src/flight/codec.rs
@@ -20,6 +20,7 @@
 use std::sync::Arc;
 
 use crate::flight::exec::{FlightConfig, FlightExec};
+use crate::flight::to_df_err;
 use datafusion::common::DataFusionError;
 use datafusion_expr::registry::FunctionRegistry;
 use datafusion_physical_plan::ExecutionPlan;
@@ -37,8 +38,7 @@ impl PhysicalExtensionCodec for FlightPhysicalCodec {
         _registry: &dyn FunctionRegistry,
     ) -> datafusion::common::Result<Arc<dyn ExecutionPlan>> {
         if inputs.is_empty() {
-            let config: FlightConfig =
-                serde_json::from_slice(buf).map_err(|e| DataFusionError::External(Box::new(e)))?;
+            let config: FlightConfig = serde_json::from_slice(buf).map_err(to_df_err)?;
             Ok(Arc::from(FlightExec::from(config)))
         } else {
             Err(DataFusionError::Internal(
@@ -53,8 +53,7 @@ impl PhysicalExtensionCodec for FlightPhysicalCodec {
         buf: &mut Vec<u8>,
     ) -> datafusion::common::Result<()> {
         if let Some(flight) = node.as_any().downcast_ref::<FlightExec>() {
-            let mut bytes = serde_json::to_vec(flight.config())
-                .map_err(|e| DataFusionError::External(Box::new(e)))?;
+            let mut bytes = serde_json::to_vec(flight.config()).map_err(to_df_err)?;
             buf.append(&mut bytes);
             Ok(())
         } else {


### PR DESCRIPTION
Address two tonic issues:
- TLS is disabled by default in tonic 0.12
- The default `max_decoding_message_size` is 4MB, not suited for a flight client 