### PR TITLE
fix tests

### DIFF
--- a/examples/sqlite.rs
+++ b/examples/sqlite.rs
@@ -1,5 +1,5 @@
 use std::sync::Arc;
-
+use std::time::Duration;
 use datafusion::{prelude::SessionContext, sql::TableReference};
 use datafusion_table_providers::{
     sql::db_connection_pool::{sqlitepool::SqliteConnectionPoolFactory, Mode},
@@ -11,7 +11,7 @@ use datafusion_table_providers::{
 #[tokio::main]
 async fn main() {
     let sqlite_pool = Arc::new(
-        SqliteConnectionPoolFactory::new("examples/sqlite_example.db", Mode::File)
+        SqliteConnectionPoolFactory::new("examples/sqlite_example.db", Mode::File, Duration::default())
             .build()
             .await
             .expect("unable to create Sqlite connection pool"),

--- a/src/sql/db_connection_pool/sqlitepool.rs
+++ b/src/sql/db_connection_pool/sqlitepool.rs
@@ -282,7 +282,7 @@ mod tests {
     #[tokio::test]
     async fn test_sqlite_connection_pool_factory() {
         let db_name = random_db_name();
-        let factory = SqliteConnectionPoolFactory::new(&db_name, Mode::File, None);
+        let factory = SqliteConnectionPoolFactory::new(&db_name, Mode::File, Duration::default());
         let pool = factory.build().await.unwrap();
 
         assert!(pool.join_push_down == JoinPushDown::AllowedFor(db_name.clone()));


### PR DESCRIPTION
`cargo test --lib --all-features` currently fails with:

```
error[E0308]: mismatched types
   --> src/sql/db_connection_pool/sqlitepool.rs:285:78
    |
285 |         let factory = SqliteConnectionPoolFactory::new(&db_name, Mode::File, None);
    |                       --------------------------------                       ^^^^ expected `Duration`, found `Option<_>`
    |                       |
    |                       arguments to this function are incorrect
    |
    = note: expected struct `std::time::Duration`
                 found enum `std::option::Option<_>`
note: associated function defined here
   --> src/sql/db_connection_pool/sqlitepool.rs:33:12
    |
33  |     pub fn new(path: &str, mode: Mode, busy_timeout: Duration) -> Self {
    |            ^^^                         ----------------------
```