### PR TITLE
make the datafusion-federation dependency optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ datafusion-expr = { version = "42.0.0", optional = true }
 datafusion-physical-expr = { version = "42.0.0", optional = true }
 datafusion-physical-plan = { version = "42.0.0", optional = true }
 datafusion-proto = { version = "42.0.0", optional = true }
-datafusion-federation = { version = "0.3.0", features = ["sql"] } 
+datafusion-federation = { version = "0.3.0", features = ["sql"], optional = true }
 duckdb = { version = "1.1.1", features = [
   "bundled",
   "r2d2",
@@ -105,8 +105,9 @@ flight = [
   "dep:serde",
   "dep:tonic",
 ]
-duckdb-federation = ["duckdb"]
-sqlite-federation = ["sqlite"]
-postgres-federation = ["postgres"]
+federation = ["dep:datafusion-federation"]
+duckdb-federation = ["duckdb", "federation"]
+sqlite-federation = ["sqlite", "federation"]
+postgres-federation = ["postgres", "federation"]
 
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -109,5 +109,6 @@ federation = ["dep:datafusion-federation"]
 duckdb-federation = ["duckdb", "federation"]
 sqlite-federation = ["sqlite", "federation"]
 postgres-federation = ["postgres", "federation"]
+mysql-federation = ["mysql", "federation"]
 
 

--- a/src/mysql.rs
+++ b/src/mysql.rs
@@ -55,6 +55,7 @@ impl MySQLTableFactory {
                 .context(UnableToConstructSQLTableSnafu)?,
         );
 
+        #[cfg(feature = "mysql-federation")]
         let table_provider = Arc::new(
             table_provider
                 .create_federated_table_provider()

--- a/src/postgres.rs
+++ b/src/postgres.rs
@@ -152,6 +152,7 @@ impl PostgresTableFactory {
             .map_err(|e| Box::new(e) as Box<dyn std::error::Error + Send + Sync>)?,
         );
 
+        #[cfg(feature = "postgres-federation")]
         let table_provider = Arc::new(
             table_provider
                 .create_federated_table_provider()

--- a/src/sql/sql_provider_datafusion/mod.rs
+++ b/src/sql/sql_provider_datafusion/mod.rs
@@ -38,6 +38,7 @@ use datafusion::{
     sql::{unparser::Unparser, TableReference},
 };
 
+#[cfg(feature = "federation")]
 pub mod federation;
 
 #[derive(Debug, Snafu)]

--- a/tests/postgres/mod.rs
+++ b/tests/postgres/mod.rs
@@ -9,6 +9,7 @@ use datafusion::execution::context::SessionContext;
 use datafusion::logical_expr::CreateExternalTable;
 use datafusion::physical_plan::collect;
 use datafusion::physical_plan::memory::MemoryExec;
+#[cfg(feature = "postgres-federation")]
 use datafusion_federation::schema_cast::record_convert::try_cast_to;
 
 use datafusion_table_providers::{
@@ -76,6 +77,7 @@ async fn arrow_postgres_round_trip(
         record_batch[0].columns()
     );
 
+    #[cfg(feature = "postgres-federation")]
     let casted_result =
         try_cast_to(record_batch[0].clone(), source_schema).expect("Failed to cast record batch");
 
@@ -83,6 +85,7 @@ async fn arrow_postgres_round_trip(
     assert_eq!(record_batch.len(), 1);
     assert_eq!(record_batch[0].num_rows(), arrow_record.num_rows());
     assert_eq!(record_batch[0].num_columns(), arrow_record.num_columns());
+    #[cfg(feature = "postgres-federation")]
     assert_eq!(arrow_record, casted_result);
 }
 

--- a/tests/sqlite/mod.rs
+++ b/tests/sqlite/mod.rs
@@ -2,6 +2,7 @@ use crate::arrow_record_batch_gen::*;
 use arrow::array::RecordBatch;
 use arrow::datatypes::SchemaRef;
 use datafusion::execution::context::SessionContext;
+#[cfg(feature = "sqlite-federation")]
 use datafusion_federation::schema_cast::record_convert::try_cast_to;
 use datafusion_table_providers::sql::arrow_sql_gen::statement::{
     CreateTableBuilder, InsertBuilder,
@@ -68,6 +69,7 @@ async fn arrow_sqlite_round_trip(
 
     let record_batch = df.collect().await.expect("RecordBatch should be collected");
 
+    #[cfg(feature = "sqlite-federation")]
     let casted_record = try_cast_to(record_batch[0].clone(), source_schema).unwrap();
 
     tracing::debug!("Original Arrow Record Batch: {:?}", arrow_record.columns());
@@ -80,6 +82,7 @@ async fn arrow_sqlite_round_trip(
     assert_eq!(record_batch.len(), 1);
     assert_eq!(record_batch[0].num_rows(), arrow_record.num_rows());
     assert_eq!(record_batch[0].num_columns(), arrow_record.num_columns());
+    #[cfg(feature = "sqlite-federation")]
     assert_eq!(casted_record, arrow_record);
 }
 


### PR DESCRIPTION
While trying to use the flight table with the latest datafusion main branch, it got really tedious to fork and upgrade federation which is currently not used in flight.
Also, there are already `*-federation` features defined in cargo so tying this dependency to those features seems like a natural fit.