### PR TITLE
Implement Debug for SqlTable

### DIFF
--- a/src/sql/sql_provider_datafusion/mod.rs
+++ b/src/sql/sql_provider_datafusion/mod.rs
@@ -18,7 +18,7 @@ use datafusion::{
 };
 use futures::TryStreamExt;
 use snafu::prelude::*;
-use std::fmt::Display;
+use std::fmt::{Display, Formatter};
 use std::{any::Any, fmt, sync::Arc};
 
 use datafusion::{
@@ -89,6 +89,17 @@ pub struct SqlTable<T: 'static, P: 'static> {
     schema: SchemaRef,
     pub table_reference: TableReference,
     engine: Engine,
+}
+
+impl<T, P> fmt::Debug for SqlTable<T, P> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.debug_struct("SqlTable")
+            .field("name", &self.name)
+            .field("schema", &self.schema)
+            .field("table_reference", &self.table_reference)
+            .field("engine", &self.engine)
+            .finish()
+    }
 }
 
 impl<T, P> SqlTable<T, P> {


### PR DESCRIPTION
Make table providers compatible with the `TableProvider` trait in DataFusion latest.
This only addresses the issue for `SqlTable`, which is the only `TableProvider` compiled unconditionally.
The rest of the table providers can only be implemented as part of the upgrade to datafusion next, when the inner TableProvider [will be Debug](https://github.com/apache/datafusion/blob/7a3414774cb7858d9649820ddffa59f5712a3153/datafusion/catalog/src/table.rs#L36) itself.