### PR TITLE
tests: Ensure all tests run on PRs, try to fix flaky DuckDB test (#150)

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -51,7 +51,7 @@ jobs:
         run: cargo check --no-default-features --features mysql
 
   integration-test:
-    name: Integration Test
+    name: Tests
     runs-on: ubuntu-latest
 
     env:
@@ -68,5 +68,5 @@ jobs:
           docker pull ${{ env.PG_DOCKER_IMAGE }}
           docker pull ${{ env.MYSQL_DOCKER_IMAGE }}
 
-      - name: Run integration test
-        run: make test-integration
+      - name: Run tests
+        run: make test

--- a/src/sql/db_connection_pool/duckdbpool.rs
+++ b/src/sql/db_connection_pool/duckdbpool.rs
@@ -324,6 +324,9 @@ mod test {
             .as_sync()
             .expect("DuckDB connection should be synchronous");
 
+        // sleep to let writes clear
+        tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+
         conn.query_arrow("SELECT * FROM test_one", &[], None)
             .expect("Query should be successful");
 


### PR DESCRIPTION
Re-merge of https://github.com/datafusion-contrib/datafusion-table-providers/pull/150 into `spiceai` branch