### PR TITLE
feat: Enable in-memory federation

### DIFF
--- a/src/duckdb.rs
+++ b/src/duckdb.rs
@@ -289,12 +289,8 @@ impl TableProviderFactory for DuckDBTableProviderFactory {
         ));
 
         #[cfg(feature = "duckdb-federation")]
-        let read_provider: Arc<dyn TableProvider> = if mode == Mode::File {
-            // federation is disabled for in-memory mode until memory connections are updated to use the same database instance instead of separate instances
-            Arc::new(read_provider.create_federated_table_provider()?)
-        } else {
-            read_provider
-        };
+        let read_provider: Arc<dyn TableProvider> =
+            Arc::new(read_provider.create_federated_table_provider()?);
 
         Ok(DuckDBTableWriter::create(
             read_provider,
@@ -470,12 +466,8 @@ impl DuckDBTableFactory {
         ));
 
         #[cfg(feature = "duckdb-federation")]
-        let table_provider: Arc<dyn TableProvider> = if self.pool.mode() == Mode::File {
-            // federation is disabled for in-memory mode until memory connections are updated to use the same database instance instead of separate instances
-            Arc::new(table_provider.create_federated_table_provider()?)
-        } else {
-            table_provider
-        };
+        let table_provider: Arc<dyn TableProvider> =
+            Arc::new(table_provider.create_federated_table_provider()?);
 
         Ok(table_provider)
     }

--- a/src/sql/db_connection_pool/duckdbpool.rs
+++ b/src/sql/db_connection_pool/duckdbpool.rs
@@ -72,8 +72,7 @@ impl DuckDbConnectionPool {
         Ok(DuckDbConnectionPool {
             path: ":memory:".into(),
             pool,
-            // There can't be any other tables that share the same context for an in-memory DuckDB.
-            join_push_down: JoinPushDown::Disallow,
+            join_push_down: JoinPushDown::AllowedFor(":memory:".to_string()),
             attached_databases: Vec::new(),
             mode: Mode::Memory,
         })

--- a/src/sql/db_connection_pool/sqlitepool.rs
+++ b/src/sql/db_connection_pool/sqlitepool.rs
@@ -73,7 +73,7 @@ impl SqliteConnectionPoolFactory {
                 }
             }
             (Mode::File, None) => JoinPushDown::AllowedFor(self.path.to_string()),
-            _ => JoinPushDown::Disallow,
+            (Mode::Memory, _) => JoinPushDown::AllowedFor("memory".to_string()),
         };
 
         let attach_databases = if let Some(attach_databases) = &self.attach_databases {

--- a/src/sqlite.rs
+++ b/src/sqlite.rs
@@ -329,12 +329,8 @@ impl TableProviderFactory for SqliteTableProviderFactory {
             .map_err(to_datafusion_error)?;
 
         #[cfg(feature = "sqlite-federation")]
-        let read_provider: Arc<dyn TableProvider> = if mode == Mode::File {
-            // federation is disabled for in-memory mode until memory connections are updated to use the same database instance instead of separate instances
-            Arc::new(read_provider.create_federated_table_provider()?)
-        } else {
-            read_provider
-        };
+        let read_provider: Arc<dyn TableProvider> =
+            Arc::new(read_provider.create_federated_table_provider()?);
 
         Ok(SqliteTableWriter::create(
             read_provider,


### PR DESCRIPTION
## 🗣 Description

* Enables federation for the in-memory table providers for DuckDB and SQLite