### PR TITLE
fix: Prevent absolute sequences in file paths

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,14 +27,13 @@ pub enum Error {
 
 pub(crate) fn check_path_within_current_directory(filepath: &str) -> Result<String, Error> {
     let path = Path::new(filepath);
-    if path.exists() && path.is_symlink() {
+    if path.is_symlink() {
         return Err(Error::FileIsSymlink {
             path: filepath.to_string(),
         });
     }
 
-    if path
-        .canonicalize()
+    if std::path::absolute(path)
         .context(FileReadSnafu)?
         .starts_with(std::env::current_dir().context(FileReadSnafu)?)
     {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+use std::path::Path;
+
 pub mod sql;
 pub mod util;
 
@@ -12,6 +14,13 @@ pub mod postgres;
 #[cfg(feature = "sqlite")]
 pub mod sqlite;
 
-pub(crate) fn path_has_absolute_sequence(path: &str) -> bool {
-    path.starts_with("./") || path.starts_with("../")
+pub(crate) fn check_path_within_current_directory(
+    filepath: &str,
+) -> Result<String, Box<dyn std::error::Error + Send + Sync>> {
+    let path = Path::new(filepath);
+    if path.canonicalize()?.starts_with(std::env::current_dir()?) {
+        Ok(filepath.to_string())
+    } else {
+        Err("Path must be absolute or relative to the current directory".into())
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,3 +11,7 @@ pub mod mysql;
 pub mod postgres;
 #[cfg(feature = "sqlite")]
 pub mod sqlite;
+
+pub(crate) fn path_has_absolute_sequence(path: &str) -> bool {
+    path.starts_with("./") || path.starts_with("../")
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,7 +27,7 @@ pub enum Error {
 
 pub(crate) fn check_path_within_current_directory(filepath: &str) -> Result<String, Error> {
     let path = Path::new(filepath);
-    if path.is_symlink() {
+    if path.exists() && path.is_symlink() {
         return Err(Error::FileIsSymlink {
             path: filepath.to_string(),
         });
@@ -60,6 +60,12 @@ mod test {
     fn test_check_path_outside_of_current_directory() {
         let path = check_path_within_current_directory("/etc/passwd");
         assert!(path.is_err());
+    }
+
+    #[test]
+    fn test_check_nonexistant_path_in_directory() {
+        let path = check_path_within_current_directory("src/notreal.rs");
+        assert!(path.is_ok());
     }
 
     #[test]

--- a/src/sqlite.rs
+++ b/src/sqlite.rs
@@ -1,3 +1,4 @@
+use crate::path_has_absolute_sequence;
 use crate::sql::arrow_sql_gen::statement::{CreateTableBuilder, IndexBuilder, InsertBuilder};
 use crate::sql::db_connection_pool::dbconnection::{self, get_schema, AsyncDbConnection};
 use crate::sql::db_connection_pool::sqlitepool::SqliteConnectionPoolFactory;
@@ -102,6 +103,9 @@ pub enum Error {
         "Unable to parse SQLite busy_timeout parameter, ensure it is a valid duration"
     ))]
     UnableToParseBusyTimeoutParameter { source: fundu::ParseError },
+
+    #[snafu(display("The file or directory path includes an absolute sequence, like './', which is not allowed: {path}"))]
+    AbsoluteSequenceNotAllowed { path: String },
 }
 
 type Result<T, E = Error> = std::result::Result<T, E>;
@@ -133,20 +137,40 @@ impl SqliteTableProviderFactory {
         })
     }
 
-    #[must_use]
-    pub fn sqlite_file_path(&self, name: &str, options: &HashMap<String, String>) -> String {
+    /// Get the path to the SQLite file database.
+    ///
+    /// ## Errors
+    ///
+    /// - If the path includes absolute sequences to escape the current directory, like `./`, `../`, or `/`.
+    pub fn sqlite_file_path(
+        &self,
+        name: &str,
+        options: &HashMap<String, String>,
+    ) -> Result<String> {
+        if path_has_absolute_sequence(name) {
+            return Err(Error::AbsoluteSequenceNotAllowed {
+                path: name.to_string(),
+            });
+        }
+
         let options = util::remove_prefix_from_hashmap_keys(options.clone(), "sqlite_");
 
-        let db_base_folder = options
-            .get(SQLITE_DB_BASE_FOLDER_PARAM)
-            .cloned()
-            .unwrap_or(".".to_string()); // default to the current directory
+        let db_base_folder = options.get(SQLITE_DB_BASE_FOLDER_PARAM).cloned().map_or(
+            Ok(".".to_string()),
+            |base| {
+                if path_has_absolute_sequence(&base) {
+                    Err(Error::AbsoluteSequenceNotAllowed { path: base.clone() })
+                } else {
+                    Ok(base)
+                }
+            },
+        )?; // default to the current directory
         let default_filepath = format!("{db_base_folder}/{name}_sqlite.db");
 
-        options
+        Ok(options
             .get(SQLITE_DB_PATH_PARAM)
             .cloned()
-            .unwrap_or(default_filepath)
+            .unwrap_or(default_filepath))
     }
 
     pub fn sqlite_busy_timeout(&self, options: &HashMap<String, String>) -> Result<Duration> {
@@ -245,7 +269,10 @@ impl TableProviderFactory for SqliteTableProviderFactory {
         let busy_timeout = self
             .sqlite_busy_timeout(&cmd.options)
             .map_err(to_datafusion_error)?;
-        let db_path: Arc<str> = self.sqlite_file_path(&name, &cmd.options).into();
+        let db_path: Arc<str> = self
+            .sqlite_file_path(&name, &cmd.options)
+            .map_err(to_datafusion_error)?
+            .into();
 
         let pool: Arc<SqliteConnectionPool> = Arc::new(
             self.get_or_init_instance(Arc::clone(&db_path), mode, busy_timeout)


### PR DESCRIPTION
This pull request introduces several important changes to improve database file path validation and error handling in the `duckdb` and `sqlite` modules. The main updates include adding a function to ensure database file paths are within the current directory and updating error handling to reflect this validation.

### Path validation and error handling improvements:

* [`src/lib.rs`](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759R1-R2): Added a new function `check_path_within_current_directory` to validate that a file path is within the current directory. [[1]](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759R1-R2) [[2]](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759R16-R26)
* [`src/duckdb.rs`](diffhunk://#diff-8cad9ca6fa4359de0c86874a73b5a9741da9b7984c226eaf9258a27b49dd2559R1): Updated the `duckdb_file_path` method to use the new `check_path_within_current_directory` function and return an error if the path is not valid. Added a new error variant `FileNotInDirectory` to handle this case. [[1]](diffhunk://#diff-8cad9ca6fa4359de0c86874a73b5a9741da9b7984c226eaf9258a27b49dd2559R1) [[2]](diffhunk://#diff-8cad9ca6fa4359de0c86874a73b5a9741da9b7984c226eaf9258a27b49dd2559R117-R119) [[3]](diffhunk://#diff-8cad9ca6fa4359de0c86874a73b5a9741da9b7984c226eaf9258a27b49dd2559L151-R179) [[4]](diffhunk://#diff-8cad9ca6fa4359de0c86874a73b5a9741da9b7984c226eaf9258a27b49dd2559L253-R270)
* [`src/sqlite.rs`](diffhunk://#diff-4f492c8ea42c6c5f25952cbbab806b16fd77c0edfa2f414f7405ba0468201f34R1): Updated the `sqlite_file_path` method to use the new `check_path_within_current_directory` function and return an error if the path is not valid. Added a new error variant `FileNotInDirectory` to handle this case. [[1]](diffhunk://#diff-4f492c8ea42c6c5f25952cbbab806b16fd77c0edfa2f414f7405ba0468201f34R1) [[2]](diffhunk://#diff-4f492c8ea42c6c5f25952cbbab806b16fd77c0edfa2f414f7405ba0468201f34R106-R108) [[3]](diffhunk://#diff-4f492c8ea42c6c5f25952cbbab806b16fd77c0edfa2f414f7405ba0468201f34L136-R164) [[4]](diffhunk://#diff-4f492c8ea42c6c5f25952cbbab806b16fd77c0edfa2f414f7405ba0468201f34L248-R266)