### PR TITLE
feat: add duckdb checks for unsupported column types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ r2d2 = { version = "0.8.10", optional = true }
 rusqlite = { version = "0.31.0", optional = true }
 sea-query = { git = "https://github.com/spiceai/sea-query.git", rev = "213b6b876068f58159ebdd5852604a021afaebf9", features = ["backend-sqlite", "backend-postgres", "postgres-array", "with-rust_decimal", "with-bigdecimal", "with-time", "with-chrono"] }
 secrecy = "0.8.0"
-serde = { version = "1.0.209", optional = true }
+serde = "1.0.209"
 serde_json = "1.0.124"
 snafu = "0.8.3"
 time = "0.3.36"
@@ -92,13 +92,11 @@ flight = [
   "dep:datafusion-physical-plan",
   "dep:datafusion-proto",
   "dep:prost",
-  "dep:serde",
   "dep:tonic",
 ]
 duckdb-federation = ["duckdb"]
 sqlite-federation = ["sqlite"]
 postgres-federation = ["postgres"]
-default = ["dep:serde"]
 
 [patch.crates-io]
 datafusion-federation = { git = "https://github.com/spiceai/datafusion-federation.git", rev = "914bd0836baa6990c5d03f977e5e87fe5eeaf4d6" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ r2d2 = { version = "0.8.10", optional = true }
 rusqlite = { version = "0.31.0", optional = true }
 sea-query = { git = "https://github.com/spiceai/sea-query.git", rev = "213b6b876068f58159ebdd5852604a021afaebf9", features = ["backend-sqlite", "backend-postgres", "postgres-array", "with-rust_decimal", "with-bigdecimal", "with-time", "with-chrono"] }
 secrecy = "0.8.0"
-serde = "1.0.209"
+serde = { version = "1.0.209", features = ["derive"] }
 serde_json = "1.0.124"
 snafu = "0.8.3"
 time = "0.3.36"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,7 +80,7 @@ insta = { version = "1.40.0", features = ["filters"] }
 mysql = ["dep:mysql_async", "dep:async-stream"]
 postgres = ["dep:tokio-postgres", "dep:uuid", "dep:postgres-native-tls", "dep:bb8", "dep:bb8-postgres", "dep:native-tls", "dep:pem", "dep:async-stream"]
 sqlite = ["dep:rusqlite", "dep:tokio-rusqlite"]
-duckdb = ["dep:duckdb", "dep:r2d2", "dep:uuid", "dep:dyn-clone", "dep:async-stream"]
+duckdb = ["dep:duckdb", "dep:r2d2", "dep:uuid", "dep:dyn-clone", "dep:async-stream", "dep:arrow-schema"]
 flight = [
   "dep:arrow-array",
   "dep:arrow-flight",
@@ -98,6 +98,7 @@ flight = [
 duckdb-federation = ["duckdb"]
 sqlite-federation = ["sqlite"]
 postgres-federation = ["postgres"]
+default = ["dep:serde"]
 
 [patch.crates-io]
 datafusion-federation = { git = "https://github.com/spiceai/datafusion-federation.git", rev = "914bd0836baa6990c5d03f977e5e87fe5eeaf4d6" }

--- a/src/duckdb.rs
+++ b/src/duckdb.rs
@@ -194,7 +194,7 @@ impl DuckDBTableProviderFactory {
 
         let pool = DuckDbConnectionPool::new_memory()
             .context(DbConnectionPoolSnafu)?
-            .with_invalid_type_action(self.invalid_type_action.clone());
+            .with_invalid_type_action(self.invalid_type_action);
 
         instances.insert(key, pool.clone());
 
@@ -215,7 +215,7 @@ impl DuckDBTableProviderFactory {
 
         let pool = DuckDbConnectionPool::new_file(&db_path, &self.access_mode)
             .context(DbConnectionPoolSnafu)?
-            .with_invalid_type_action(self.invalid_type_action.clone());
+            .with_invalid_type_action(self.invalid_type_action);
 
         instances.insert(key, pool.clone());
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,9 +25,10 @@ pub enum Error {
     FileReadError { source: std::io::Error },
 }
 
-#[derive(PartialEq, Eq, Clone, Debug, Serialize, Deserialize)]
+#[derive(PartialEq, Eq, Clone, Copy, Default, Debug, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum InvalidTypeAction {
+    #[default]
     Error,
     Warn,
     Ignore,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+use serde::{Deserialize, Serialize};
 use snafu::prelude::*;
 
 pub mod sql;
@@ -22,4 +23,12 @@ pub enum Error {
     FileIsSymlink { path: String },
     #[snafu(display("Error reading file: {source}"))]
     FileReadError { source: std::io::Error },
+}
+
+#[derive(PartialEq, Eq, Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum InvalidTypeAction {
+    Error,
+    Warn,
+    Ignore,
 }

--- a/src/sql/db_connection_pool/dbconnection.rs
+++ b/src/sql/db_connection_pool/dbconnection.rs
@@ -1,5 +1,6 @@
 use std::{any::Any, sync::Arc};
 
+use arrow_schema::DataType;
 use datafusion::{
     arrow::datatypes::SchemaRef, execution::SendableRecordBatchStream, sql::TableReference,
 };
@@ -24,6 +25,12 @@ pub enum Error {
 
     #[snafu(display("Unable to get schema: {source}"))]
     UnableToGetSchema { source: GenericError },
+
+    #[snafu(display("The field '{field_name}' has an unsupported data type: {data_type}"))]
+    UnsupportedDataType {
+        data_type: DataType,
+        field_name: String,
+    },
 
     #[snafu(display("Unable to query arrow: {source}"))]
     UnableToQueryArrow { source: GenericError },

--- a/src/sql/db_connection_pool/dbconnection.rs
+++ b/src/sql/db_connection_pool/dbconnection.rs
@@ -1,6 +1,8 @@
 use std::{any::Any, sync::Arc};
 
+#[cfg(feature = "duckdb")]
 use arrow_schema::DataType;
+
 use datafusion::{
     arrow::datatypes::SchemaRef, execution::SendableRecordBatchStream, sql::TableReference,
 };
@@ -27,6 +29,7 @@ pub enum Error {
     UnableToGetSchema { source: GenericError },
 
     #[snafu(display("The field '{field_name}' has an unsupported data type: {data_type}"))]
+    #[cfg(feature = "duckdb")]
     UnsupportedDataType {
         data_type: DataType,
         field_name: String,

--- a/src/sql/db_connection_pool/duckdbpool.rs
+++ b/src/sql/db_connection_pool/duckdbpool.rs
@@ -7,9 +7,12 @@ use super::{
     dbconnection::duckdbconn::{DuckDBAttachments, DuckDBParameter},
     DbConnectionPool, Mode, Result,
 };
-use crate::sql::db_connection_pool::{
-    dbconnection::{duckdbconn::DuckDbConnection, DbConnection, SyncDbConnection},
-    JoinPushDown,
+use crate::{
+    sql::db_connection_pool::{
+        dbconnection::{duckdbconn::DuckDbConnection, DbConnection, SyncDbConnection},
+        JoinPushDown,
+    },
+    InvalidTypeAction,
 };
 
 #[derive(Debug, Snafu)]
@@ -40,6 +43,7 @@ pub struct DuckDbConnectionPool {
     join_push_down: JoinPushDown,
     attached_databases: Vec<Arc<str>>,
     mode: Mode,
+    invalid_type_action: InvalidTypeAction,
 }
 
 impl DuckDbConnectionPool {
@@ -75,6 +79,7 @@ impl DuckDbConnectionPool {
             join_push_down: JoinPushDown::AllowedFor(":memory:".to_string()),
             attached_databases: Vec::new(),
             mode: Mode::Memory,
+            invalid_type_action: InvalidTypeAction::Error,
         })
     }
 
@@ -113,7 +118,14 @@ impl DuckDbConnectionPool {
             join_push_down: JoinPushDown::AllowedFor(path.to_string()),
             attached_databases: Vec::new(),
             mode: Mode::File,
+            invalid_type_action: InvalidTypeAction::Error,
         })
+    }
+
+    #[must_use]
+    pub fn with_invalid_type_action(mut self, action: InvalidTypeAction) -> Self {
+        self.invalid_type_action = action;
+        self
     }
 
     #[must_use]
@@ -148,7 +160,9 @@ impl DuckDbConnectionPool {
         let attachments = self.get_attachments()?;
 
         Ok(Box::new(
-            DuckDbConnection::new(conn).with_attachments(attachments),
+            DuckDbConnection::new(conn)
+                .with_attachments(attachments)
+                .with_invalid_type_action(self.invalid_type_action.clone()),
         ))
     }
 
@@ -189,7 +203,9 @@ impl DbConnectionPool<r2d2::PooledConnection<DuckdbConnectionManager>, DuckDBPar
         let attachments = self.get_attachments()?;
 
         Ok(Box::new(
-            DuckDbConnection::new(conn).with_attachments(attachments),
+            DuckDbConnection::new(conn)
+                .with_attachments(attachments)
+                .with_invalid_type_action(self.invalid_type_action.clone()),
         ))
     }
 

--- a/src/sql/db_connection_pool/duckdbpool.rs
+++ b/src/sql/db_connection_pool/duckdbpool.rs
@@ -162,7 +162,7 @@ impl DuckDbConnectionPool {
         Ok(Box::new(
             DuckDbConnection::new(conn)
                 .with_attachments(attachments)
-                .with_invalid_type_action(self.invalid_type_action.clone()),
+                .with_invalid_type_action(self.invalid_type_action),
         ))
     }
 
@@ -205,7 +205,7 @@ impl DbConnectionPool<r2d2::PooledConnection<DuckdbConnectionManager>, DuckDBPar
         Ok(Box::new(
             DuckDbConnection::new(conn)
                 .with_attachments(attachments)
-                .with_invalid_type_action(self.invalid_type_action.clone()),
+                .with_invalid_type_action(self.invalid_type_action),
         ))
     }
 


### PR DESCRIPTION
## 🗣 Description

* Adds behavior for `get_schema()` in DuckDB connections to explicitly check for unsupported column data types.

This allows catching unsupported data types from tables before the query executes, which usually results in panics when the DuckDB arrow conversion attempts to convert the data instead of a result that can be handled.

* `InvalidTypeAction::Error` throws an error.
* `InvalidTypeAction::Warn` traces a warning, and excludes the column from the schema.
* `InvalidTypeAction::Ignore` silently excludes the column from the schema.