### PR TITLE
Fix `MySQLConnection::get_schema` for uppercase `TableReference`

### DIFF
--- a/src/sql/db_connection_pool/dbconnection/mysqlconn.rs
+++ b/src/sql/db_connection_pool/dbconnection/mysqlconn.rs
@@ -45,7 +45,7 @@ pub struct MySQLConnection {
 }
 
 impl MySQLConnection {
-    /// Create a [`TableReference`] in a manner that properly handles the unique quote style for MySQL.
+    /// Create a [`TableReference`] in a manner that properly handles the unique quote style of MySQL.
     ///
     /// [`TableReference::from`] uses `DefaultDialect` and therefore gets quoting incorrect.
     fn to_mysql_quoted_string(tbl: &TableReference) -> String {

--- a/src/sql/db_connection_pool/dbconnection/mysqlconn.rs
+++ b/src/sql/db_connection_pool/dbconnection/mysqlconn.rs
@@ -53,7 +53,13 @@ impl MySQLConnection {
         let tbl_name = [tbl.catalog(), tbl.schema(), Some(tbl.table())]
             .into_iter()
             .filter_map(|part| part)
-            .map(|part| format!("{quote}{part}{quote}", quote = q))
+            .map(|part| {
+                if part.starts_with(quote) && part.ends_with(quote) {
+                    part.to_string()
+                } else {
+                    format!("{quote}{part}{quote}", quote = q)
+                }
+            })
             .collect::<Vec<_>>()
             .join(".");
 

--- a/src/sql/db_connection_pool/dbconnection/mysqlconn.rs
+++ b/src/sql/db_connection_pool/dbconnection/mysqlconn.rs
@@ -55,7 +55,7 @@ impl MySQLConnection {
 
         [tbl.catalog(), tbl.schema(), Some(tbl.table())]
             .into_iter()
-            .filter_map(|part| part)
+            flatten()
             .map(|part| {
                 if part.starts_with(q) && part.ends_with(q) {
                     part.to_string()

--- a/src/sql/db_connection_pool/dbconnection/mysqlconn.rs
+++ b/src/sql/db_connection_pool/dbconnection/mysqlconn.rs
@@ -55,7 +55,7 @@ impl MySQLConnection {
 
         [tbl.catalog(), tbl.schema(), Some(tbl.table())]
             .into_iter()
-            flatten()
+            .flatten()
             .map(|part| {
                 if part.starts_with(q) && part.ends_with(q) {
                     part.to_string()


### PR DESCRIPTION
For MySQL servers with table names (or schema, catalogs), `get_schema` does not handle uppercases correctly.
 - `table_reference.to_quoted_string()` uses the `DefaultDialect` which has a different `identifier_quote_style` than `MySqlDialect`. 