### PR TITLE
fix: DuckDB boolean list support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,7 +100,7 @@ postgres-federation = ["postgres"]
 
 [patch.crates-io]
 datafusion-federation = { git = "https://github.com/spiceai/datafusion-federation.git", rev = "914bd0836baa6990c5d03f977e5e87fe5eeaf4d6" }
-duckdb = { git = "https://github.com/spiceai/duckdb-rs.git", rev = "5b98603705a381ceeb5cc371e4f606b7332b57ce" }
+duckdb = { git = "https://github.com/spiceai/duckdb-rs.git", rev = "6e7097758320a49f25f578dd54175145a4014582" }
 
 datafusion = { git = "https://github.com/spiceai/datafusion.git", rev = "06969ee5af853f0c071a98683dc2b9fde71b81a9"}
 datafusion-expr =  { git = "https://github.com/spiceai/datafusion.git", rev = "06969ee5af853f0c071a98683dc2b9fde71b81a9"}

--- a/src/sql/db_connection_pool/dbconnection/duckdbconn.rs
+++ b/src/sql/db_connection_pool/dbconnection/duckdbconn.rs
@@ -294,7 +294,7 @@ fn data_type_is_unsupported(data_type: &DataType) -> bool {
         | DataType::LargeList(inner_field) => {
             match inner_field.data_type() {
                 dt if dt.is_primitive() => false,
-                DataType::Utf8 | DataType::Binary => false,
+                DataType::Utf8 | DataType::Binary | DataType::Boolean => false,
                 _ => true, // nested lists don't support anything else yet
             }
         }


### PR DESCRIPTION
## 🗣 Description

* Adds `DataType::Boolean` to the list of supported bare DuckDB data types, which enables boolean list support