### PR TITLE
Use DuckDB Dialect and update Datafusion patch

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,8 +102,8 @@ postgres-federation = ["postgres"]
 datafusion-federation = { git = "https://github.com/spiceai/datafusion-federation.git", rev = "5af0df83c2cd1d3f82f293b066b401a4dfd4064b" }
 duckdb = { git = "https://github.com/spiceai/duckdb-rs.git", rev = "d6f8c3e0dc1ba073a86756eba4dacf044dfa892d" }
 
-datafusion = { git = "https://github.com/spiceai/datafusion.git", rev = "0bad328656a07fd5ab899186462b09e119e21f90"}
-datafusion-expr =  { git = "https://github.com/spiceai/datafusion.git", rev = "0bad328656a07fd5ab899186462b09e119e21f90"}
-datafusion-physical-expr =  { git = "https://github.com/spiceai/datafusion.git", rev = "0bad328656a07fd5ab899186462b09e119e21f90"}
-datafusion-physical-plan =  { git = "https://github.com/spiceai/datafusion.git", rev = "0bad328656a07fd5ab899186462b09e119e21f90"}
-datafusion-proto =  { git = "https://github.com/spiceai/datafusion.git", rev = "0bad328656a07fd5ab899186462b09e119e21f90"}
+datafusion = { git = "https://github.com/spiceai/datafusion.git", rev = "aaa46be22cff778e0e618b5eaeee3c2830d4e7ee"}
+datafusion-expr =  { git = "https://github.com/spiceai/datafusion.git", rev = "aaa46be22cff778e0e618b5eaeee3c2830d4e7ee"}
+datafusion-physical-expr =  { git = "https://github.com/spiceai/datafusion.git", rev = "aaa46be22cff778e0e618b5eaeee3c2830d4e7ee"}
+datafusion-physical-plan =  { git = "https://github.com/spiceai/datafusion.git", rev = "aaa46be22cff778e0e618b5eaeee3c2830d4e7ee"}
+datafusion-proto =  { git = "https://github.com/spiceai/datafusion.git", rev = "aaa46be22cff778e0e618b5eaeee3c2830d4e7ee"}

--- a/src/duckdb/sql_table.rs
+++ b/src/duckdb/sql_table.rs
@@ -20,7 +20,7 @@ use datafusion::{
         stream::RecordBatchStreamAdapter, DisplayAs, DisplayFormatType, ExecutionPlan,
         PlanProperties, SendableRecordBatchStream,
     },
-    sql::TableReference,
+    sql::{unparser::dialect::DuckDBDialect, TableReference},
 };
 
 pub struct DuckDBTable<T: 'static, P: 'static> {
@@ -51,7 +51,8 @@ impl<T, P> DuckDBTable<T, P> {
             schema,
             table_reference,
             Some(Engine::DuckDB),
-        );
+        )
+        .with_dialect(Arc::new(DuckDBDialect {}));
 
         Self {
             base_table,


### PR DESCRIPTION
- Use DuckDB Dialect for DuckDBTable
- Update Datafusion patch to include recent fixes for DuckDB unparsing: https://github.com/spiceai/datafusion/pull/64 and https://github.com/spiceai/datafusion/pull/59