### PR TITLE
Fix MySQL timestamp conversion when running via `MySQLSQLExec`

### DIFF
--- a/src/mysql/sql_table.rs
+++ b/src/mysql/sql_table.rs
@@ -1,4 +1,5 @@
 use crate::sql::db_connection_pool::DbConnectionPool;
+use crate::sql::sql_provider_datafusion::expr::Engine;
 use async_trait::async_trait;
 use datafusion::catalog::Session;
 use datafusion::sql::unparser::dialect::MySqlDialect;
@@ -123,7 +124,7 @@ impl<T, P> MySQLSQLExec<T, P> {
             pool,
             filters,
             limit,
-            None,
+            Some(Engine::MySQL),
         )?;
 
         Ok(Self { base_exec })

--- a/src/sql/sql_provider_datafusion/expr.rs
+++ b/src/sql/sql_provider_datafusion/expr.rs
@@ -113,7 +113,9 @@ pub fn to_sql_with_engine(expr: &Expr, engine: Option<Engine>) -> Result<String>
                         Ok(format!("TO_TIMESTAMP({})", *value as f64 / 1_000_000.0))
                     }
                 }
-                Some(Engine::MySQL) => Ok(format!("TIMESTAMP({})", value / 1_000_000)),
+                Some(Engine::MySQL) => {
+                    Ok(format!("FROM_UNIXTIME({})", *value as f64 / 1_000_000.0))
+                }
                 _ => Ok(format!("TO_TIMESTAMP({})", value / 1_000_000)),
             },
             ScalarValue::TimestampMillisecond(Some(value), timezone) => match engine {

--- a/src/sql/sql_provider_datafusion/expr.rs
+++ b/src/sql/sql_provider_datafusion/expr.rs
@@ -24,6 +24,7 @@ pub enum Engine {
     DuckDB,
     ODBC,
     Postgres,
+    MySQL,
 }
 
 #[allow(clippy::too_many_lines)]
@@ -112,6 +113,7 @@ pub fn to_sql_with_engine(expr: &Expr, engine: Option<Engine>) -> Result<String>
                         Ok(format!("TO_TIMESTAMP({})", *value as f64 / 1_000_000.0))
                     }
                 }
+                Some(Engine::MySQL) => Ok(format!("TIMESTAMP({})", value / 1_000_000)),
                 _ => Ok(format!("TO_TIMESTAMP({})", value / 1_000_000)),
             },
             ScalarValue::TimestampMillisecond(Some(value), timezone) => match engine {


### PR DESCRIPTION
Fix MySQL timestamp conversion:  it does not support `TO_TIMESTAMP(..)` and requires `FROM_UNIXTIME(..)`

This fixes error below when using append mode with MySQL data connector
>Unable to query arrow: Server error: `ERROR 42000 (1305): FUNCTION spice_demo.TO_TIMESTAMP does not exist'