### PR TITLE
Handle all MySQL Timestamp types as UTC time

### DIFF
--- a/src/sql/db_connection_pool/mysqlpool.rs
+++ b/src/sql/db_connection_pool/mysqlpool.rs
@@ -185,7 +185,14 @@ impl MySQLConnectionPool {
     /// Returns an error if there is a problem creating the connection pool.
     pub async fn connect_direct(&self) -> super::Result<MySQLConnection> {
         let pool = Arc::clone(&self.pool);
-        let conn = pool.get_conn().await.context(MySQLConnectionSnafu)?;
+        let mut conn = pool.get_conn().await.context(MySQLConnectionSnafu)?;
+
+        // Set MySQL server timezone to UTC and handle all MySQL timestamp types uniformly in UTC.
+        let _: Vec<Row> = conn
+            .exec("SET time_zone = '+00:00'", Params::Empty)
+            .await
+            .context(MySQLConnectionSnafu)?;
+
         Ok(MySQLConnection::new(conn))
     }
 }
@@ -244,7 +251,14 @@ impl DbConnectionPool<mysql_async::Conn, &'static (dyn ToValue + Sync)> for MySQ
     ) -> super::Result<Box<dyn DbConnection<mysql_async::Conn, &'static (dyn ToValue + Sync)>>>
     {
         let pool = Arc::clone(&self.pool);
-        let conn = pool.get_conn().await.context(MySQLConnectionSnafu)?;
+        let mut conn = pool.get_conn().await.context(MySQLConnectionSnafu)?;
+
+        // Set MySQL server timezone to UTC and handle all MySQL timestamp types uniformly in UTC.
+        let _: Vec<Row> = conn
+            .exec("SET time_zone = '+00:00'", Params::Empty)
+            .await
+            .context(MySQLConnectionSnafu)?;
+
         Ok(Box::new(MySQLConnection::new(conn)))
     }
 

--- a/src/sql/db_connection_pool/mysqlpool.rs
+++ b/src/sql/db_connection_pool/mysqlpool.rs
@@ -187,7 +187,7 @@ impl MySQLConnectionPool {
         let pool = Arc::clone(&self.pool);
         let mut conn = pool.get_conn().await.context(MySQLConnectionSnafu)?;
 
-        // Set MySQL server timezone to UTC and handle all MySQL timestamp types uniformly in UTC.
+        // Set MySQL session default time zone to UTC to match Datafusion
         let _: Vec<Row> = conn
             .exec("SET time_zone = '+00:00'", Params::Empty)
             .await
@@ -253,7 +253,7 @@ impl DbConnectionPool<mysql_async::Conn, &'static (dyn ToValue + Sync)> for MySQ
         let pool = Arc::clone(&self.pool);
         let mut conn = pool.get_conn().await.context(MySQLConnectionSnafu)?;
 
-        // Set MySQL server timezone to UTC and handle all MySQL timestamp types uniformly in UTC.
+        // Set MySQL session default time zone to UTC to match Datafusion
         let _: Vec<Row> = conn
             .exec("SET time_zone = '+00:00'", Params::Empty)
             .await


### PR DESCRIPTION
Handle all MySQL Timestamp as UTC time.

In MySQL, there's no `timestamp with time zone` type, and the retrieved value of `timestamp` type depends on the timezone per session, which depends on the default server timezone where the MySQL server is located in. https://dev.mysql.com/doc/refman/8.4/en/time-zone-support.html

![image](https://github.com/user-attachments/assets/d6b12e90-a469-492d-95bd-3b072643652a)

To avoid the confusion caused by the default timezone of server, which varies from machine to machine, this PR implement changes to always configure session timezone to UTC, and the timestamp value retrived from MySQL will always be in UTC time.