### PR TITLE
Fix MySQL errors

### DIFF
--- a/src/sql/db_connection_pool/dbconnection.rs
+++ b/src/sql/db_connection_pool/dbconnection.rs
@@ -28,7 +28,7 @@ pub enum Error {
     #[snafu(display("{source}"))]
     UnableToGetSchema { source: GenericError },
 
-    #[snafu(display("The field '{field_name}' has an unsupported data type: {data_type}.\n Please file an issue https://github.com/datafusion-contrib/datafusion-table-providers"))]
+    #[snafu(display("The field '{field_name}' has an unsupported data type: {data_type}.\nReport a bug to request support for this data type: https://github.com/datafusion-contrib/datafusion-table-providers/issues"))]
     #[cfg(feature = "duckdb")]
     UnsupportedDataType {
         data_type: DataType,

--- a/src/sql/db_connection_pool/dbconnection.rs
+++ b/src/sql/db_connection_pool/dbconnection.rs
@@ -28,7 +28,7 @@ pub enum Error {
     #[snafu(display("{source}"))]
     UnableToGetSchema { source: GenericError },
 
-    #[snafu(display("The field '{field_name}' has an unsupported data type: {data_type}"))]
+    #[snafu(display("The field '{field_name}' has an unsupported data type: {data_type}.\n Please file an issue https://github.com/datafusion-contrib/datafusion-table-providers"))]
     #[cfg(feature = "duckdb")]
     UnsupportedDataType {
         data_type: DataType,

--- a/src/sql/db_connection_pool/dbconnection.rs
+++ b/src/sql/db_connection_pool/dbconnection.rs
@@ -25,7 +25,7 @@ pub enum Error {
     #[snafu(display("Unable to downcast connection"))]
     UnableToDowncastConnection {},
 
-    #[snafu(display("Unable to get schema: {source}"))]
+    #[snafu(display("{source}"))]
     UnableToGetSchema { source: GenericError },
 
     #[snafu(display("The field '{field_name}' has an unsupported data type: {data_type}"))]

--- a/src/sql/db_connection_pool/dbconnection/mysqlconn.rs
+++ b/src/sql/db_connection_pool/dbconnection/mysqlconn.rs
@@ -27,7 +27,7 @@ pub enum Error {
     #[snafu(display("Failed to convert query result to Arrow: {source}.\nThis was likely caused by a bug in the DataFusion Table Providers code, which you can report here: https://github.com/datafusion-contrib/datafusion-table-providers/issues"))]
     ConversionError { source: arrow_sql_gen::mysql::Error },
 
-    #[snafu(display("Unable to get MySQL query result stream"))]
+    #[snafu(display("Unable to get MySQL query result stream.\nReport a bug to request support: https://github.com/datafusion-contrib/datafusion-table-providers/issues"))]
     QueryResultStreamError {},
 
     #[snafu(display("The field '{column_name}' has an unsupported data type: {data_type}.\nReport a bug to request support for this data type: https://github.com/datafusion-contrib/datafusion-table-providers/issues"))]

--- a/src/sql/db_connection_pool/dbconnection/mysqlconn.rs
+++ b/src/sql/db_connection_pool/dbconnection/mysqlconn.rs
@@ -39,7 +39,7 @@ pub enum Error {
     #[snafu(display("Unable to extract precision and scale from type: {data_type}. \n This was likely caused by a bug in DataFusion Table Providers code, please file an issue https://github.com/datafusion-contrib/datafusion-table-providers"))]
     UnableToGetDecimalPrecisionAndScale { data_type: String },
 
-    #[snafu(display("Field '{field}' is missing. \n This was likely caused by a bug in DataFusion Table Providers code, please file an issue https://github.com/datafusion-contrib/datafusion-table-providers"))]
+    #[snafu(display("Failed to find the field '{field}'.\nThis was likely caused by a bug in the DataFusion Table Providers code, which you can report here: https://github.com/datafusion-contrib/datafusion-table-providers/issues"))]
     MissingField { field: String },
 }
 

--- a/src/sql/db_connection_pool/dbconnection/mysqlconn.rs
+++ b/src/sql/db_connection_pool/dbconnection/mysqlconn.rs
@@ -21,7 +21,7 @@ use super::{AsyncDbConnection, DbConnection};
 
 #[derive(Debug, Snafu)]
 pub enum Error {
-    #[snafu(display("{source}"))]
+    #[snafu(display("{source}\nFor further information, refer to the MySQL manual: https://dev.mysql.com/doc/mysql-errors/9.1/en/error-reference-introduction.html"))]
     QueryError { source: mysql_async::Error },
 
     #[snafu(display("Failed to convert query result to Arrow: {source}"))]

--- a/src/sql/db_connection_pool/dbconnection/mysqlconn.rs
+++ b/src/sql/db_connection_pool/dbconnection/mysqlconn.rs
@@ -146,7 +146,6 @@ impl<'a> AsyncDbConnection<Conn, &'a (dyn ToValue + Sync)> for MySQLConnection {
         let params_vec: Vec<_> = params.iter().map(|&p| p.to_value()).collect();
         let sql = sql.replace('"', "");
 
-        println!("{:?}", sql);
         let conn = Arc::clone(&self.conn);
 
         let mut stream = Box::pin(stream! {

--- a/src/sql/db_connection_pool/dbconnection/mysqlconn.rs
+++ b/src/sql/db_connection_pool/dbconnection/mysqlconn.rs
@@ -24,7 +24,7 @@ pub enum Error {
     #[snafu(display("{source}\nFor further information, refer to the MySQL manual: https://dev.mysql.com/doc/mysql-errors/9.1/en/error-reference-introduction.html"))]
     QueryError { source: mysql_async::Error },
 
-    #[snafu(display("Failed to convert query result to Arrow: {source}"))]
+    #[snafu(display("Failed to convert query result to Arrow: {source}.\nThis was likely caused by a bug in the DataFusion Table Providers code, which you can report here: https://github.com/datafusion-contrib/datafusion-table-providers/issues"))]
     ConversionError { source: arrow_sql_gen::mysql::Error },
 
     #[snafu(display("Unable to get MySQL query result stream"))]

--- a/src/sql/db_connection_pool/dbconnection/mysqlconn.rs
+++ b/src/sql/db_connection_pool/dbconnection/mysqlconn.rs
@@ -30,16 +30,16 @@ pub enum Error {
     #[snafu(display("Unable to get MySQL query result stream"))]
     QueryResultStreamError {},
 
-    #[snafu(display("The field '{column_name}' contains unsupported data type: {data_type}"))]
+    #[snafu(display("The field '{column_name}' contains unsupported data type: {data_type}. \n Please file an issue https://github.com/datafusion-contrib/datafusion-table-providers"))]
     UnsupportedDataTypeError {
         column_name: String,
         data_type: String,
     },
 
-    #[snafu(display("Unable to extract precision and scale from type: {data_type}"))]
+    #[snafu(display("Unable to extract precision and scale from type: {data_type}. \n This was likely caused by a bug in DataFusion Table Providers code, please file an issue https://github.com/datafusion-contrib/datafusion-table-providers"))]
     UnableToGetDecimalPrecisionAndScale { data_type: String },
 
-    #[snafu(display("Field '{field}' is missing"))]
+    #[snafu(display("Field '{field}' is missing. \n This was likely caused by a bug in DataFusion Table Providers code, please file an issue https://github.com/datafusion-contrib/datafusion-table-providers"))]
     MissingField { field: String },
 }
 

--- a/src/sql/db_connection_pool/dbconnection/mysqlconn.rs
+++ b/src/sql/db_connection_pool/dbconnection/mysqlconn.rs
@@ -30,7 +30,7 @@ pub enum Error {
     #[snafu(display("Unable to get MySQL query result stream"))]
     QueryResultStreamError {},
 
-    #[snafu(display("The field '{column_name}' contains unsupported data type: {data_type}. \n Please file an issue https://github.com/datafusion-contrib/datafusion-table-providers"))]
+    #[snafu(display("The field '{column_name}' has an unsupported data type: {data_type}.\nReport a bug to request support for this data type: https://github.com/datafusion-contrib/datafusion-table-providers/issues"))]
     UnsupportedDataTypeError {
         column_name: String,
         data_type: String,

--- a/src/sql/db_connection_pool/dbconnection/mysqlconn.rs
+++ b/src/sql/db_connection_pool/dbconnection/mysqlconn.rs
@@ -36,7 +36,7 @@ pub enum Error {
         data_type: String,
     },
 
-    #[snafu(display("Unable to extract precision and scale from type: {data_type}. \n This was likely caused by a bug in DataFusion Table Providers code, please file an issue https://github.com/datafusion-contrib/datafusion-table-providers"))]
+    #[snafu(display("Unable to extract precision and scale from type: {data_type}.\nThis was likely caused by a bug in the DataFusion Table Providers code, which you can report here: https://github.com/datafusion-contrib/datafusion-table-providers/issues"))]
     UnableToGetDecimalPrecisionAndScale { data_type: String },
 
     #[snafu(display("Failed to find the field '{field}'.\nThis was likely caused by a bug in the DataFusion Table Providers code, which you can report here: https://github.com/datafusion-contrib/datafusion-table-providers/issues"))]

--- a/src/sql/db_connection_pool/mysqlpool.rs
+++ b/src/sql/db_connection_pool/mysqlpool.rs
@@ -22,16 +22,18 @@ pub type Result<T, E = Error> = std::result::Result<T, E>;
 
 #[derive(Debug, Snafu)]
 pub enum Error {
-    #[snafu(display("MySQL connection error: {source}"))]
+    #[snafu(display("MySQL connection error: {source}\nFor further information, refer to the MySQL manual: https://dev.mysql.com/doc/mysql-errors/9.1/en/error-reference-introduction.html"))]
     MySQLConnectionError { source: mysql_async::Error },
 
-    #[snafu(display("Invalid MySQL connection string: {source} "))]
+    #[snafu(display(
+        "Invalid MySQL connection string: {source}\nEnsure the MySQL connection string is valid"
+    ))]
     InvalidConnectionString { source: mysql_async::UrlError },
 
-    #[snafu(display("Invalid parameter: {parameter_name}"))]
+    #[snafu(display("Invalid value for parameter {parameter_name}\nEnsure the parameter value is valid for {parameter_name}"))]
     InvalidParameterError { parameter_name: String },
 
-    #[snafu(display("Invalid root cert path: {path}"))]
+    #[snafu(display("Invalid root cert path: {path}\nEnsure the root cert path is valid"))]
     InvalidRootCertPathError { path: String },
 
     #[snafu(display("Cannot connect to MySQL on {host}:{port}. Ensure that the host and port are correctly configured, and that the host is reachable."))]
@@ -46,7 +48,7 @@ pub enum Error {
     ))]
     InvalidUsernameOrPassword,
 
-    #[snafu(display("{message}"))]
+    #[snafu(display("{message}\nEnsure that the MySQL database name provided exists"))]
     UnknownMySQLDatabase { message: String },
 }
 


### PR DESCRIPTION
- Remove text message from `dbconnection::Error::UnableToGetSchema`. This error is widely used within the `get_schema` function itself, which really should just bubble up the internal error instead of wrapping duplicated `Unable to get schema:`, error message `Unable to get schema:` should be set and handled by caller of the `get_schema` function, for example, in `sql_provider_datafusion::Error`.
- Update the column type message to include column name information.
- Add file issue guide for catastrophic error caused by bugs in datafusion-table-providers, and bugs caused by things currently unsupported in the repo 
- Add MySQL manual reference for MySQL query errors

Besides changes for MySQL, this PR also include changes for instructing users to file an issue for DuckDB type related errors.

Before:
![image](https://github.com/user-attachments/assets/d50bdd92-1903-49cb-86e6-be12aebba94d)
After:
![image](https://github.com/user-attachments/assets/f6536335-b45c-4824-b553-85104aefb734)
