### PR TITLE
Update DuckDB Error messages

### DIFF
--- a/src/sql/db_connection_pool/dbconnection/duckdbconn.rs
+++ b/src/sql/db_connection_pool/dbconnection/duckdbconn.rs
@@ -27,20 +27,19 @@ use super::SyncDbConnection;
 
 #[derive(Debug, Snafu)]
 pub enum Error {
-    #[snafu(display("DuckDBError: {source}"))]
+    #[snafu(display("DuckDBError: {source}\nFor further information, refer to the DuckDB manual: https://duckdb.org/docs/"))]
     DuckDBError { source: duckdb::Error },
 
-    #[snafu(display("ChannelError: {message}"))]
+    #[snafu(display("ChannelError: {message}\nReport a bug to request support: https://github.com/datafusion-contrib/datafusion-table-providers/issues"))]
     ChannelError { message: String },
 
-    #[snafu(display("Unable to attach DuckDB database {path}: {source}"))]
+    #[snafu(display(
+        "Unable to attach DuckDB database {path}: {source}\nEnsure all DuckDB file path is valid"
+    ))]
     UnableToAttachDatabase {
         path: Arc<str>,
         source: std::io::Error,
     },
-
-    #[snafu(display("Unable to extract database name from database file path"))]
-    UnableToExtractDatabaseNameFromPath { path: Arc<str> },
 }
 
 pub trait DuckDBSyncParameter: ToSql + Sync + Send + DynClone {

--- a/src/sql/db_connection_pool/dbconnection/duckdbconn.rs
+++ b/src/sql/db_connection_pool/dbconnection/duckdbconn.rs
@@ -34,7 +34,7 @@ pub enum Error {
     ChannelError { message: String },
 
     #[snafu(display(
-        "Unable to attach DuckDB database {path}: {source}\nEnsure all DuckDB file path is valid"
+        "Unable to attach DuckDB database {path}: {source}\nEnsure the DuckDB file path is valid"
     ))]
     UnableToAttachDatabase {
         path: Arc<str>,

--- a/src/sql/db_connection_pool/dbconnection/duckdbconn.rs
+++ b/src/sql/db_connection_pool/dbconnection/duckdbconn.rs
@@ -30,7 +30,7 @@ pub enum Error {
     #[snafu(display("DuckDBError: {source}\nFor further information, refer to the DuckDB manual: https://duckdb.org/docs/"))]
     DuckDBError { source: duckdb::Error },
 
-    #[snafu(display("ChannelError: {message}\nReport a bug to request support: https://github.com/datafusion-contrib/datafusion-table-providers/issues"))]
+    #[snafu(display("An unexpected error occurred.\n{message}\nVerify the configuration, and try again."))]
     ChannelError { message: String },
 
     #[snafu(display(

--- a/src/sql/db_connection_pool/dbconnection/duckdbconn.rs
+++ b/src/sql/db_connection_pool/dbconnection/duckdbconn.rs
@@ -27,10 +27,10 @@ use super::SyncDbConnection;
 
 #[derive(Debug, Snafu)]
 pub enum Error {
-    #[snafu(display("DuckDB connection failed: {source}\nFor details, refer to the DuckDB manual: https://duckdb.org/docs/"))]
+    #[snafu(display("DuckDB connection failed.\n{source}\nFor details, refer to the DuckDB manual: https://duckdb.org/docs/"))]
     DuckDBConnectionError { source: duckdb::Error },
 
-    #[snafu(display("Query execution failed: {source}\nFor details, refer to the DuckDB manual: https://duckdb.org/docs/"))]
+    #[snafu(display("Query execution failed.\n{source}\nFor details, refer to the DuckDB manual: https://duckdb.org/docs/"))]
     DuckDBQueryError { source: duckdb::Error },
 
     #[snafu(display(
@@ -39,7 +39,7 @@ pub enum Error {
     ChannelError { message: String },
 
     #[snafu(display(
-        "Unable to attach DuckDB database {path}: {source}\nEnsure the DuckDB file path is valid."
+        "Unable to attach DuckDB database {path}.\n{source}\nEnsure the DuckDB file path is valid."
     ))]
     UnableToAttachDatabase {
         path: Arc<str>,

--- a/src/sql/db_connection_pool/dbconnection/duckdbconn.rs
+++ b/src/sql/db_connection_pool/dbconnection/duckdbconn.rs
@@ -27,19 +27,19 @@ use super::SyncDbConnection;
 
 #[derive(Debug, Snafu)]
 pub enum Error {
-    #[snafu(display("Failed to connect to DuckDB: {source}\nFor further information, refer to the DuckDB manual: https://duckdb.org/docs/"))]
+    #[snafu(display("Failed to connect to DuckDB: {source}\nFor details, refer to the DuckDB manual: https://duckdb.org/docs/"))]
     DuckDBConnectionError { source: duckdb::Error },
 
-    #[snafu(display("Failed to execute query: {source}\nFor further information, refer to the DuckDB manual: https://duckdb.org/docs/"))]
+    #[snafu(display("Query execution failed: {source}\nFor details, refer to the DuckDB manual: https://duckdb.org/docs/"))]
     DuckDBQueryError { source: duckdb::Error },
 
     #[snafu(display(
-        "An unexpected error occurred.\n{message}\nVerify the configuration, and try again."
+        "An unexpected error occurred.\n{message}\nVerify the configuration and try again."
     ))]
     ChannelError { message: String },
 
     #[snafu(display(
-        "Unable to attach DuckDB database {path}: {source}\nEnsure the DuckDB file path is valid"
+        "Unable to attach DuckDB database {path}: {source}\nEnsure the DuckDB file path is valid."
     ))]
     UnableToAttachDatabase {
         path: Arc<str>,

--- a/src/sql/db_connection_pool/dbconnection/duckdbconn.rs
+++ b/src/sql/db_connection_pool/dbconnection/duckdbconn.rs
@@ -27,7 +27,7 @@ use super::SyncDbConnection;
 
 #[derive(Debug, Snafu)]
 pub enum Error {
-    #[snafu(display("Failed to connect to DuckDB: {source}\nFor details, refer to the DuckDB manual: https://duckdb.org/docs/"))]
+    #[snafu(display("DuckDB connection failed: {source}\nFor details, refer to the DuckDB manual: https://duckdb.org/docs/"))]
     DuckDBConnectionError { source: duckdb::Error },
 
     #[snafu(display("Query execution failed: {source}\nFor details, refer to the DuckDB manual: https://duckdb.org/docs/"))]

--- a/src/sql/db_connection_pool/dbconnection/duckdbconn.rs
+++ b/src/sql/db_connection_pool/dbconnection/duckdbconn.rs
@@ -27,10 +27,15 @@ use super::SyncDbConnection;
 
 #[derive(Debug, Snafu)]
 pub enum Error {
-    #[snafu(display("DuckDBError: {source}\nFor further information, refer to the DuckDB manual: https://duckdb.org/docs/"))]
-    DuckDBError { source: duckdb::Error },
+    #[snafu(display("Failed to connect to DuckDB: {source}\nFor further information, refer to the DuckDB manual: https://duckdb.org/docs/"))]
+    DuckDBConnectionError { source: duckdb::Error },
 
-    #[snafu(display("An unexpected error occurred.\n{message}\nVerify the configuration, and try again."))]
+    #[snafu(display("Failed to execute query: {source}\nFor further information, refer to the DuckDB manual: https://duckdb.org/docs/"))]
+    DuckDBQueryError { source: duckdb::Error },
+
+    #[snafu(display(
+        "An unexpected error occurred.\n{message}\nVerify the configuration, and try again."
+    ))]
     ChannelError { message: String },
 
     #[snafu(display(
@@ -95,7 +100,7 @@ impl DuckDBAttachments {
     /// Returns an error if the search path cannot be set or the connection fails.
     pub fn set_search_path(&self, conn: &Connection) -> Result<()> {
         conn.execute(&format!("SET search_path ='{}'", self.search_path), [])
-            .context(DuckDBSnafu)?;
+            .context(DuckDBConnectionSnafu)?;
         Ok(())
     }
 
@@ -105,7 +110,8 @@ impl DuckDBAttachments {
     ///
     /// Returns an error if the search path cannot be set or the connection fails.
     pub fn reset_search_path(&self, conn: &Connection) -> Result<()> {
-        conn.execute("RESET search_path", []).context(DuckDBSnafu)?;
+        conn.execute("RESET search_path", [])
+            .context(DuckDBConnectionSnafu)?;
         Ok(())
     }
 
@@ -125,7 +131,7 @@ impl DuckDBAttachments {
                 &format!("ATTACH IF NOT EXISTS '{db}' AS attachment_{i} (READ_ONLY)"),
                 [],
             )
-            .context(DuckDBSnafu)?;
+            .context(DuckDBConnectionSnafu)?;
         }
 
         self.set_search_path(conn)?;
@@ -141,7 +147,7 @@ impl DuckDBAttachments {
     pub fn detach(&self, conn: &Connection) -> Result<()> {
         for (i, _) in self.attachments.iter().enumerate() {
             conn.execute(&format!("DETACH attachment_{i}"), [])
-                .context(DuckDBSnafu)?;
+                .context(DuckDBConnectionSnafu)?;
         }
 
         self.reset_search_path(conn)?;
@@ -374,14 +380,14 @@ impl SyncDbConnection<r2d2::PooledConnection<DuckdbConnectionManager>, DuckDBPar
 
         let join_handle = tokio::task::spawn_blocking(move || {
             Self::attach(&conn, &attachments)?; // this attach could happen when we clone the connection, but we can't detach after the thread closes because the connection isn't thread safe
-            let mut stmt = conn.prepare(&sql).context(DuckDBSnafu)?;
+            let mut stmt = conn.prepare(&sql).context(DuckDBQuerySnafu)?;
             let params: &[&dyn ToSql] = &params
                 .iter()
                 .map(|f| f.as_input_parameter())
                 .collect::<Vec<_>>();
             let result: duckdb::ArrowStream<'_> = stmt
                 .stream_arrow(params, cloned_schema)
-                .context(DuckDBSnafu)?;
+                .context(DuckDBQuerySnafu)?;
             for i in result {
                 blocking_channel_send(&batch_tx, i)?;
             }
@@ -422,7 +428,7 @@ impl SyncDbConnection<r2d2::PooledConnection<DuckdbConnectionManager>, DuckDBPar
             .map(|f| f.as_input_parameter())
             .collect::<Vec<_>>();
 
-        let rows_modified = self.conn.execute(sql, params).context(DuckDBSnafu)?;
+        let rows_modified = self.conn.execute(sql, params).context(DuckDBQuerySnafu)?;
         Ok(rows_modified as u64)
     }
 }

--- a/src/sql/db_connection_pool/duckdbpool.rs
+++ b/src/sql/db_connection_pool/duckdbpool.rs
@@ -17,11 +17,11 @@ use crate::{
 
 #[derive(Debug, Snafu)]
 pub enum Error {
-    #[snafu(display("DuckDB connection failed: {source}\nFor details, refer to the DuckDB manual: https://duckdb.org/docs/"))]
+    #[snafu(display("DuckDB connection failed.\n{source}\nFor details, refer to the DuckDB manual: https://duckdb.org/docs/"))]
     DuckDBConnectionError { source: duckdb::Error },
 
     #[snafu(display(
-        "DuckDB connection failed: {source}\nAdjust the DuckDB connection pool parameters for sufficient capacity."
+        "DuckDB connection failed.\n{source}\nAdjust the DuckDB connection pool parameters for sufficient capacity."
     ))]
     ConnectionPoolError { source: r2d2::Error },
 

--- a/src/sql/db_connection_pool/duckdbpool.rs
+++ b/src/sql/db_connection_pool/duckdbpool.rs
@@ -17,15 +17,17 @@ use crate::{
 
 #[derive(Debug, Snafu)]
 pub enum Error {
-    #[snafu(display("Failed to connect to DuckDB: {source}\nFor further information, refer to the DuckDB manual: https://duckdb.org/docs/"))]
+    #[snafu(display("Failed to connect to DuckDB: {source}\nFor details, refer to the DuckDB manual: https://duckdb.org/docs/"))]
     DuckDBConnectionError { source: duckdb::Error },
 
     #[snafu(display(
-        "Failed to connect to DuckDB: {source}\nAdjust the DuckDB connection pool parameters to ensure sufficient capacity for the workload"
+        "Failed to connect to DuckDB: {source}\nAdjust the DuckDB connection pool parameters for sufficient capacity."
     ))]
     ConnectionPoolError { source: r2d2::Error },
 
-    #[snafu(display("Unable to extract database name from database file path\nEnsure the DuckDB file path contains a valid database name"))]
+    #[snafu(display(
+        "Invalid DuckDB file path: {path}. Ensure it contains a valid database name."
+    ))]
     UnableToExtractDatabaseNameFromPath { path: Arc<str> },
 }
 

--- a/src/sql/db_connection_pool/duckdbpool.rs
+++ b/src/sql/db_connection_pool/duckdbpool.rs
@@ -17,11 +17,11 @@ use crate::{
 
 #[derive(Debug, Snafu)]
 pub enum Error {
-    #[snafu(display("DuckDBError: {source}\nFor further information, refer to the DuckDB manual: https://duckdb.org/docs/"))]
+    #[snafu(display("Failed to execute query: {source}\nFor further information, refer to the DuckDB manual: https://duckdb.org/docs/"))]
     DuckDBError { source: duckdb::Error },
 
     #[snafu(display(
-        "ConnectionPoolError: {source}\nAdjust the DuckDB connection pool parameters to ensure sufficient capacity for the workload"
+        "Failed to connect to DuckDB: {source}\nAdjust the DuckDB connection pool parameters to ensure sufficient capacity for the workload"
     ))]
     ConnectionPoolError { source: r2d2::Error },
 

--- a/src/sql/db_connection_pool/duckdbpool.rs
+++ b/src/sql/db_connection_pool/duckdbpool.rs
@@ -17,22 +17,18 @@ use crate::{
 
 #[derive(Debug, Snafu)]
 pub enum Error {
-    #[snafu(display("DuckDBError: {source}"))]
+    #[snafu(display("DuckDBError: {source}\nFor further information, refer to the DuckDB manual: https://duckdb.org/docs/"))]
     DuckDBError { source: duckdb::Error },
 
-    #[snafu(display("ConnectionPoolError: {source}"))]
+    #[snafu(display(
+        "ConnectionPoolError: {source}\nAdjust the DuckDB connection pool parameters to ensure sufficient capacity for the workload"
+    ))]
     ConnectionPoolError { source: r2d2::Error },
 
     #[snafu(display("Unable to connect to DuckDB: {source}"))]
     UnableToConnect { source: duckdb::Error },
 
-    #[snafu(display("Unable to attach DuckDB database {path}: {source}"))]
-    UnableToAttachDatabase {
-        path: Arc<str>,
-        source: std::io::Error,
-    },
-
-    #[snafu(display("Unable to extract database name from database file path"))]
+    #[snafu(display("Unable to extract database name from database file path\nEnsure the DuckDB file path contains a valid database name"))]
     UnableToExtractDatabaseNameFromPath { path: Arc<str> },
 }
 

--- a/src/sql/db_connection_pool/duckdbpool.rs
+++ b/src/sql/db_connection_pool/duckdbpool.rs
@@ -17,11 +17,11 @@ use crate::{
 
 #[derive(Debug, Snafu)]
 pub enum Error {
-    #[snafu(display("Failed to connect to DuckDB: {source}\nFor details, refer to the DuckDB manual: https://duckdb.org/docs/"))]
+    #[snafu(display("DuckDB connection failed: {source}\nFor details, refer to the DuckDB manual: https://duckdb.org/docs/"))]
     DuckDBConnectionError { source: duckdb::Error },
 
     #[snafu(display(
-        "Failed to connect to DuckDB: {source}\nAdjust the DuckDB connection pool parameters for sufficient capacity."
+        "DuckDB connection failed: {source}\nAdjust the DuckDB connection pool parameters for sufficient capacity."
     ))]
     ConnectionPoolError { source: r2d2::Error },
 


### PR DESCRIPTION
- Removed an unused error
- Separate the DuckDB Connection & Query error for clearer error messages
- Update DuckDB Error messages following the principles: https://github.com/spiceai/spiceai/blob/trunk/docs/dev/error_handling.md