### PR TITLE
Fix writing to a Postgres table with a schema

### DIFF
--- a/src/postgres.rs
+++ b/src/postgres.rs
@@ -121,6 +121,9 @@ pub enum Error {
 
     #[snafu(display("Error parsing on_conflict: {source}"))]
     UnableToParseOnConflict { source: on_conflict::Error },
+
+    #[snafu(display("Failed to create '{table_name}': creating a table with a schema is not supported"))]
+    TableWithSchemaCreationNotSupported { table_name: String },
 }
 
 type Result<T, E = Error> = std::result::Result<T, E>;
@@ -170,9 +173,8 @@ impl PostgresTableFactory {
         let read_provider = Self::table_provider(self, table_reference.clone()).await?;
         let schema = read_provider.schema();
 
-        let table_name = table_reference.to_string();
         let postgres = Postgres::new(
-            table_name,
+            table_reference,
             Arc::clone(&self.pool),
             schema,
             Constraints::empty(),
@@ -205,7 +207,15 @@ impl TableProviderFactory for PostgresTableProviderFactory {
         _state: &dyn Session,
         cmd: &CreateExternalTable,
     ) -> DataFusionResult<Arc<dyn TableProvider>> {
-        let name = cmd.name.to_string();
+
+        if cmd.name.schema().is_some() {
+            TableWithSchemaCreationNotSupportedSnafu {
+                table_name: cmd.name.to_string(),
+            }
+            .fail().map_err(to_datafusion_error)?;
+        }
+
+        let name = cmd.name.clone();
         let mut options = cmd.options.clone();
         let schema: Schema = cmd.schema.as_ref().into();
 
@@ -297,7 +307,7 @@ impl TableProviderFactory for PostgresTableProviderFactory {
                 "postgres",
                 &dyn_pool,
                 Arc::clone(&schema),
-                TableReference::bare(name.clone()),
+                name,
                 Some(Engine::Postgres),
             )
             .with_dialect(Arc::new(PostgreSqlDialect {})),
@@ -320,7 +330,7 @@ fn to_datafusion_error(error: Error) -> DataFusionError {
 
 #[derive(Clone)]
 pub struct Postgres {
-    table_name: String,
+    table: TableReference,
     pool: Arc<PostgresConnectionPool>,
     schema: SchemaRef,
     constraints: Constraints,
@@ -329,7 +339,7 @@ pub struct Postgres {
 impl std::fmt::Debug for Postgres {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("Postgres")
-            .field("table_name", &self.table_name)
+            .field("table_name", &self.table)
             .field("schema", &self.schema)
             .field("constraints", &self.constraints)
             .finish()
@@ -339,13 +349,13 @@ impl std::fmt::Debug for Postgres {
 impl Postgres {
     #[must_use]
     pub fn new(
-        table_name: String,
+        table: TableReference,
         pool: Arc<PostgresConnectionPool>,
         schema: SchemaRef,
         constraints: Constraints,
     ) -> Self {
         Self {
-            table_name,
+            table,
             pool,
             schema,
             constraints,
@@ -354,7 +364,7 @@ impl Postgres {
 
     #[must_use]
     pub fn table_name(&self) -> &str {
-        &self.table_name
+        self.table.table()
     }
 
     #[must_use]
@@ -369,7 +379,7 @@ impl Postgres {
 
         if !self.table_exists(pg_conn).await {
             TableDoesntExistSnafu {
-                table_name: self.table_name.clone(),
+                table_name: self.table.to_string(),
             }
             .fail()?;
         }
@@ -387,14 +397,18 @@ impl Postgres {
     }
 
     async fn table_exists(&self, postgres_conn: &PostgresConnection) -> bool {
-        let sql = format!(
-            r#"SELECT EXISTS (
-          SELECT 1
-          FROM information_schema.tables
-          WHERE table_name = '{name}'
-        )"#,
-            name = self.table_name
-        );
+        let sql = match self.table.schema() {
+            Some(schema) => format!(
+                r#"SELECT EXISTS (SELECT 1 FROM information_schema.tables WHERE table_name = '{name}' AND table_schema = '{schema}')"#,
+                name = self.table.table(),
+                schema = schema
+            ),
+            None => format!(
+                r#"SELECT EXISTS (SELECT 1 FROM information_schema.tables WHERE table_name = '{name}')"#,
+                name = self.table.table()
+            ),
+        };
+
         tracing::trace!("{sql}");
 
         let Ok(row) = postgres_conn.conn.query_one(&sql, &[]).await else {
@@ -410,7 +424,8 @@ impl Postgres {
         batch: RecordBatch,
         on_conflict: Option<OnConflict>,
     ) -> Result<()> {
-        let insert_table_builder = InsertBuilder::new(&self.table_name, vec![batch]);
+        let insert_table_builder =
+            InsertBuilder::new(&self.table, vec![batch]);
 
         let sea_query_on_conflict =
             on_conflict.map(|oc| oc.build_sea_query_on_conflict(&self.schema));
@@ -430,7 +445,7 @@ impl Postgres {
     async fn delete_all_table_data(&self, transaction: &Transaction<'_>) -> Result<()> {
         transaction
             .execute(
-                format!(r#"DELETE FROM "{}""#, self.table_name).as_str(),
+                format!(r#"DELETE FROM {}"#, self.table.to_quoted_string()).as_str(),
                 &[],
             )
             .await
@@ -445,8 +460,8 @@ impl Postgres {
         transaction: &Transaction<'_>,
         primary_keys: Vec<String>,
     ) -> Result<()> {
-        let create_table_statement =
-            CreateTableBuilder::new(schema, &self.table_name).primary_keys(primary_keys);
+        let create_table_statement = CreateTableBuilder::new(schema, self.table.table())
+            .primary_keys(primary_keys);
         let create_stmts = create_table_statement.build_postgres();
 
         for create_stmt in create_stmts {
@@ -465,7 +480,7 @@ impl Postgres {
         columns: Vec<&str>,
         unique: bool,
     ) -> Result<()> {
-        let mut index_builder = IndexBuilder::new(&self.table_name, columns);
+        let mut index_builder = IndexBuilder::new(self.table.table(), columns);
         if unique {
             index_builder = index_builder.unique();
         }

--- a/src/sqlite.rs
+++ b/src/sqlite.rs
@@ -102,6 +102,9 @@ pub enum Error {
         "Unable to parse SQLite busy_timeout parameter, ensure it is a valid duration"
     ))]
     UnableToParseBusyTimeoutParameter { source: fundu::ParseError },
+
+    #[snafu(display("Failed to create '{table_name}': creating a table with a schema is not supported"))]
+    TableWithSchemaCreationNotSupported { table_name: String },
 }
 
 type Result<T, E = Error> = std::result::Result<T, E>;
@@ -216,7 +219,15 @@ impl TableProviderFactory for SqliteTableProviderFactory {
         _state: &dyn Session,
         cmd: &CreateExternalTable,
     ) -> DataFusionResult<Arc<dyn TableProvider>> {
-        let name = cmd.name.to_string();
+
+        if cmd.name.schema().is_some() {
+            TableWithSchemaCreationNotSupportedSnafu {
+                table_name: cmd.name.to_string(),
+            }
+            .fail().map_err(to_datafusion_error)?;
+        }
+
+        let name = cmd.name.clone();
         let mut options = cmd.options.clone();
         let mode = options.remove("mode").unwrap_or_default();
         let mode: Mode = mode.as_str().into();
@@ -256,7 +267,7 @@ impl TableProviderFactory for SqliteTableProviderFactory {
             .sqlite_busy_timeout(&cmd.options)
             .map_err(to_datafusion_error)?;
         let db_path: Arc<str> = self
-            .sqlite_file_path(&name, &cmd.options)
+            .sqlite_file_path(name.table(), &cmd.options)
             .map_err(to_datafusion_error)?
             .into();
 
@@ -334,7 +345,7 @@ impl TableProviderFactory for SqliteTableProviderFactory {
         let read_provider = Arc::new(SQLiteTable::new_with_schema(
             &dyn_pool,
             Arc::clone(&schema),
-            TableReference::bare(name.clone()),
+            name,
         ));
 
         let sqlite = Arc::into_inner(sqlite)
@@ -392,7 +403,7 @@ fn to_datafusion_error(error: Error) -> DataFusionError {
 
 #[derive(Clone)]
 pub struct Sqlite {
-    table_name: String,
+    table: TableReference,
     schema: SchemaRef,
     pool: Arc<SqliteConnectionPool>,
     constraints: Constraints,
@@ -401,7 +412,7 @@ pub struct Sqlite {
 impl std::fmt::Debug for Sqlite {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("Sqlite")
-            .field("table_name", &self.table_name)
+            .field("table_name", &self.table)
             .field("schema", &self.schema)
             .field("constraints", &self.constraints)
             .finish()
@@ -411,13 +422,13 @@ impl std::fmt::Debug for Sqlite {
 impl Sqlite {
     #[must_use]
     pub fn new(
-        table_name: String,
+        table: TableReference,
         schema: SchemaRef,
         pool: Arc<SqliteConnectionPool>,
         constraints: Constraints,
     ) -> Self {
         Self {
-            table_name,
+            table,
             schema,
             pool,
             constraints,
@@ -426,7 +437,7 @@ impl Sqlite {
 
     #[must_use]
     pub fn table_name(&self) -> &str {
-        &self.table_name
+        self.table.table()
     }
 
     #[must_use]
@@ -457,7 +468,7 @@ impl Sqlite {
           WHERE type='table'
           AND name = '{name}'
         )"#,
-            name = self.table_name
+            name = self.table
         );
         tracing::trace!("{sql}");
 
@@ -478,7 +489,7 @@ impl Sqlite {
         batch: RecordBatch,
         on_conflict: Option<&OnConflict>,
     ) -> rusqlite::Result<()> {
-        let insert_table_builder = InsertBuilder::new(&self.table_name, vec![batch]);
+        let insert_table_builder = InsertBuilder::new(&self.table, vec![batch]);
 
         let sea_query_on_conflict =
             on_conflict.map(|oc| oc.build_sea_query_on_conflict(&self.schema));
@@ -493,7 +504,7 @@ impl Sqlite {
     }
 
     fn delete_all_table_data(&self, transaction: &Transaction<'_>) -> rusqlite::Result<()> {
-        transaction.execute(format!(r#"DELETE FROM "{}""#, self.table_name).as_str(), [])?;
+        transaction.execute(format!(r#"DELETE FROM {}"#, self.table.to_quoted_string()).as_str(), [])?;
 
         Ok(())
     }
@@ -504,7 +515,7 @@ impl Sqlite {
         primary_keys: Vec<String>,
     ) -> rusqlite::Result<()> {
         let create_table_statement =
-            CreateTableBuilder::new(Arc::clone(&self.schema), &self.table_name)
+            CreateTableBuilder::new(Arc::clone(&self.schema), self.table.table())
                 .primary_keys(primary_keys);
         let sql = create_table_statement.build_sqlite();
 
@@ -519,7 +530,7 @@ impl Sqlite {
         columns: Vec<&str>,
         unique: bool,
     ) -> rusqlite::Result<()> {
-        let mut index_builder = IndexBuilder::new(&self.table_name, columns);
+        let mut index_builder = IndexBuilder::new(self.table.table(), columns);
         if unique {
             index_builder = index_builder.unique();
         }
@@ -536,7 +547,7 @@ impl Sqlite {
     ) -> DataFusionResult<HashSet<String>> {
         let query_result = sqlite_conn
             .query_arrow(
-                format!("PRAGMA index_list({name})", name = self.table_name).as_str(),
+                format!("PRAGMA index_list({name})", name = self.table).as_str(),
                 &[],
                 None,
             )
@@ -572,7 +583,7 @@ impl Sqlite {
     ) -> DataFusionResult<HashSet<String>> {
         let query_result = sqlite_conn
             .query_arrow(
-                format!("PRAGMA table_info({name})", name = self.table_name).as_str(),
+                format!("PRAGMA table_info({name})", name = self.table).as_str(),
                 &[],
                 None,
             )
@@ -614,7 +625,7 @@ impl Sqlite {
     ) -> DataFusionResult<bool> {
         let expected_indexes_str_map: HashSet<String> = indexes
             .iter()
-            .map(|(col, _)| IndexBuilder::new(&self.table_name, col.iter().collect()).index_name())
+            .map(|(col, _)| IndexBuilder::new(self.table.table(), col.iter().collect()).index_name())
             .collect();
 
         let actual_indexes_str_map = self.get_indexes(sqlite_conn).await?;
@@ -630,14 +641,14 @@ impl Sqlite {
             tracing::warn!(
                 "Missing indexes detected for the table '{name}': {:?}.",
                 missing_in_actual,
-                name = self.table_name
+                name = self.table
             );
         }
         if !extra_in_actual.is_empty() {
             tracing::warn!(
                 "The table '{name}' contains unexpected indexes not presented in the configuration: {:?}.",
                 extra_in_actual,
-                name = self.table_name
+                name = self.table
             );
         }
 
@@ -664,14 +675,14 @@ impl Sqlite {
             tracing::warn!(
                 "Missing primary keys detected for the table '{name}': {:?}.",
                 missing_in_actual,
-                name = self.table_name
+                name = self.table
             );
         }
         if !extra_in_actual.is_empty() {
             tracing::warn!(
                 "The table '{name}' contains unexpected primary keys not presented in the configuration: {:?}.",
                 extra_in_actual,
-                name = self.table_name
+                name = self.table
             );
         }
 

--- a/tests/sqlite/mod.rs
+++ b/tests/sqlite/mod.rs
@@ -2,6 +2,7 @@ use crate::arrow_record_batch_gen::*;
 use arrow::array::RecordBatch;
 use arrow::datatypes::SchemaRef;
 use datafusion::execution::context::SessionContext;
+use datafusion::sql::TableReference;
 use datafusion_federation::schema_cast::record_convert::try_cast_to;
 use datafusion_table_providers::sql::arrow_sql_gen::statement::{
     CreateTableBuilder, InsertBuilder,
@@ -39,7 +40,7 @@ async fn arrow_sqlite_round_trip(
     // Create sqlite table from arrow records and insert arrow records
     let schema = Arc::clone(&arrow_record.schema());
     let create_table_stmts = CreateTableBuilder::new(schema, table_name).build_sqlite();
-    let insert_table_stmt = InsertBuilder::new(table_name, vec![arrow_record.clone()])
+    let insert_table_stmt = InsertBuilder::new(&TableReference::from(table_name), vec![arrow_record.clone()])
         .build_sqlite(None)
         .expect("SQLite insert statement should be constructed");
 


### PR DESCRIPTION
1. Fixes issues when writing to an existing Postgres table with a schema in name

>Error: "Tonic error: status: Internal, message: \"Error writing data: Unable to execute the table insert for table_name: External error: The table 'table_schema.table_name' doesn't exist in the Postgres server\

Includes `test_table_insertion_with_schema` unit test

1. Adds error when dataset creation is called for table name with schema part which is not properly supported

Postgres, SQLite, and DuckDB do not correctly handle table creation with a TableReference that includes a schema, instead converting the schema to be part of the table name. (SQLite does not natively support schemas, so passing a TableReference with a schema is invalid.) This can lead to unpredictable or unexpected behavior. Therefore, this PR adds verification for such cases and fails them. Users should explicitly convert a TableReference with a schema to a bare table name if the current behavior is desirable:
```
let table_name = TableReference::bare(table_name_with_schema.to_string());
<table creation>
``` 