### PR TITLE
DuckDB: support for nested types in Lists (Struct, List, FixedSizeList)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,7 +100,7 @@ postgres-federation = ["postgres"]
 
 [patch.crates-io]
 datafusion-federation = { git = "https://github.com/spiceai/datafusion-federation.git", rev = "5af0df83c2cd1d3f82f293b066b401a4dfd4064b" }
-duckdb = { git = "https://github.com/spiceai/duckdb-rs.git", rev = "d6f8c3e0dc1ba073a86756eba4dacf044dfa892d" }
+duckdb = { git = "https://github.com/spiceai/duckdb-rs.git", rev = "c7421f30d8ff2d39ed6df01a9ec51bc8781cfaae" }
 
 datafusion = { git = "https://github.com/spiceai/datafusion.git", rev = "37f0f144650db9e07a09c02fdbb69179438316be"}
 datafusion-expr =  { git = "https://github.com/spiceai/datafusion.git", rev = "37f0f144650db9e07a09c02fdbb69179438316be"}

--- a/tests/duckdb/mod.rs
+++ b/tests/duckdb/mod.rs
@@ -97,6 +97,12 @@ async fn arrow_duckdb_round_trip(
 #[case::duration(get_arrow_duration_record_batch(), "duration")]
 #[case::list(get_arrow_list_record_batch(), "list")]
 #[case::null(get_arrow_null_record_batch(), "null")]
+#[case::list_of_structs(get_arrow_list_of_structs_record_batch(), "list_of_structs")]
+#[case::list_of_fixed_size_lists(
+    get_arrow_list_of_fixed_size_lists_record_batch(),
+    "list_of_fixed_size_lists"
+)]
+#[case::list_of_lists(get_arrow_list_of_lists_record_batch(), "list_of_lists")]
 #[test_log::test(tokio::test)]
 async fn test_arrow_duckdb_roundtrip(
     #[case] arrow_result: (RecordBatch, SchemaRef),


### PR DESCRIPTION
Update duckdb-rs version to include [DuckDB: Add support for nested types in Lists (Struct, List, FixedSizeList)](https://github.com/spiceai/duckdb-rs/pull/11) and add tests for nested lists