### PR TITLE
Use random identifier in DuckDB attachment name

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ fallible-iterator = "0.3.0"
 futures = "0.3.30"
 mysql_async = { version = "0.34.1", features = ["native-tls-tls", "chrono"], optional = true }
 prost = { version = "0.13.2", optional = true }
+rand = "0.8.5"
 r2d2 = { version = "0.8.10", optional = true }
 rusqlite = { version = "0.31.0", optional = true }
 sea-query = { git = "https://github.com/spiceai/sea-query.git", rev = "213b6b876068f58159ebdd5852604a021afaebf9", features = ["backend-sqlite", "backend-postgres", "postgres-array", "with-rust_decimal", "with-bigdecimal", "with-time", "with-chrono"] }


### PR DESCRIPTION
This PR addresses a concurrency issue where multiple queries attempting to attach the same DuckDB database would fail with catalog write-write conflicts.

## Problem

When multiple queries run concurrently and each tries to attach a database using the same attachment name (e.g., "attachment_0"), they create separate transactions that attempt to modify DuckDB's catalog simultaneously. DuckDB enforces strict serialization of catalog modifications to maintain consistency, causing errors like:
`TransactionContext Error: Catalog write-write conflict on create with "attachment_0"`

Example of the failing scenario:
```shell
Query 1: BEGIN
Query 1: Check if attachment_0 exists (sees it doesn't exist)
Query 2: BEGIN
Query 2: Check if attachment_0 exists (sees it doesn't exist)
Query 1: Try to create attachment_0
Query 2: Try to create attachment_0 -> CONFLICT! Transaction 1's change is not visible in Transaction 2's snapshot
```

## Solution
Instead of having concurrent transactions compete to create the same attachment name, we now generate a unique identifier for each attachment. This means each transaction creates its own uniquely named attachment, avoiding catalog conflicts entirely.