### PR TITLE
fix: Don't silence disk full errors with SQLite

### DIFF
--- a/src/sqlite/write.rs
+++ b/src/sqlite/write.rs
@@ -215,7 +215,6 @@ impl DataSink for SqliteDataSink {
                     to_retriable_data_write_error(e)
                 }
             })?;
-        // .map_err(to_retriable_data_write_error)?;
 
         let num_rows = task.await.map_err(to_retriable_data_write_error)??;
 


### PR DESCRIPTION
# 🗣 Description

* SQLite incorrectly treats a disk full error as a retriable error. It is not retriable, so don't wrap it in a retriable error.