### PR TITLE
fix: Validate schema for SQLite connections

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,7 +80,7 @@ insta = { version = "1.40.0", features = ["filters"] }
 [features]
 mysql = ["dep:mysql_async", "dep:async-stream"]
 postgres = ["dep:tokio-postgres", "dep:uuid", "dep:postgres-native-tls", "dep:bb8", "dep:bb8-postgres", "dep:native-tls", "dep:pem", "dep:async-stream"]
-sqlite = ["dep:rusqlite", "dep:tokio-rusqlite"]
+sqlite = ["dep:rusqlite", "dep:tokio-rusqlite", "dep:arrow-schema"]
 duckdb = ["dep:duckdb", "dep:r2d2", "dep:uuid", "dep:dyn-clone", "dep:async-stream", "dep:arrow-schema"]
 flight = [
   "dep:arrow-array",

--- a/src/sql/db_connection_pool/dbconnection/duckdbconn.rs
+++ b/src/sql/db_connection_pool/dbconnection/duckdbconn.rs
@@ -2,7 +2,6 @@ use std::any::Any;
 use std::sync::Arc;
 
 use arrow::array::RecordBatch;
-use arrow_schema::{DataType, Fields, SchemaBuilder};
 use async_stream::stream;
 use datafusion::arrow::datatypes::SchemaRef;
 use datafusion::error::DataFusionError;
@@ -12,7 +11,6 @@ use datafusion::sql::sqlparser::ast::TableFactor;
 use datafusion::sql::sqlparser::parser::Parser;
 use datafusion::sql::sqlparser::{dialect::DuckDbDialect, tokenizer::Tokenizer};
 use datafusion::sql::TableReference;
-use duckdb::vtab::to_duckdb_type_id;
 use duckdb::ToSql;
 use duckdb::{Connection, DuckdbConnectionManager};
 use dyn_clone::DynClone;

--- a/src/sqlite.rs
+++ b/src/sqlite.rs
@@ -9,6 +9,8 @@ use crate::sql::db_connection_pool::{
     DbConnectionPool, Mode,
 };
 use crate::sql::sql_provider_datafusion;
+use crate::util::schema::SchemaValidator;
+use crate::InvalidTypeAction;
 use arrow::array::{Int64Array, StringArray};
 use arrow::{array::RecordBatch, datatypes::SchemaRef};
 use async_trait::async_trait;
@@ -103,7 +105,9 @@ pub enum Error {
     ))]
     UnableToParseBusyTimeoutParameter { source: fundu::ParseError },
 
-    #[snafu(display("Failed to create '{table_name}': creating a table with a schema is not supported"))]
+    #[snafu(display(
+        "Failed to create '{table_name}': creating a table with a schema is not supported"
+    ))]
     TableWithSchemaCreationNotSupported { table_name: String },
 }
 
@@ -219,12 +223,12 @@ impl TableProviderFactory for SqliteTableProviderFactory {
         _state: &dyn Session,
         cmd: &CreateExternalTable,
     ) -> DataFusionResult<Arc<dyn TableProvider>> {
-
         if cmd.name.schema().is_some() {
             TableWithSchemaCreationNotSupportedSnafu {
                 table_name: cmd.name.to_string(),
             }
-            .fail().map_err(to_datafusion_error)?;
+            .fail()
+            .map_err(to_datafusion_error)?;
         }
 
         let name = cmd.name.clone();
@@ -291,6 +295,10 @@ impl TableProviderFactory for SqliteTableProviderFactory {
         };
 
         let schema: SchemaRef = Arc::new(cmd.schema.as_ref().into());
+        let schema: SchemaRef =
+            SqliteConnection::handle_unsupported_schema(&schema, InvalidTypeAction::Error)
+                .map_err(|e| DataFusionError::External(e.into()))?;
+
         let sqlite = Arc::new(Sqlite::new(
             name.clone(),
             Arc::clone(&schema),
@@ -504,7 +512,10 @@ impl Sqlite {
     }
 
     fn delete_all_table_data(&self, transaction: &Transaction<'_>) -> rusqlite::Result<()> {
-        transaction.execute(format!(r#"DELETE FROM {}"#, self.table.to_quoted_string()).as_str(), [])?;
+        transaction.execute(
+            format!(r#"DELETE FROM {}"#, self.table.to_quoted_string()).as_str(),
+            [],
+        )?;
 
         Ok(())
     }
@@ -625,7 +636,9 @@ impl Sqlite {
     ) -> DataFusionResult<bool> {
         let expected_indexes_str_map: HashSet<String> = indexes
             .iter()
-            .map(|(col, _)| IndexBuilder::new(self.table.table(), col.iter().collect()).index_name())
+            .map(|(col, _)| {
+                IndexBuilder::new(self.table.table(), col.iter().collect()).index_name()
+            })
             .collect();
 
         let actual_indexes_str_map = self.get_indexes(sqlite_conn).await?;

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -14,6 +14,8 @@ pub mod indexes;
 pub mod ns_lookup;
 pub mod on_conflict;
 pub mod retriable_error;
+
+#[cfg(any(feature = "sqlite", feature = "duckdb"))]
 pub mod schema;
 pub mod secrets;
 pub mod test;

--- a/src/util/schema.rs
+++ b/src/util/schema.rs
@@ -119,7 +119,7 @@ impl SchemaValidator for SqliteConnection {
 
     fn is_data_type_valid(data_type: &DataType) -> bool {
         match data_type {
-            DataType::Dictionary(_, _) | DataType::Interval(_) => false,
+            DataType::Dictionary(_, _) | DataType::Interval(_) | DataType::Map(_, _) => false,
             DataType::List(inner_field)
             | DataType::FixedSizeList(inner_field, _)
             | DataType::LargeList(inner_field) => {

--- a/src/util/schema.rs
+++ b/src/util/schema.rs
@@ -1,18 +1,9 @@
 use std::sync::Arc;
 
 use super::handle_invalid_type_error;
-use crate::sql::db_connection_pool::dbconnection::Error as DbConnectionError;
 use crate::InvalidTypeAction;
 use arrow_schema::{DataType, Field, SchemaBuilder};
 use datafusion::arrow::datatypes::SchemaRef;
-
-#[cfg(feature = "sqlite")]
-use crate::sql::db_connection_pool::dbconnection::sqliteconn::SqliteConnection;
-
-#[cfg(feature = "duckdb")]
-use crate::sql::db_connection_pool::dbconnection::duckdbconn::DuckDbConnection;
-#[cfg(feature = "duckdb")]
-use duckdb::vtab::to_duckdb_type_id;
 
 type GenericError = Box<dyn std::error::Error + Send + Sync>;
 type Result<T, E = GenericError> = std::result::Result<T, E>;
@@ -59,79 +50,5 @@ pub trait SchemaValidator {
         }
 
         Ok(Arc::new(schema_builder.finish()))
-    }
-}
-
-#[cfg(feature = "duckdb")]
-impl SchemaValidator for DuckDbConnection {
-    type Error = DbConnectionError;
-
-    fn is_data_type_valid(data_type: &DataType) -> bool {
-        match data_type {
-            DataType::List(inner_field)
-            | DataType::FixedSizeList(inner_field, _)
-            | DataType::LargeList(inner_field) => {
-                match inner_field.data_type() {
-                    dt if dt.is_primitive() => true,
-                    DataType::Utf8
-                    | DataType::Binary
-                    | DataType::Utf8View
-                    | DataType::BinaryView
-                    | DataType::Boolean => true,
-                    _ => false, // nested lists don't support anything else yet
-                }
-            }
-            DataType::Struct(inner_fields) => inner_fields
-                .iter()
-                .all(|field| Self::is_data_type_valid(field.data_type())),
-            _ => true,
-        }
-    }
-
-    fn is_field_valid(field: &Arc<Field>) -> bool {
-        let duckdb_type_id = to_duckdb_type_id(field.data_type());
-        Self::is_data_type_valid(field.data_type()) && duckdb_type_id.is_ok()
-    }
-
-    fn invalid_type_error(data_type: &DataType, field_name: &str) -> Self::Error {
-        DbConnectionError::UnsupportedDataType {
-            data_type: data_type.to_string(),
-            field_name: field_name.to_string(),
-        }
-    }
-}
-
-#[cfg(feature = "sqlite")]
-impl SchemaValidator for SqliteConnection {
-    type Error = DbConnectionError;
-
-    fn is_data_type_valid(data_type: &DataType) -> bool {
-        match data_type {
-            DataType::Dictionary(_, _) | DataType::Interval(_) | DataType::Map(_, _) => false,
-            DataType::List(inner_field)
-            | DataType::FixedSizeList(inner_field, _)
-            | DataType::LargeList(inner_field) => {
-                match inner_field.data_type() {
-                    dt if dt.is_primitive() => true,
-                    DataType::Utf8
-                    | DataType::Binary
-                    | DataType::Utf8View
-                    | DataType::BinaryView
-                    | DataType::Boolean => true,
-                    _ => false, // nested lists don't support anything else yet
-                }
-            }
-            DataType::Struct(inner_fields) => inner_fields
-                .iter()
-                .all(|field| Self::is_data_type_valid(field.data_type())),
-            _ => true,
-        }
-    }
-
-    fn invalid_type_error(data_type: &DataType, field_name: &str) -> Self::Error {
-        DbConnectionError::UnsupportedDataType {
-            data_type: data_type.to_string(),
-            field_name: field_name.to_string(),
-        }
     }
 }

--- a/src/util/schema.rs
+++ b/src/util/schema.rs
@@ -119,8 +119,7 @@ impl SchemaValidator for SqliteConnection {
 
     fn is_data_type_valid(data_type: &DataType) -> bool {
         match data_type {
-            DataType::Interval(_) => false,
-            DataType::Dictionary(_, _) => false,
+            DataType::Dictionary(_, _) | DataType::Interval(_) => false,
             DataType::List(inner_field)
             | DataType::FixedSizeList(inner_field, _)
             | DataType::LargeList(inner_field) => {

--- a/src/util/schema.rs
+++ b/src/util/schema.rs
@@ -3,7 +3,6 @@ use std::sync::Arc;
 use super::handle_invalid_type_error;
 use crate::sql::db_connection_pool::dbconnection::Error as DbConnectionError;
 use crate::InvalidTypeAction;
-#[cfg(any(feature = "sqlite", feature = "duckdb"))]
 use arrow_schema::{DataType, Field, SchemaBuilder};
 use datafusion::arrow::datatypes::SchemaRef;
 

--- a/src/util/schema.rs
+++ b/src/util/schema.rs
@@ -1,0 +1,149 @@
+use std::any::Any;
+use std::sync::Arc;
+
+use crate::sql::db_connection_pool::dbconnection::sqliteconn::SqliteConnection;
+use crate::sql::db_connection_pool::dbconnection::Error as DbConnectionError;
+use arrow::array::RecordBatch;
+use arrow_schema::{DataType, Field, Fields, SchemaBuilder};
+use async_stream::stream;
+use datafusion::arrow::datatypes::SchemaRef;
+use datafusion::error::DataFusionError;
+use datafusion::execution::SendableRecordBatchStream;
+use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
+use datafusion::sql::sqlparser::ast::TableFactor;
+use datafusion::sql::sqlparser::parser::Parser;
+use datafusion::sql::sqlparser::{dialect::DuckDbDialect, tokenizer::Tokenizer};
+use datafusion::sql::TableReference;
+
+#[cfg(feature = "duckdb")]
+use duckdb::vtab::to_duckdb_type_id;
+
+#[cfg(feature = "duckdb")]
+use crate::sql::db_connection_pool::dbconnection::duckdbconn::DuckDbConnection;
+
+use crate::duckdb::DuckDBTableFactory;
+use crate::InvalidTypeAction;
+
+use super::handle_invalid_type_error;
+
+type GenericError = Box<dyn std::error::Error + Send + Sync>;
+type Result<T, E = GenericError> = std::result::Result<T, E>;
+
+pub trait SchemaValidator {
+    type Error: std::error::Error + Send + Sync;
+
+    #[must_use]
+    fn is_field_valid(field: &Arc<Field>) -> bool {
+        Self::is_data_type_valid(field.data_type())
+    }
+
+    #[must_use]
+    fn is_schema_valid(schema: &SchemaRef) -> bool {
+        schema.fields.iter().all(Self::is_field_valid)
+    }
+
+    fn is_data_type_valid(data_type: &DataType) -> bool;
+    fn invalid_type_error(data_type: &DataType, field_name: &str) -> Self::Error;
+
+    /// For a given input schema, rebuild it according to the `InvalidTypeAction`.
+    /// Implemented for a specific connection type, that connection determines which types it supports.
+    /// If the `InvalidTypeAction` is `Error`, the function will return an error if the schema contains an unsupported data type.
+    /// If the `InvalidTypeAction` is `Warn`, the function will log a warning if the schema contains an unsupported data type and remove the column.
+    /// If the `InvalidTypeAction` is `Ignore`, the function will remove the column silently.
+    ///
+    /// # Errors
+    ///
+    /// If the `InvalidTypeAction` is `Error` and the schema contains an unsupported data type, the function will return an error.
+    fn handle_unsupported_schema(
+        schema: &SchemaRef,
+        invalid_type_action: InvalidTypeAction,
+    ) -> Result<SchemaRef, Self::Error> {
+        let mut schema_builder = SchemaBuilder::new();
+        for field in &schema.fields {
+            if Self::is_field_valid(field) {
+                schema_builder.push(Arc::clone(field));
+            } else {
+                handle_invalid_type_error(
+                    invalid_type_action,
+                    Self::invalid_type_error(field.data_type(), field.name()),
+                )?;
+            }
+        }
+
+        Ok(Arc::new(schema_builder.finish()))
+    }
+}
+
+#[cfg(feature = "duckdb")]
+impl SchemaValidator for DuckDbConnection {
+    type Error = DbConnectionError;
+
+    fn is_data_type_valid(data_type: &DataType) -> bool {
+        match data_type {
+            DataType::List(inner_field)
+            | DataType::FixedSizeList(inner_field, _)
+            | DataType::LargeList(inner_field) => {
+                match inner_field.data_type() {
+                    dt if dt.is_primitive() => true,
+                    DataType::Utf8
+                    | DataType::Binary
+                    | DataType::Utf8View
+                    | DataType::BinaryView
+                    | DataType::Boolean => true,
+                    _ => false, // nested lists don't support anything else yet
+                }
+            }
+            DataType::Struct(inner_fields) => inner_fields
+                .iter()
+                .all(|field| Self::is_data_type_valid(field.data_type())),
+            _ => true,
+        }
+    }
+
+    fn is_field_valid(field: &Arc<Field>) -> bool {
+        let duckdb_type_id = to_duckdb_type_id(field.data_type());
+        Self::is_data_type_valid(field.data_type()) && duckdb_type_id.is_ok()
+    }
+
+    fn invalid_type_error(data_type: &DataType, field_name: &str) -> Self::Error {
+        DbConnectionError::UnsupportedDataType {
+            data_type: data_type.to_string(),
+            field_name: field_name.to_string(),
+        }
+    }
+}
+
+#[cfg(feature = "sqlite")]
+impl SchemaValidator for SqliteConnection {
+    type Error = DbConnectionError;
+
+    fn is_data_type_valid(data_type: &DataType) -> bool {
+        match data_type {
+            DataType::Interval(_) => false,
+            DataType::List(inner_field)
+            | DataType::FixedSizeList(inner_field, _)
+            | DataType::LargeList(inner_field) => {
+                match inner_field.data_type() {
+                    dt if dt.is_primitive() => true,
+                    DataType::Utf8
+                    | DataType::Binary
+                    | DataType::Utf8View
+                    | DataType::BinaryView
+                    | DataType::Boolean => true,
+                    _ => false, // nested lists don't support anything else yet
+                }
+            }
+            DataType::Struct(inner_fields) => inner_fields
+                .iter()
+                .all(|field| Self::is_data_type_valid(field.data_type())),
+            _ => true,
+        }
+    }
+
+    fn invalid_type_error(data_type: &DataType, field_name: &str) -> Self::Error {
+        DbConnectionError::UnsupportedDataType {
+            data_type: data_type.to_string(),
+            field_name: field_name.to_string(),
+        }
+    }
+}

--- a/src/util/schema.rs
+++ b/src/util/schema.rs
@@ -1,30 +1,18 @@
-use std::any::Any;
 use std::sync::Arc;
 
-use crate::sql::db_connection_pool::dbconnection::sqliteconn::SqliteConnection;
+use super::handle_invalid_type_error;
 use crate::sql::db_connection_pool::dbconnection::Error as DbConnectionError;
-use arrow::array::RecordBatch;
-use arrow_schema::{DataType, Field, Fields, SchemaBuilder};
-use async_stream::stream;
+use crate::InvalidTypeAction;
+use arrow_schema::{DataType, Field, SchemaBuilder};
 use datafusion::arrow::datatypes::SchemaRef;
-use datafusion::error::DataFusionError;
-use datafusion::execution::SendableRecordBatchStream;
-use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
-use datafusion::sql::sqlparser::ast::TableFactor;
-use datafusion::sql::sqlparser::parser::Parser;
-use datafusion::sql::sqlparser::{dialect::DuckDbDialect, tokenizer::Tokenizer};
-use datafusion::sql::TableReference;
 
-#[cfg(feature = "duckdb")]
-use duckdb::vtab::to_duckdb_type_id;
+#[cfg(feature = "sqlite")]
+use crate::sql::db_connection_pool::dbconnection::sqliteconn::SqliteConnection;
 
 #[cfg(feature = "duckdb")]
 use crate::sql::db_connection_pool::dbconnection::duckdbconn::DuckDbConnection;
-
-use crate::duckdb::DuckDBTableFactory;
-use crate::InvalidTypeAction;
-
-use super::handle_invalid_type_error;
+#[cfg(feature = "duckdb")]
+use duckdb::vtab::to_duckdb_type_id;
 
 type GenericError = Box<dyn std::error::Error + Send + Sync>;
 type Result<T, E = GenericError> = std::result::Result<T, E>;

--- a/src/util/schema.rs
+++ b/src/util/schema.rs
@@ -120,6 +120,7 @@ impl SchemaValidator for SqliteConnection {
     fn is_data_type_valid(data_type: &DataType) -> bool {
         match data_type {
             DataType::Interval(_) => false,
+            DataType::Dictionary(_, _) => false,
             DataType::List(inner_field)
             | DataType::FixedSizeList(inner_field, _)
             | DataType::LargeList(inner_field) => {

--- a/src/util/schema.rs
+++ b/src/util/schema.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use super::handle_invalid_type_error;
 use crate::sql::db_connection_pool::dbconnection::Error as DbConnectionError;
 use crate::InvalidTypeAction;
+#[cfg(any(feature = "sqlite", feature = "duckdb"))]
 use arrow_schema::{DataType, Field, SchemaBuilder};
 use datafusion::arrow::datatypes::SchemaRef;
 


### PR DESCRIPTION
# 🗣 Description

* Updates schema validation to use a new `SchemaValidator` trait, wrapping some helpers into common trait functions
* Updates the schema validation for DuckDB to use the new `SchemaValidator` pattern
* Creates a `SchemaValidator` for SQLite connections