### PR TITLE
fix: Don't panic on unsupported data insert with Postgres

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,7 +79,7 @@ insta = { version = "1.40.0", features = ["filters"] }
 
 [features]
 mysql = ["dep:mysql_async", "dep:async-stream"]
-postgres = ["dep:tokio-postgres", "dep:uuid", "dep:postgres-native-tls", "dep:bb8", "dep:bb8-postgres", "dep:native-tls", "dep:pem", "dep:async-stream"]
+postgres = ["dep:tokio-postgres", "dep:uuid", "dep:postgres-native-tls", "dep:bb8", "dep:bb8-postgres", "dep:native-tls", "dep:pem", "dep:async-stream", "dep:arrow-schema"]
 sqlite = ["dep:rusqlite", "dep:tokio-rusqlite", "dep:arrow-schema"]
 duckdb = ["dep:duckdb", "dep:r2d2", "dep:uuid", "dep:dyn-clone", "dep:async-stream", "dep:arrow-schema"]
 flight = [

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -15,7 +15,7 @@ pub mod ns_lookup;
 pub mod on_conflict;
 pub mod retriable_error;
 
-#[cfg(any(feature = "sqlite", feature = "duckdb"))]
+#[cfg(any(feature = "sqlite", feature = "duckdb", feature = "postgres"))]
 pub mod schema;
 pub mod secrets;
 pub mod test;


### PR DESCRIPTION
# 🗣 Description

* Adds a `SchemaValidator` implementation for `PostgresConnection`, used during `TableFactory` creation time to validate the incoming schema.

Although Postgres already had a schema validation in `.get_schema()`, this only runs during queries not during inserts. This then allows panics to throw from trying to insert a type that is not supported.