### PR TITLE
fix: Use Unparser for expr to sql

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -82,7 +82,7 @@ jobs:
             google-cloud-sdk imagemagick \
             libmagickcore-dev libmagickwand-dev libmagic-dev ant ant-optional kubectl \
             mercurial apt-transport-https mono-complete libmysqlclient \
-            unixodbc-dev yarn chrpath libssl-dev libxft-dev \
+            yarn chrpath libssl-dev libxft-dev \
             libfreetype6 libfreetype6-dev libfontconfig1 libfontconfig1-dev \
             snmp pollinate libpq-dev postgresql-client powershell ruby-full \
             sphinxsearch subversion mongodb-org azure-cli microsoft-edge-stable \
@@ -96,6 +96,11 @@ jobs:
           sudo apt-get autoclean -y >/dev/null 2>&1
           echo "some packages purged"
           df -h
+
+      - name: Install ODBC & Sqlite
+        run: |
+          sudo apt-get install -y unixodbc-dev
+          sudo apt-get install -y libsqlite3-dev
 
       - name: Run tests
         run: make test

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -56,7 +56,7 @@ jobs:
 
     env:
       PG_DOCKER_IMAGE: ghcr.io/cloudnative-pg/postgresql:16-bookworm
-      MYSQL_DOCKER_IMAGE: ghcr.io/mirrorshub/docker/mysql:8-debian
+      MYSQL_DOCKER_IMAGE: public.ecr.aws/ubuntu/mysql:8.0-22.04_beta
 
     steps:
       - uses: actions/checkout@v4

--- a/src/duckdb/sql_table.rs
+++ b/src/duckdb/sql_table.rs
@@ -153,6 +153,7 @@ impl<T, P> DuckSqlExec<T, P> {
 
     fn sql(&self) -> SqlResult<String> {
         let sql = self.base_exec.sql()?;
+
         Ok(format!(
             "{cte_expr} {sql}",
             cte_expr = get_cte(&self.table_functions)

--- a/src/sql/sql_provider_datafusion/expr.rs
+++ b/src/sql/sql_provider_datafusion/expr.rs
@@ -1,7 +1,12 @@
+use std::sync::Arc;
+
 use bigdecimal::{num_bigint::BigInt, BigDecimal};
 use datafusion::{
     logical_expr::{Cast, Expr},
     scalar::ScalarValue,
+    sql::unparser::dialect::{
+        DefaultDialect, Dialect, MySqlDialect, PostgreSqlDialect, SqliteDialect,
+    },
 };
 
 pub const SECONDS_IN_DAY: i32 = 86_400;
@@ -25,6 +30,18 @@ pub enum Engine {
     ODBC,
     Postgres,
     MySQL,
+}
+
+impl Engine {
+    /// Get the corresponding `Dialect` to use for unparsing
+    pub fn dialect(&self) -> Arc<dyn Dialect + Send + Sync> {
+        match self {
+            Engine::SQLite => Arc::new(SqliteDialect {}),
+            Engine::Postgres => Arc::new(PostgreSqlDialect {}),
+            Engine::MySQL => Arc::new(MySqlDialect {}),
+            Engine::Spark | Engine::DuckDB | Engine::ODBC => Arc::new(DefaultDialect {}),
+        }
+    }
 }
 
 #[allow(clippy::too_many_lines)]
@@ -233,6 +250,16 @@ fn handle_cast(cast: &Cast, engine: Option<Engine>, expr: &Expr) -> Result<Strin
             .fail()?,
             _ => Ok(format!(
                 "CAST({} AS TIMESTAMPTZ)",
+                to_sql_with_engine(&cast.expr, engine)?,
+            )),
+        },
+        arrow::datatypes::DataType::Int64 => match engine {
+            Some(Engine::DuckDB | Engine::SQLite | Engine::Postgres) => Ok(format!(
+                "CAST({} AS BIGINT)",
+                to_sql_with_engine(&cast.expr, engine)?,
+            )),
+            _ => Ok(format!(
+                "CAST({} AS INT64)",
                 to_sql_with_engine(&cast.expr, engine)?,
             )),
         },

--- a/src/sql/sql_provider_datafusion/expr.rs
+++ b/src/sql/sql_provider_datafusion/expr.rs
@@ -253,16 +253,10 @@ fn handle_cast(cast: &Cast, engine: Option<Engine>, expr: &Expr) -> Result<Strin
                 to_sql_with_engine(&cast.expr, engine)?,
             )),
         },
-        arrow::datatypes::DataType::Int64 => match engine {
-            Some(Engine::DuckDB | Engine::SQLite | Engine::Postgres) => Ok(format!(
-                "CAST({} AS BIGINT)",
-                to_sql_with_engine(&cast.expr, engine)?,
-            )),
-            _ => Ok(format!(
-                "CAST({} AS INT64)",
-                to_sql_with_engine(&cast.expr, engine)?,
-            )),
-        },
+        arrow::datatypes::DataType::Int64 => Ok(format!(
+            "CAST({} AS BIGINT)",
+            to_sql_with_engine(&cast.expr, engine)?,
+        )),
         _ => Err(Error::UnsupportedFilterExpr {
             expr: format!("{expr}"),
         }),

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -6,10 +6,7 @@ use snafu::prelude::*;
 use std::hash::Hash;
 use std::{collections::HashMap, sync::Arc};
 
-use crate::{
-    sql::sql_provider_datafusion::expr::{self, Engine},
-    InvalidTypeAction,
-};
+use crate::{sql::sql_provider_datafusion::expr::Engine, InvalidTypeAction};
 
 pub mod column_reference;
 pub mod constraints;

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -32,7 +32,6 @@ pub enum Error {
 }
 
 pub fn filters_to_sql(filters: &[Expr], engine: Option<Engine>) -> Result<String, Error> {
-    println!("filters_to_sql: filters: {:?}", filters);
     let dialect = engine
         .map(|e| e.dialect())
         .unwrap_or(Arc::new(DefaultDialect {}));


### PR DESCRIPTION
* Cherry picks a couple changes from `main` that include helpers to get dialect by engine, and `filters_to_sql` updates to use the DataFusion Unparser
* Updates the `sql()` function of the `SqlExec` to use the DataFusion Unparser instead of `to_sql_with_engine`