### PR TITLE
fix: Postgres LargeUtf8 is equivalent to Utf8

### DIFF
--- a/src/postgres/write.rs
+++ b/src/postgres/write.rs
@@ -1,7 +1,7 @@
 use std::{any::Any, fmt, sync::Arc};
 
 use arrow::datatypes::SchemaRef;
-use arrow_schema::{DataType, Schema};
+use arrow_schema::{DataType, Field, Schema};
 use async_trait::async_trait;
 use datafusion::{
     catalog::Session,
@@ -145,11 +145,15 @@ impl DataSink for PostgresDataSink {
             .fields
             .iter()
             .map(|f| {
-                if f.data_type() == &DataType::LargeUtf8 {
-                    Arc::new(f.with_data_type(DataType::Utf8))
-                } else {
-                    Arc::clone(f)
-                }
+                Arc::new(Field::new(
+                    f.name(),
+                    if f.data_type() == &DataType::LargeUtf8 {
+                        DataType::Utf8
+                    } else {
+                        f.data_type().clone()
+                    },
+                    f.is_nullable(),
+                ))
             })
             .collect::<Vec<_>>();
 
@@ -166,11 +170,15 @@ impl DataSink for PostgresDataSink {
                 .fields()
                 .iter()
                 .map(|f| {
-                    if f.data_type() == &DataType::LargeUtf8 {
-                        Arc::new(f.with_data_type(DataType::Utf8))
-                    } else {
-                        Arc::clone(f)
-                    }
+                    Arc::new(Field::new(
+                        f.name(),
+                        if f.data_type() == &DataType::LargeUtf8 {
+                            DataType::Utf8
+                        } else {
+                            f.data_type().clone()
+                        },
+                        f.is_nullable(),
+                    ))
                 })
                 .collect::<Vec<_>>();
             let batch_schema = Arc::new(Schema::new(batch_fields));

--- a/src/postgres/write.rs
+++ b/src/postgres/write.rs
@@ -1,11 +1,11 @@
 use std::{any::Any, fmt, sync::Arc};
 
 use arrow::datatypes::SchemaRef;
-use arrow_schema::DataType;
+use arrow_schema::{DataType, Schema};
 use async_trait::async_trait;
 use datafusion::{
     catalog::Session,
-    common::{Constraints, DFSchema, SchemaExt},
+    common::{Constraints, SchemaExt},
     datasource::{TableProvider, TableType},
     execution::{SendableRecordBatchStream, TaskContext},
     logical_expr::{dml::InsertOp, Expr},
@@ -142,25 +142,40 @@ impl DataSink for PostgresDataSink {
         while let Some(batch) = data.next().await {
             let batch = batch.map_err(check_and_mark_retriable_error)?;
 
-            let postgres_fields = &self.postgres.schema.fields;
-            let batch_fields = batch.schema_ref().fields();
-
-            if !postgres_fields
+            // for the purposes of PostgreSQL, LargeUtf8 is equivalent to Utf8
+            // because Postgres physically cannot store anything larger than 1Gb in text (VARCHAR)
+            // normalize LargeUtf8 fields to Utf8 for both the incoming batch, and Postgres if it happens to specify any
+            let batch_fields = batch
+                .schema_ref()
+                .fields()
                 .iter()
-                .zip(batch_fields.iter())
-                .all(|(pg_field, batch_field)| {
-                    pg_field.name() == batch_field.name()
-                        && DFSchema::datatype_is_semantically_equal(
-                            pg_field.data_type(), // for the purposes of PostgreSQL, LargeUtf8 is equivalent to Utf8
-                            // because Postgres physically cannot store anything larger than 1Gb in text (VARCHAR)
-                            if batch_field.data_type() == &DataType::LargeUtf8 {
-                                &DataType::Utf8
-                            } else {
-                                batch_field.data_type()
-                            },
-                        )
+                .map(|f| {
+                    if f.data_type() == &DataType::LargeUtf8 {
+                        Arc::new(f.with_data_type(DataType::Utf8))
+                    } else {
+                        Arc::clone(f)
+                    }
                 })
-            {
+                .collect::<Vec<_>>();
+
+            let postgres_fields = self
+                .postgres
+                .schema
+                .fields
+                .iter()
+                .map(|f| {
+                    if f.data_type() == &DataType::LargeUtf8 {
+                        Arc::new(f.with_data_type(DataType::Utf8))
+                    } else {
+                        Arc::clone(f)
+                    }
+                })
+                .collect::<Vec<_>>();
+
+            let postgres_schema = Arc::new(Schema::new(postgres_fields));
+            let batch_schema = Arc::new(Schema::new(batch_fields));
+
+            if !postgres_schema.equivalent_names_and_types(&batch_schema) {
                 return Err(to_datafusion_error(super::Error::SchemaValidationError {
                     table_name: self.postgres.table.to_string(),
                 }));

--- a/src/sql/arrow_sql_gen/postgres/schema.rs
+++ b/src/sql/arrow_sql_gen/postgres/schema.rs
@@ -390,7 +390,7 @@ mod tests {
         // Test JSON types
         assert_eq!(
             pg_data_type_to_arrow_type("json", None).expect("Failed to convert json"),
-            DataType::LargeUtf8
+            DataType::Utf8
         );
 
         // Test UUID type

--- a/src/sql/arrow_sql_gen/postgres/schema.rs
+++ b/src/sql/arrow_sql_gen/postgres/schema.rs
@@ -43,7 +43,7 @@ pub(crate) fn pg_data_type_to_arrow_type(
             Arc::new(Field::new("item", DataType::Float64, true)),
             2,
         )),
-        "xml" | "json" => Ok(DataType::LargeUtf8),
+        "xml" | "json" => Ok(DataType::Utf8),
         "array" => parse_array_type(type_details),
         "composite" => parse_composite_type(type_details),
         "geometry" | "geography" => Ok(DataType::Binary),

--- a/src/sql/arrow_sql_gen/statement.rs
+++ b/src/sql/arrow_sql_gen/statement.rs
@@ -12,7 +12,9 @@ use chrono::{DateTime, Offset, TimeZone};
 use datafusion::sql::TableReference;
 use num_bigint::BigInt;
 use sea_query::{
-    Alias, ColumnDef, ColumnType, Expr, GenericBuilder, Index, InsertStatement, IntoIden, IntoIndexColumn, Keyword, MysqlQueryBuilder, OnConflict, PostgresQueryBuilder, Query, QueryBuilder, SeaRc, SimpleExpr, SqliteQueryBuilder, StringLen, Table, TableRef
+    Alias, ColumnDef, ColumnType, Expr, GenericBuilder, Index, InsertStatement, IntoIden,
+    IntoIndexColumn, Keyword, MysqlQueryBuilder, OnConflict, PostgresQueryBuilder, Query,
+    QueryBuilder, SeaRc, SimpleExpr, SqliteQueryBuilder, StringLen, Table, TableRef,
 };
 use snafu::Snafu;
 use std::{any::Any, str::FromStr, sync::Arc};
@@ -1061,14 +1063,20 @@ impl InsertBuilder {
     }
 }
 
-fn table_reference_to_sea_table_ref(table: &TableReference ) -> TableRef {
+fn table_reference_to_sea_table_ref(table: &TableReference) -> TableRef {
     match table {
-        TableReference::Bare{table} => TableRef::Table(SeaRc::new(Alias::new(table.to_string()))),
-        TableReference::Partial{schema, table} => TableRef::SchemaTable(
+        TableReference::Bare { table } => {
+            TableRef::Table(SeaRc::new(Alias::new(table.to_string())))
+        }
+        TableReference::Partial { schema, table } => TableRef::SchemaTable(
             SeaRc::new(Alias::new(schema.to_string())),
             SeaRc::new(Alias::new(table.to_string())),
         ),
-        TableReference::Full { catalog, schema, table } => TableRef::DatabaseSchemaTable(
+        TableReference::Full {
+            catalog,
+            schema,
+            table,
+        } => TableRef::DatabaseSchemaTable(
             SeaRc::new(Alias::new(catalog.to_string())),
             SeaRc::new(Alias::new(schema.to_string())),
             SeaRc::new(Alias::new(table.to_string())),
@@ -1466,7 +1474,6 @@ mod tests {
             .expect("Failed to build insert statement");
         assert_eq!(sql, "INSERT INTO \"users\" (\"id\", \"name\", \"age\") VALUES (1, 'a', 10), (2, 'b', 20), (3, 'c', 30), (1, 'a', 10), (2, 'b', 20), (3, 'c', 30)");
     }
-
 
     #[test]
     fn test_table_insertion_with_schema() {

--- a/tests/postgres/snapshots/integration__postgres__schema__postgres_schema_inference_complex_types.snap
+++ b/tests/postgres/snapshots/integration__postgres__schema__postgres_schema_inference_complex_types.snap
@@ -187,7 +187,7 @@ Schema {
         },
         Field {
             name: "json_col",
-            data_type: LargeUtf8,
+            data_type: Utf8,
             nullable: true,
             dict_id: 0,
             dict_is_ordered: false,


### PR DESCRIPTION
* In Postgres, the largest string that can be stored is 1GB (VARCHAR). This is smaller than the largest string a `Utf8` in DataFusion can represent, so for the purposes of type equivalency `LargeUtf8` and `Utf8` are equal for Postgres.