### PR TITLE
Rename `InvalidTypeAction` to `UnsupportedTypeAction`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,9 +27,14 @@ pub enum Error {
 
 #[derive(PartialEq, Eq, Clone, Copy, Default, Debug, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
-pub enum InvalidTypeAction {
+pub enum UnsupportedTypeAction {
+    /// Refuse to create the table if any unsupported types are found
     #[default]
     Error,
+    /// Log a warning for any unsupported types
     Warn,
+    /// Ignore any unsupported types (i.e. skip them)
     Ignore,
+    /// Attempt to convert any unsupported types to a string
+    String,
 }

--- a/src/postgres.rs
+++ b/src/postgres.rs
@@ -12,7 +12,7 @@ use crate::sql::sql_provider_datafusion::{
     SqlTable,
 };
 use crate::util::schema::SchemaValidator;
-use crate::InvalidTypeAction;
+use crate::UnsupportedTypeAction;
 use arrow::{
     array::RecordBatch,
     datatypes::{Schema, SchemaRef},
@@ -267,7 +267,7 @@ impl TableProviderFactory for PostgresTableProviderFactory {
         );
 
         let schema: SchemaRef = Arc::new(schema);
-        PostgresConnection::handle_unsupported_schema(&schema, InvalidTypeAction::default())
+        PostgresConnection::handle_unsupported_schema(&schema, UnsupportedTypeAction::default())
             .map_err(|e| DataFusionError::External(e.into()))?;
 
         let postgres = Postgres::new(

--- a/src/sql/db_connection_pool/dbconnection/sqliteconn.rs
+++ b/src/sql/db_connection_pool/dbconnection/sqliteconn.rs
@@ -2,7 +2,7 @@ use std::any::Any;
 
 use crate::sql::arrow_sql_gen::sqlite::rows_to_arrow;
 use crate::util::schema::SchemaValidator;
-use crate::InvalidTypeAction;
+use crate::UnsupportedTypeAction;
 use arrow::datatypes::SchemaRef;
 use arrow_schema::DataType;
 use async_trait::async_trait;
@@ -110,7 +110,7 @@ impl AsyncDbConnection<Connection, &'static (dyn ToSql + Sync)> for SqliteConnec
             .boxed()
             .context(super::UnableToGetSchemaSnafu)?;
 
-        Self::handle_unsupported_schema(&schema, InvalidTypeAction::Error)
+        Self::handle_unsupported_schema(&schema, UnsupportedTypeAction::Error)
     }
 
     async fn query_arrow(

--- a/src/sql/db_connection_pool/duckdbpool.rs
+++ b/src/sql/db_connection_pool/duckdbpool.rs
@@ -12,7 +12,7 @@ use crate::{
         dbconnection::{duckdbconn::DuckDbConnection, DbConnection, SyncDbConnection},
         JoinPushDown,
     },
-    InvalidTypeAction,
+    UnsupportedTypeAction,
 };
 
 #[derive(Debug, Snafu)]
@@ -38,7 +38,7 @@ pub struct DuckDbConnectionPool {
     join_push_down: JoinPushDown,
     attached_databases: Vec<Arc<str>>,
     mode: Mode,
-    invalid_type_action: InvalidTypeAction,
+    unsupported_type_action: UnsupportedTypeAction,
 }
 
 impl std::fmt::Debug for DuckDbConnectionPool {
@@ -48,7 +48,7 @@ impl std::fmt::Debug for DuckDbConnectionPool {
             .field("join_push_down", &self.join_push_down)
             .field("attached_databases", &self.attached_databases)
             .field("mode", &self.mode)
-            .field("invalid_type_action", &self.invalid_type_action)
+            .field("unsupported_type_action", &self.unsupported_type_action)
             .finish()
     }
 }
@@ -86,7 +86,7 @@ impl DuckDbConnectionPool {
             join_push_down: JoinPushDown::AllowedFor(":memory:".to_string()),
             attached_databases: Vec::new(),
             mode: Mode::Memory,
-            invalid_type_action: InvalidTypeAction::Error,
+            unsupported_type_action: UnsupportedTypeAction::Error,
         })
     }
 
@@ -124,13 +124,13 @@ impl DuckDbConnectionPool {
             join_push_down: JoinPushDown::AllowedFor(path.to_string()),
             attached_databases: Vec::new(),
             mode: Mode::File,
-            invalid_type_action: InvalidTypeAction::Error,
+            unsupported_type_action: UnsupportedTypeAction::Error,
         })
     }
 
     #[must_use]
-    pub fn with_invalid_type_action(mut self, action: InvalidTypeAction) -> Self {
-        self.invalid_type_action = action;
+    pub fn with_unsupported_type_action(mut self, action: UnsupportedTypeAction) -> Self {
+        self.unsupported_type_action = action;
         self
     }
 
@@ -168,7 +168,7 @@ impl DuckDbConnectionPool {
         Ok(Box::new(
             DuckDbConnection::new(conn)
                 .with_attachments(attachments)
-                .with_invalid_type_action(self.invalid_type_action),
+                .with_unsupported_type_action(self.unsupported_type_action),
         ))
     }
 
@@ -211,7 +211,7 @@ impl DbConnectionPool<r2d2::PooledConnection<DuckdbConnectionManager>, DuckDBPar
         Ok(Box::new(
             DuckDbConnection::new(conn)
                 .with_attachments(attachments)
-                .with_invalid_type_action(self.invalid_type_action),
+                .with_unsupported_type_action(self.unsupported_type_action),
         ))
     }
 

--- a/src/sql/db_connection_pool/postgrespool.rs
+++ b/src/sql/db_connection_pool/postgrespool.rs
@@ -2,7 +2,7 @@ use std::{collections::HashMap, path::PathBuf, str::FromStr, sync::Arc};
 
 use crate::{
     util::{self, ns_lookup::verify_ns_lookup_and_tcp_connect},
-    InvalidTypeAction,
+    UnsupportedTypeAction,
 };
 use async_trait::async_trait;
 use bb8::ErrorSink;
@@ -82,7 +82,7 @@ pub type Result<T, E = Error> = std::result::Result<T, E>;
 pub struct PostgresConnectionPool {
     pool: Arc<bb8::Pool<PostgresConnectionManager<MakeTlsConnector>>>,
     join_push_down: JoinPushDown,
-    invalid_type_action: InvalidTypeAction,
+    unsupported_type_action: UnsupportedTypeAction,
 }
 
 impl PostgresConnectionPool {
@@ -208,14 +208,14 @@ impl PostgresConnectionPool {
         Ok(PostgresConnectionPool {
             pool: Arc::new(pool.clone()),
             join_push_down,
-            invalid_type_action: InvalidTypeAction::default(),
+            unsupported_type_action: UnsupportedTypeAction::default(),
         })
     }
 
     /// Specify the action to take when an invalid type is encountered.
     #[must_use]
-    pub fn with_invalid_type_action(mut self, action: InvalidTypeAction) -> Self {
-        self.invalid_type_action = action;
+    pub fn with_unsupported_type_action(mut self, action: UnsupportedTypeAction) -> Self {
+        self.unsupported_type_action = action;
         self
     }
 
@@ -385,7 +385,7 @@ impl
         let pool = Arc::clone(&self.pool);
         let conn = pool.get_owned().await.context(ConnectionPoolRunSnafu)?;
         Ok(Box::new(
-            PostgresConnection::new(conn).with_invalid_type_action(self.invalid_type_action),
+            PostgresConnection::new(conn).with_unsupported_type_action(self.unsupported_type_action),
         ))
     }
 

--- a/src/sqlite.rs
+++ b/src/sqlite.rs
@@ -10,7 +10,7 @@ use crate::sql::db_connection_pool::{
 };
 use crate::sql::sql_provider_datafusion;
 use crate::util::schema::SchemaValidator;
-use crate::InvalidTypeAction;
+use crate::UnsupportedTypeAction;
 use arrow::array::{Int64Array, StringArray};
 use arrow::{array::RecordBatch, datatypes::SchemaRef};
 use async_trait::async_trait;
@@ -299,7 +299,7 @@ impl TableProviderFactory for SqliteTableProviderFactory {
 
         let schema: SchemaRef = Arc::new(cmd.schema.as_ref().into());
         let schema: SchemaRef =
-            SqliteConnection::handle_unsupported_schema(&schema, InvalidTypeAction::Error)
+            SqliteConnection::handle_unsupported_schema(&schema, UnsupportedTypeAction::Error)
                 .map_err(|e| DataFusionError::External(e.into()))?;
 
         let sqlite = Arc::new(Sqlite::new(


### PR DESCRIPTION
Renames the `InvalidTypeAction` parameter to `UnsupportedTypeAction` to properly reflect its intended behavior of handling unsupported types.

Also adds a new `UnsupportedTypeAction::String` which currently behaves similarly to `UnsupportedTypeAction::Error` but can be overridden by components to attempt conversion to string types.