### PR TITLE
Handle JSONB as UnsupportedTypeAction::String

### DIFF
--- a/src/sql/arrow_sql_gen/postgres/schema.rs
+++ b/src/sql/arrow_sql_gen/postgres/schema.rs
@@ -4,9 +4,45 @@ use serde_json::json;
 use serde_json::Value;
 use std::sync::Arc;
 
+use crate::UnsupportedTypeAction;
+
+#[derive(Debug, Clone)]
+pub(crate) struct ParseContext {
+    pub(crate) unsupported_type_action: UnsupportedTypeAction,
+    pub(crate) type_details: Option<serde_json::Value>,
+}
+
+impl ParseContext {
+    pub(crate) fn new() -> Self {
+        Self {
+            unsupported_type_action: UnsupportedTypeAction::Error,
+            type_details: None,
+        }
+    }
+
+    pub(crate) fn with_unsupported_type_action(
+        mut self,
+        unsupported_type_action: UnsupportedTypeAction,
+    ) -> Self {
+        self.unsupported_type_action = unsupported_type_action;
+        self
+    }
+
+    pub(crate) fn with_type_details(mut self, type_details: serde_json::Value) -> Self {
+        self.type_details = Some(type_details);
+        self
+    }
+}
+
+impl Default for ParseContext {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 pub(crate) fn pg_data_type_to_arrow_type(
     pg_type: &str,
-    type_details: Option<serde_json::Value>,
+    context: &ParseContext,
 ) -> Result<DataType, ArrowError> {
     let base_type = pg_type.split('(').next().unwrap_or(pg_type).trim();
 
@@ -44,9 +80,14 @@ pub(crate) fn pg_data_type_to_arrow_type(
             2,
         )),
         "xml" | "json" => Ok(DataType::Utf8),
-        "array" => parse_array_type(type_details),
-        "composite" => parse_composite_type(type_details),
+        "array" => parse_array_type(context),
+        "composite" => parse_composite_type(context),
         "geometry" | "geography" => Ok(DataType::Binary),
+
+        // `jsonb` is currently not supported, but if the user has set the `UnsupportedTypeAction` to `String` we'll return `Utf8`.
+        "jsonb" if context.unsupported_type_action == UnsupportedTypeAction::String => {
+            Ok(DataType::Utf8)
+        }
         _ => Err(ArrowError::ParseError(format!(
             "Unsupported PostgreSQL type: {}",
             pg_type
@@ -54,8 +95,10 @@ pub(crate) fn pg_data_type_to_arrow_type(
     }
 }
 
-fn parse_array_type(type_details: Option<serde_json::Value>) -> Result<DataType, ArrowError> {
-    let details = type_details
+fn parse_array_type(context: &ParseContext) -> Result<DataType, ArrowError> {
+    let details = context
+        .type_details
+        .as_ref()
         .ok_or_else(|| ArrowError::ParseError("Missing type details for array type".to_string()))?;
     let details = details
         .as_object()
@@ -68,11 +111,13 @@ fn parse_array_type(type_details: Option<serde_json::Value>) -> Result<DataType,
         })?;
 
     let inner_type = if element_type.ends_with("[]") {
-        parse_array_type(Some(
-            json!({"type": "array", "element_type": element_type.trim_end_matches("[]")}),
-        ))?
+        let inner_context = context.clone().with_type_details(json!({
+            "type": "array",
+            "element_type": element_type.trim_end_matches("[]"),
+        }));
+        parse_array_type(&inner_context)?
     } else {
-        pg_data_type_to_arrow_type(element_type, None)?
+        pg_data_type_to_arrow_type(element_type, context)?
     };
 
     Ok(DataType::List(Arc::new(Field::new(
@@ -80,8 +125,8 @@ fn parse_array_type(type_details: Option<serde_json::Value>) -> Result<DataType,
     ))))
 }
 
-fn parse_composite_type(type_details: Option<serde_json::Value>) -> Result<DataType, ArrowError> {
-    let details = type_details.ok_or_else(|| {
+fn parse_composite_type(context: &ParseContext) -> Result<DataType, ArrowError> {
+    let details = context.type_details.as_ref().ok_or_else(|| {
         ArrowError::ParseError("Missing type details for composite type".to_string())
     })?;
     let details = details.as_object().ok_or_else(|| {
@@ -117,9 +162,10 @@ fn parse_composite_type(type_details: Option<serde_json::Value>) -> Result<DataT
                     )
                 })?;
             let field_type = if attr_type == "composite" {
-                parse_composite_type(Some(attr.clone()))?
+                let inner_context = context.clone().with_type_details(attr.clone());
+                parse_composite_type(&inner_context)?
             } else {
-                pg_data_type_to_arrow_type(attr_type, None)?
+                pg_data_type_to_arrow_type(attr_type, context)?
             };
             Ok(Field::new(name, field_type, true))
         })
@@ -175,98 +221,102 @@ mod tests {
 
     #[test]
     fn test_pg_data_type_to_arrow_type() {
+        let context = ParseContext::new();
         // Test basic types
         assert_eq!(
-            pg_data_type_to_arrow_type("smallint", None).expect("Failed to convert smallint"),
+            pg_data_type_to_arrow_type("smallint", &context).expect("Failed to convert smallint"),
             DataType::Int16
         );
         assert_eq!(
-            pg_data_type_to_arrow_type("integer", None).expect("Failed to convert integer"),
+            pg_data_type_to_arrow_type("integer", &context).expect("Failed to convert integer"),
             DataType::Int32
         );
         assert_eq!(
-            pg_data_type_to_arrow_type("bigint", None).expect("Failed to convert bigint"),
+            pg_data_type_to_arrow_type("bigint", &context).expect("Failed to convert bigint"),
             DataType::Int64
         );
         assert_eq!(
-            pg_data_type_to_arrow_type("real", None).expect("Failed to convert real"),
+            pg_data_type_to_arrow_type("real", &context).expect("Failed to convert real"),
             DataType::Float32
         );
         assert_eq!(
-            pg_data_type_to_arrow_type("double precision", None)
+            pg_data_type_to_arrow_type("double precision", &context)
                 .expect("Failed to convert double precision"),
             DataType::Float64
         );
         assert_eq!(
-            pg_data_type_to_arrow_type("boolean", None).expect("Failed to convert boolean"),
+            pg_data_type_to_arrow_type("boolean", &context).expect("Failed to convert boolean"),
             DataType::Boolean
         );
 
         // Test string types
         assert_eq!(
-            pg_data_type_to_arrow_type("character", None).expect("Failed to convert character"),
+            pg_data_type_to_arrow_type("character", &context).expect("Failed to convert character"),
             DataType::Utf8
         );
         assert_eq!(
-            pg_data_type_to_arrow_type("character varying", None)
+            pg_data_type_to_arrow_type("character varying", &context)
                 .expect("Failed to convert character varying"),
             DataType::Utf8
         );
         assert_eq!(
-            pg_data_type_to_arrow_type("text", None).expect("Failed to convert text"),
+            pg_data_type_to_arrow_type("text", &context).expect("Failed to convert text"),
             DataType::Utf8
         );
 
         // Test date/time types
         assert_eq!(
-            pg_data_type_to_arrow_type("date", None).expect("Failed to convert date"),
+            pg_data_type_to_arrow_type("date", &context).expect("Failed to convert date"),
             DataType::Date32
         );
         assert_eq!(
-            pg_data_type_to_arrow_type("time without time zone", None)
+            pg_data_type_to_arrow_type("time without time zone", &context)
                 .expect("Failed to convert time without time zone"),
             DataType::Time64(TimeUnit::Nanosecond)
         );
         assert_eq!(
-            pg_data_type_to_arrow_type("timestamp without time zone", None)
+            pg_data_type_to_arrow_type("timestamp without time zone", &context)
                 .expect("Failed to convert timestamp without time zone"),
             DataType::Timestamp(TimeUnit::Nanosecond, None)
         );
         assert_eq!(
-            pg_data_type_to_arrow_type("timestamp with time zone", None)
+            pg_data_type_to_arrow_type("timestamp with time zone", &context)
                 .expect("Failed to convert timestamp with time zone"),
             DataType::Timestamp(TimeUnit::Nanosecond, Some("UTC".into()))
         );
         assert_eq!(
-            pg_data_type_to_arrow_type("interval", None).expect("Failed to convert interval"),
+            pg_data_type_to_arrow_type("interval", &context).expect("Failed to convert interval"),
             DataType::Interval(IntervalUnit::MonthDayNano)
         );
 
         // Test numeric types
         assert_eq!(
-            pg_data_type_to_arrow_type("numeric", None).expect("Failed to convert numeric"),
+            pg_data_type_to_arrow_type("numeric", &context).expect("Failed to convert numeric"),
             DataType::Decimal128(38, 20)
         );
         assert_eq!(
-            pg_data_type_to_arrow_type("numeric()", None).expect("Failed to convert numeric()"),
+            pg_data_type_to_arrow_type("numeric()", &context).expect("Failed to convert numeric()"),
             DataType::Decimal128(38, 20)
         );
         assert_eq!(
-            pg_data_type_to_arrow_type("numeric(10,2)", None)
+            pg_data_type_to_arrow_type("numeric(10,2)", &context)
                 .expect("Failed to convert numeric(10,2)"),
             DataType::Decimal128(10, 2)
         );
 
         // Test array type
-        let array_type_details = Some(json!({"type": "array", "element_type": "integer"}));
+        let array_type_context = context.clone().with_type_details(json!({
+            "type": "array",
+            "element_type": "integer",
+        }));
         assert_eq!(
-            pg_data_type_to_arrow_type("array", array_type_details)
+            pg_data_type_to_arrow_type("array", &array_type_context)
                 .expect("Failed to convert array"),
             DataType::List(Arc::new(Field::new("item", DataType::Int32, true)))
         );
 
         // Test composite type
-        let composite_type_details = Some(json!({
+        let composite_type_context = context.clone().with_type_details(json!({
             "type": "composite",
             "attributes": [
                 {"name": "x", "type": "integer"},
@@ -274,7 +324,7 @@ mod tests {
             ]
         }));
         assert_eq!(
-            pg_data_type_to_arrow_type("composite", composite_type_details)
+            pg_data_type_to_arrow_type("composite", &composite_type_context)
                 .expect("Failed to convert composite"),
             DataType::Struct(Fields::from(vec![
                 Field::new("x", DataType::Int32, true),
@@ -283,7 +333,7 @@ mod tests {
         );
 
         // Test unsupported type
-        assert!(pg_data_type_to_arrow_type("unsupported_type", None).is_err());
+        assert!(pg_data_type_to_arrow_type("unsupported_type", &context).is_err());
     }
 
     #[test]
@@ -329,18 +379,19 @@ mod tests {
 
     #[test]
     fn test_pg_data_type_to_arrow_type_with_size() {
+        let context = ParseContext::new();
         assert_eq!(
-            pg_data_type_to_arrow_type("character(10)", None)
+            pg_data_type_to_arrow_type("character(10)", &context)
                 .expect("Failed to convert character(10)"),
             DataType::Utf8
         );
         assert_eq!(
-            pg_data_type_to_arrow_type("character varying(255)", None)
+            pg_data_type_to_arrow_type("character varying(255)", &context)
                 .expect("Failed to convert character varying(255)"),
             DataType::Utf8
         );
         assert_eq!(
-            pg_data_type_to_arrow_type("numeric(10,2)", None)
+            pg_data_type_to_arrow_type("numeric(10,2)", &context)
                 .expect("Failed to convert numeric(10,2)"),
             DataType::Decimal128(10, 2)
         );
@@ -348,29 +399,33 @@ mod tests {
 
     #[test]
     fn test_pg_data_type_to_arrow_type_extended() {
+        let context = ParseContext::new();
         // Test additional numeric types
         assert_eq!(
-            pg_data_type_to_arrow_type("numeric(38,10)", None)
+            pg_data_type_to_arrow_type("numeric(38,10)", &context)
                 .expect("Failed to convert numeric(38,10)"),
             DataType::Decimal128(38, 10)
         );
         assert_eq!(
-            pg_data_type_to_arrow_type("decimal(5,0)", None)
+            pg_data_type_to_arrow_type("decimal(5,0)", &context)
                 .expect("Failed to convert decimal(5,0)"),
             DataType::Decimal128(5, 0)
         );
 
         // Test time types with precision
         assert_eq!(
-            pg_data_type_to_arrow_type("time(6) without time zone", None)
+            pg_data_type_to_arrow_type("time(6) without time zone", &context)
                 .expect("Failed to convert time(6) without time zone"),
             DataType::Time64(TimeUnit::Nanosecond)
         );
 
         // Test array types
-        let nested_array_type_details = Some(json!({"type": "array", "element_type": "integer[]"}));
+        let nested_array_type_details = context.clone().with_type_details(json!({
+            "type": "array",
+            "element_type": "integer[]",
+        }));
         assert_eq!(
-            pg_data_type_to_arrow_type("array", nested_array_type_details)
+            pg_data_type_to_arrow_type("array", &nested_array_type_details)
                 .expect("Failed to convert nested array"),
             DataType::List(Arc::new(Field::new(
                 "item",
@@ -380,49 +435,59 @@ mod tests {
         );
 
         // Test enum type
-        let enum_type_details =
-            Some(json!({"type": "enum", "values": ["small", "medium", "large"]}));
+        let enum_type_details = context.clone().with_type_details(json!({
+            "type": "enum",
+            "values": ["small", "medium", "large"]
+        }));
         assert_eq!(
-            pg_data_type_to_arrow_type("enum", enum_type_details).expect("Failed to convert enum"),
+            pg_data_type_to_arrow_type("enum", &enum_type_details).expect("Failed to convert enum"),
             DataType::Dictionary(Box::new(DataType::Int8), Box::new(DataType::Utf8))
         );
 
         // Test JSON types
         assert_eq!(
-            pg_data_type_to_arrow_type("json", None).expect("Failed to convert json"),
+            pg_data_type_to_arrow_type("json", &context).expect("Failed to convert json"),
             DataType::Utf8
         );
 
         // Test UUID type
         assert_eq!(
-            pg_data_type_to_arrow_type("uuid", None).expect("Failed to convert uuid"),
+            pg_data_type_to_arrow_type("uuid", &context).expect("Failed to convert uuid"),
             DataType::Utf8
         );
 
         // Test bpchar type
         assert_eq!(
-            pg_data_type_to_arrow_type("bpchar", None).expect("Failed to convert bpchar"),
+            pg_data_type_to_arrow_type("bpchar", &context).expect("Failed to convert bpchar"),
             DataType::Utf8
         );
 
         // Test bpchar with length specification
         assert_eq!(
-            pg_data_type_to_arrow_type("bpchar(10)", None).expect("Failed to convert bpchar(10)"),
+            pg_data_type_to_arrow_type("bpchar(10)", &context)
+                .expect("Failed to convert bpchar(10)"),
             DataType::Utf8
         );
     }
 
     #[test]
     fn test_parse_array_type_extended() {
-        let single_dim_array = Some(json!({"type": "array", "element_type": "integer"}));
+        let context = ParseContext::new();
+        let single_dim_array = context.clone().with_type_details(json!({
+            "type": "array",
+            "element_type": "integer",
+        }));
         assert_eq!(
-            parse_array_type(single_dim_array).expect("Failed to parse single dimension array"),
+            parse_array_type(&single_dim_array).expect("Failed to parse single dimension array"),
             DataType::List(Arc::new(Field::new("item", DataType::Int32, true)))
         );
 
-        let multi_dim_array = Some(json!({"type": "array", "element_type": "text[]"}));
+        let multi_dim_array = context.clone().with_type_details(json!({
+            "type": "array",
+            "element_type": "text[]",
+        }));
         assert_eq!(
-            parse_array_type(multi_dim_array).expect("Failed to parse multi-dimension array"),
+            parse_array_type(&multi_dim_array).expect("Failed to parse multi-dimension array"),
             DataType::List(Arc::new(Field::new(
                 "item",
                 DataType::List(Arc::new(Field::new("item", DataType::Utf8, true))),
@@ -430,13 +495,14 @@ mod tests {
             )))
         );
 
-        let invalid_array = Some(json!({"type": "array"}));
-        assert!(parse_array_type(invalid_array).is_err());
+        let invalid_array = context.clone().with_type_details(json!({"type": "array"}));
+        assert!(parse_array_type(&invalid_array).is_err());
     }
 
     #[test]
     fn test_parse_composite_type_extended() {
-        let simple_composite = Some(json!({
+        let context = ParseContext::new();
+        let simple_composite = context.clone().with_type_details(json!({
             "type": "composite",
             "attributes": [
                 {"name": "id", "type": "integer"},
@@ -445,7 +511,7 @@ mod tests {
             ]
         }));
         assert_eq!(
-            parse_composite_type(simple_composite).expect("Failed to parse simple composite type"),
+            parse_composite_type(&simple_composite).expect("Failed to parse simple composite type"),
             DataType::Struct(Fields::from(vec![
                 Field::new("id", DataType::Int32, true),
                 Field::new("name", DataType::Utf8, true),
@@ -453,7 +519,7 @@ mod tests {
             ]))
         );
 
-        let nested_composite = Some(json!({
+        let nested_composite = context.clone().with_type_details(json!({
             "type": "composite",
             "attributes": [
                 {"name": "id", "type": "integer"},
@@ -464,7 +530,7 @@ mod tests {
             ]
         }));
         assert_eq!(
-            parse_composite_type(nested_composite).expect("Failed to parse nested composite type"),
+            parse_composite_type(&nested_composite).expect("Failed to parse nested composite type"),
             DataType::Struct(Fields::from(vec![
                 Field::new("id", DataType::Int32, true),
                 Field::new(
@@ -478,7 +544,9 @@ mod tests {
             ]))
         );
 
-        let invalid_composite = Some(json!({"type": "composite"}));
-        assert!(parse_composite_type(invalid_composite).is_err());
+        let invalid_composite = context.clone().with_type_details(json!({
+            "type": "composite",
+        }));
+        assert!(parse_composite_type(&invalid_composite).is_err());
     }
 }

--- a/src/sql/db_connection_pool/dbconnection/sqliteconn.rs
+++ b/src/sql/db_connection_pool/dbconnection/sqliteconn.rs
@@ -38,7 +38,7 @@ pub struct SqliteConnection {
 impl SchemaValidator for SqliteConnection {
     type Error = super::Error;
 
-    fn is_data_type_valid(data_type: &DataType) -> bool {
+    fn is_data_type_supported(data_type: &DataType) -> bool {
         match data_type {
             DataType::Dictionary(_, _) | DataType::Interval(_) | DataType::Map(_, _) => false,
             DataType::List(inner_field)
@@ -56,12 +56,12 @@ impl SchemaValidator for SqliteConnection {
             }
             DataType::Struct(inner_fields) => inner_fields
                 .iter()
-                .all(|field| Self::is_data_type_valid(field.data_type())),
+                .all(|field| Self::is_data_type_supported(field.data_type())),
             _ => true,
         }
     }
 
-    fn invalid_type_error(data_type: &DataType, field_name: &str) -> Self::Error {
+    fn unsupported_type_error(data_type: &DataType, field_name: &str) -> Self::Error {
         super::Error::UnsupportedDataType {
             data_type: data_type.to_string(),
             field_name: field_name.to_string(),

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -90,7 +90,7 @@ pub fn remove_prefix_from_hashmap_keys<V>(
 /// # Errors
 ///
 /// If the `UnsupportedTypeAction` is `Error` or `String` the function will return an error.
-pub fn handle_invalid_type_error<E>(
+pub fn handle_unsupported_type_error<E>(
     unsupported_type_action: UnsupportedTypeAction,
     error: E,
 ) -> Result<(), E>

--- a/tests/postgres/mod.rs
+++ b/tests/postgres/mod.rs
@@ -1,4 +1,4 @@
-use crate::arrow_record_batch_gen::*;
+use crate::{arrow_record_batch_gen::*, docker::RunningContainer};
 use arrow::{
     array::{Decimal128Array, RecordBatch},
     datatypes::{DataType, Field, Schema, SchemaRef},
@@ -13,8 +13,10 @@ use datafusion_federation::schema_cast::record_convert::try_cast_to;
 use datafusion_table_providers::{
     postgres::{DynPostgresConnectionPool, PostgresTableProviderFactory},
     sql::sql_provider_datafusion::SqlTable,
+    UnsupportedTypeAction,
 };
 use rstest::{fixture, rstest};
+use serde_json::Value;
 use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::sync::{Mutex, MutexGuard};
@@ -87,22 +89,27 @@ async fn arrow_postgres_round_trip(
     assert_eq!(arrow_record, casted_result);
 }
 
-#[derive(Debug)]
 struct ContainerManager {
     port: usize,
     claimed: bool,
+    running_container: Option<RunningContainer>,
 }
 
 impl Drop for ContainerManager {
     fn drop(&mut self) {
-        let _ = tokio::runtime::Runtime::new()
+        tokio::runtime::Runtime::new()
             .unwrap()
-            .block_on(stop_container(self.port));
+            .block_on(stop_container(self.running_container.take(), self.port));
     }
 }
 
-async fn stop_container(port: usize) {
+async fn stop_container(running_container: Option<RunningContainer>, port: usize) {
     println!("Stopping Postgres container on port {}", port);
+    if let Some(running_container) = running_container {
+        if let Err(e) = running_container.stop().await {
+            tracing::error!("Error stopping container: {}", e);
+        };
+    }
 }
 
 #[fixture]
@@ -111,13 +118,16 @@ fn container_manager() -> Mutex<ContainerManager> {
     Mutex::new(ContainerManager {
         port: crate::get_random_port(),
         claimed: false,
+        running_container: None,
     })
 }
 
-async fn start_container(manager: &MutexGuard<'_, ContainerManager>) {
-    let _ = common::start_postgres_docker_container(manager.port)
+async fn start_container(manager: &mut MutexGuard<'_, ContainerManager>) {
+    let running_container = common::start_postgres_docker_container(manager.port)
         .await
         .expect("Postgres container to start");
+
+    manager.running_container = Some(running_container);
 
     tracing::debug!("Container started");
 }
@@ -146,7 +156,7 @@ async fn test_arrow_postgres_roundtrip(
     let mut container_manager = container_manager.lock().await;
     if !container_manager.claimed {
         container_manager.claimed = true;
-        start_container(&container_manager).await;
+        start_container(&mut container_manager).await;
     }
 
     arrow_postgres_round_trip(
@@ -164,11 +174,12 @@ async fn test_arrow_postgres_one_way(container_manager: &Mutex<ContainerManager>
     let mut container_manager = container_manager.lock().await;
     if !container_manager.claimed {
         container_manager.claimed = true;
-        start_container(&container_manager).await;
+        start_container(&mut container_manager).await;
     }
 
     test_postgres_enum_type(container_manager.port).await;
     test_postgres_numeric_type(container_manager.port).await;
+    test_postgres_jsonb_type(container_manager.port).await;
 }
 
 async fn test_postgres_enum_type(port: usize) {
@@ -191,6 +202,7 @@ async fn test_postgres_enum_type(port: usize) {
         insert_table_stmt,
         extra_stmt,
         expected_record,
+        UnsupportedTypeAction::default(),
     )
     .await;
 }
@@ -247,6 +259,65 @@ async fn test_postgres_numeric_type(port: usize) {
         insert_table_stmt,
         extra_stmt,
         expected_record,
+        UnsupportedTypeAction::default(),
+    )
+    .await;
+}
+
+async fn test_postgres_jsonb_type(port: usize) {
+    let create_table_stmt = "
+    CREATE TABLE jsonb_values (
+        data JSONB
+    );";
+
+    let insert_table_stmt = r#"
+    INSERT INTO jsonb_values (data) VALUES 
+    ('{"name": "John", "age": 30}'),
+    ('{"name": "Jane", "age": 25}'),
+    ('[1, 2, 3]'),
+    ('null'),
+    ('{"nested": {"key": "value"}}');
+    "#;
+
+    let schema = Arc::new(Schema::new(vec![Field::new(
+        "data",
+        DataType::LargeUtf8,
+        true,
+    )]));
+
+    // Parse and re-serialize the JSON to ensure consistent ordering
+    let expected_values = vec![
+        serde_json::from_str::<Value>(r#"{"name":"John","age":30}"#)
+            .unwrap()
+            .to_string(),
+        serde_json::from_str::<Value>(r#"{"name":"Jane","age":25}"#)
+            .unwrap()
+            .to_string(),
+        serde_json::from_str::<Value>("[1,2,3]")
+            .unwrap()
+            .to_string(),
+        serde_json::from_str::<Value>("null").unwrap().to_string(),
+        serde_json::from_str::<Value>(r#"{"nested":{"key":"value"}}"#)
+            .unwrap()
+            .to_string(),
+    ];
+
+    let expected_record = RecordBatch::try_new(
+        Arc::clone(&schema),
+        vec![Arc::new(arrow::array::LargeStringArray::from(
+            expected_values,
+        ))],
+    )
+    .expect("Failed to create arrow record batch");
+
+    arrow_postgres_one_way(
+        port,
+        "jsonb_values",
+        create_table_stmt,
+        insert_table_stmt,
+        None,
+        expected_record,
+        UnsupportedTypeAction::String,
     )
     .await;
 }
@@ -258,13 +329,15 @@ async fn arrow_postgres_one_way(
     insert_table_stmt: &str,
     extra_stmt: Option<&str>,
     expected_record: RecordBatch,
+    unsupported_type_action: UnsupportedTypeAction,
 ) {
     tracing::debug!("Running tests on {table_name}");
     let ctx = SessionContext::new();
 
     let pool = common::get_postgres_connection_pool(port)
         .await
-        .expect("Postgres connection pool should be created");
+        .expect("Postgres connection pool should be created")
+        .with_unsupported_type_action(unsupported_type_action);
 
     let db_conn = pool
         .connect_direct()


### PR DESCRIPTION
Handles converting `JSONB` Postgres columns to strings when `UnsupportedTypeAction` is set to `String`.