### PR TITLE
DuckDB: Use temp table only for append with defined resolution strategy

### DIFF
--- a/src/duckdb.rs
+++ b/src/duckdb.rs
@@ -468,7 +468,7 @@ impl DuckDB {
         Ok(())
     }
 
-    fn insert_batch_no_constraints(
+    fn insert_batch(
         &self,
         transaction: &Transaction<'_>,
         batch: &RecordBatch,


### PR DESCRIPTION
Simplify DuckDB acceleration to write directly to target table even if table contains constraints. This is now possible after upgrading to DuckDB 1.2.0 that fixes the following limitation

https://duckdb.org/2025/02/05/announcing-duckdb-120.html

>[Over-eager constraint checking addressed.](https://github.com/duckdb/duckdb/pull/15092) We also resolved a long-standing issue with [over-eager unique constraint checking](https://duckdb.org/docs/archive/1.1/sql/indexes.html#over-eager-unique-constraint-checking). For example, the following sequence of commands used to throw an error but now works:
CREATE TABLE students (id INTEGER PRIMARY KEY, name VARCHAR);
INSERT INTO students VALUES (1, 'John Doe');
BEGIN; -- start transaction
DELETE FROM students WHERE id = 1;
INSERT INTO students VALUES (1, 'Jane Doe');