### PR TITLE
DuckDB: fix error handling during record batch insertion

### DIFF
--- a/src/duckdb.rs
+++ b/src/duckdb.rs
@@ -483,6 +483,8 @@ impl DuckDB {
                 .context(UnableToInsertToDuckDBTableSnafu)?;
         }
 
+        appender.flush().context(UnableToInsertToDuckDBTableSnafu)?;
+
         Ok(())
     }
 


### PR DESCRIPTION
Appender flushes inserted data during drop. If this fails, we don't catch the exception, and instead, the next append attempt will fail with the `Current transaction is aborted (please ROLLBACK)` error.
This ensures we catches insertion error (if any)