### PR TITLE
Add bundled feature to SQLite

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -132,6 +132,7 @@ postgres = [
 postgres-federation = ["postgres", "federation"]
 sqlite = ["dep:rusqlite", "dep:tokio-rusqlite"]
 sqlite-federation = ["sqlite", "federation"]
+sqlite-bundled = ["sqlite", "rusqlite/bundled"]
 
 [[example]]
 name = "odbc_sqlite"


### PR DESCRIPTION
Adds the `sqlite-bundled` feature, allowing clients to use the SQLite table provider without needing to install the dependency.