### PR TITLE
Add indexes mismatch detection for DuckDB table creation

### DIFF
--- a/src/duckdb.rs
+++ b/src/duckdb.rs
@@ -615,11 +615,12 @@ impl DuckDB {
             );
         }
         if !extra_in_actual.is_empty() {
-            tracing::warn!(
-                "The table '{name}' has unexpected index(es) not defined in the configuration: {:?}.",
-                extra_in_actual.iter().join(", "),
-                name = self.table_name
-            );
+           tracing::warn!(
+    "Unexpected index(es) detected in table '{name}': {}.\n\
+     These indexes are not defined in the expected configuration.",
+    extra_in_actual.iter().join(", "),
+    name = self.table_name
+);
         }
 
         Ok(missing_in_actual.is_empty() && extra_in_actual.is_empty())

--- a/src/duckdb.rs
+++ b/src/duckdb.rs
@@ -618,7 +618,7 @@ impl DuckDB {
         if !extra_in_actual.is_empty() {
            tracing::warn!(
     "Unexpected index(es) detected in table '{name}': {}.\n\
-     These indexes are not defined in the expected configuration.",
+     These indexes are not defined in the configuration.",
     extra_in_actual.iter().join(", "),
     name = self.table_name
 );

--- a/src/duckdb.rs
+++ b/src/duckdb.rs
@@ -348,17 +348,24 @@ impl TableProviderFactory for DuckDBTableProviderFactory {
 
         let duckdb = TableCreator::new(name.clone(), Arc::clone(&schema), Arc::new(pool))
             .constraints(cmd.constraints.clone())
-            .indexes(indexes)
+            .indexes(indexes.clone())
             .create()
             .map_err(to_datafusion_error)?;
 
-        // If the table is already created, we don't create it again and don't apply primary keys.
-        // We need to verify that the table was created with the correct primary keys.
-        if !duckdb
+        // If the table is already created, we don't create it again and don't apply primary keys and remove previosly created indexes (if any).
+        // Thus we verify that primary keys and indexes for the table created match the configuration.
+        let mut table_schema_matches = true;
+        table_schema_matches &= duckdb
             .verify_primary_keys_match()
             .await
-            .map_err(to_datafusion_error)?
-        {
+            .map_err(to_datafusion_error)?;
+
+        table_schema_matches &= duckdb
+            .verify_indexes_match(&indexes)
+            .await
+            .map_err(to_datafusion_error)?;
+
+        if !table_schema_matches {
             tracing::warn!(
                 "Schema mismatch detected:\nThe local table definition for '{table_name}' in database '{db_path}' does not match the expected configuration.\n\
                  To fix this, drop the existing local copy. A new table with the correct schema will be automatically created upon the next access.",
@@ -565,6 +572,51 @@ impl DuckDB {
         if !extra_in_actual.is_empty() {
             tracing::warn!(
                 "The table '{name}' has unexpected primary key(s) not defined in the configuration: {:?}.",
+                extra_in_actual.iter().join(", "),
+                name = self.table_name
+            );
+        }
+
+        Ok(missing_in_actual.is_empty() && extra_in_actual.is_empty())
+    }
+
+    async fn verify_indexes_match(&self, indexes: &[(ColumnReference, IndexType)]) -> Result<bool> {
+        let expected_indexes_str_map: HashSet<String> = indexes
+            .iter()
+            .map(|index| TableCreator::get_index_name(&self.table_name, index))
+            .collect();
+
+        let mut db_conn = self.connect_sync()?;
+
+        let actual_indexes_str_map = TableCreator::get_existing_indexes(
+            DuckDB::duckdb_conn(&mut db_conn)?,
+            &self.table_name,
+        )
+        .await?;
+
+        tracing::debug!(
+            "Expected indexes: {:?}\nActual indexes: {:?}",
+            expected_indexes_str_map,
+            actual_indexes_str_map
+        );
+
+        let missing_in_actual = expected_indexes_str_map
+            .difference(&actual_indexes_str_map)
+            .collect::<Vec<_>>();
+        let extra_in_actual = actual_indexes_str_map
+            .difference(&expected_indexes_str_map)
+            .collect::<Vec<_>>();
+
+        if !missing_in_actual.is_empty() {
+            tracing::warn!(
+                "Missing index(es) detected for the table '{name}': {:?}.",
+                missing_in_actual.iter().join(", "),
+                name = self.table_name
+            );
+        }
+        if !extra_in_actual.is_empty() {
+            tracing::warn!(
+                "The table '{name}' has unexpected index(es) not defined in the configuration: {:?}.",
                 extra_in_actual.iter().join(", "),
                 name = self.table_name
             );

--- a/src/duckdb.rs
+++ b/src/duckdb.rs
@@ -367,8 +367,9 @@ impl TableProviderFactory for DuckDBTableProviderFactory {
 
         if !table_schema_matches {
             tracing::warn!(
-                "Schema mismatch detected:\nThe local table definition for '{table_name}' in database '{db_path}' does not match the expected configuration.\n\
-                 To fix this, drop the existing local copy. A new table with the correct schema will be automatically created upon the next access.",
+                "Schema mismatch detected for table '{table_name}' in database '{db_path}'.\n\
+         The local table definition does not match the expected schema.\n\
+         To resolve this issue, drop the existing table. A new table with the correct schema will be created automatically on the next access.",
                 db_path = duckdb.pool.db_path(),
                 table_name = duckdb.table_name
             );

--- a/src/duckdb/creator.rs
+++ b/src/duckdb/creator.rs
@@ -155,9 +155,7 @@ impl TableCreator {
             .context(UnableToGetPrimaryKeysOnDuckDBTableSnafu)?;
 
         let primary_keys_iter = stmt
-            .query_map([], |row| {
-                row.get::<usize, String>(0)
-            })
+            .query_map([], |row| row.get::<usize, String>(0))
             .context(UnableToGetPrimaryKeysOnDuckDBTableSnafu)?;
 
         let mut primary_keys = HashSet::new();
@@ -166,6 +164,44 @@ impl TableCreator {
         }
 
         Ok(primary_keys)
+    }
+
+    #[tracing::instrument(level = "trace")]
+    pub fn get_index_name(table_name: &str, index: &(ColumnReference, IndexType)) -> String {
+        let mut index_builder = IndexBuilder::new(table_name, index.0.iter().collect());
+        if matches!(index.1, IndexType::Unique) {
+            index_builder = index_builder.unique();
+        }
+        index_builder.index_name()
+    }
+
+    #[tracing::instrument(level = "debug", skip(conn))]
+    pub async fn get_existing_indexes(
+        conn: &mut DuckDbConnection,
+        table_name: &str,
+    ) -> super::Result<HashSet<String>> {
+        let sql = format!(
+            r#"SELECT index_name FROM duckdb_indexes WHERE table_name = '{table_name}'"#,
+            table_name = table_name
+        );
+
+        tracing::debug!("{sql}");
+
+        let mut stmt = conn
+            .conn
+            .prepare(&sql)
+            .context(UnableToGetPrimaryKeysOnDuckDBTableSnafu)?;
+
+        let indexes_iter = stmt
+            .query_map([], |row| row.get::<usize, String>(0))
+            .context(UnableToGetPrimaryKeysOnDuckDBTableSnafu)?;
+
+        let mut indexes = HashSet::new();
+        for pk in indexes_iter {
+            indexes.insert(pk.context(UnableToGetPrimaryKeysOnDuckDBTableSnafu)?);
+        }
+
+        Ok(indexes)
     }
 
     #[tracing::instrument(level = "debug", skip_all)]
@@ -355,8 +391,13 @@ impl TableCreator {
 
 #[cfg(test)]
 pub(crate) mod tests {
-    use crate::sql::db_connection_pool::{
-        dbconnection::duckdbconn::DuckDbConnection, duckdbpool::DuckDbConnectionPool,
+    use std::collections::HashMap;
+
+    use crate::{
+        sql::db_connection_pool::{
+            dbconnection::duckdbconn::DuckDbConnection, duckdbpool::DuckDbConnectionPool,
+        },
+        util::indexes,
     };
     use arrow::array::RecordBatch;
     use datafusion::{
@@ -470,6 +511,21 @@ pub(crate) mod tests {
                 .expect("to get primary keys");
 
             assert_eq!(primary_keys, HashSet::<String>::new());
+
+            let created_indexes_str_map = TableCreator::get_existing_indexes(conn, "eth.logs")
+                .await
+                .expect("to get indexes");
+
+            assert_eq!(
+                created_indexes_str_map,
+                vec![
+                    "i_eth.logs_block_number".to_string(),
+                    "i_eth.logs_log_index_transaction_hash".to_string()
+                ]
+                .into_iter()
+                .collect::<HashSet<_>>(),
+                "Indexes must match"
+            );
         }
     }
 
@@ -550,6 +606,18 @@ pub(crate) mod tests {
                 vec!["log_index".to_string(), "transaction_hash".to_string()]
                     .into_iter()
                     .collect::<HashSet<_>>()
+            );
+
+            let created_indexes_str_map = TableCreator::get_existing_indexes(conn, "eth.logs")
+                .await
+                .expect("to get indexes");
+
+            assert_eq!(
+                created_indexes_str_map,
+                vec!["i_eth.logs_block_number".to_string()]
+                    .into_iter()
+                    .collect::<HashSet<_>>(),
+                "Indexes must match"
             );
         }
     }


### PR DESCRIPTION
> 2025-03-15T20:21:24.250731Z  WARN datafusion_table_providers::duckdb: The table 'test.issues' has unexpected index(es) not defined in the configuration: "i_test.issues_created_at_id, i_test.issues_created_at".
2025-03-15T20:21:24.250782Z  WARN datafusion_table_providers::duckdb: Schema mismatch detected:
The local table definition for 'test.issues' in database '/Users/sg/spice/spiceai/.spice/data/accelerated_duckdb.db' does not match the expected configuration.
To fix this, drop the existing local copy. A new table with the correct schema will be automatically created upon the next access.
2025-03-15T20:21:24.262991Z  INFO runtime::init::dataset: Dataset test.issues registered (github:github.com/spiceai/spiceai/issues), acceleration (duckdb:file), results cache enabled.
2025-03-15T20:21:24.264535Z  INFO runtime::accelerated_table::refresh_task: Loading data for dataset test.issues
2025-03-15T20:21:25.245245Z  INFO runtime::accelerated_table::refresh_task: Loaded 1 rows (12.22 kiB) for dataset test.issues in 980ms.


![image](https://github.com/user-attachments/assets/e6e7667c-bf60-4ab1-ac42-461d7736d553)
