### PR TITLE
refactor: New TableManager interfaces for DuckDB

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -103,7 +103,7 @@ postgres-federation = ["postgres"]
 
 [patch.crates-io]
 datafusion-federation = { git = "https://github.com/spiceai/datafusion-federation.git", rev = "8b373f95e3fa0eaa4f13b93435275acc4096bf2f" }
-duckdb = { git = "https://github.com/spiceai/duckdb-rs.git", rev = "e5bd8ecd01e1f6874e2e5595d6f830239c6030c6" }
+duckdb = { git = "https://github.com/spiceai/duckdb-rs.git", rev = "bf6d04933ad9d69108567418303b60aa227d93cc" } # spiceai-1.1.3-backported
 
 datafusion = { git = "https://github.com/spiceai/datafusion.git", rev = "37f0f144650db9e07a09c02fdbb69179438316be"}
 datafusion-expr =  { git = "https://github.com/spiceai/datafusion.git", rev = "37f0f144650db9e07a09c02fdbb69179438316be"}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,6 +78,7 @@ rstest = "0.22.0"
 geozero = { version = "0.13.0", features = ["with-wkb"] }
 tokio-stream = { version = "0.1.15", features = ["net"] }
 insta = { version = "1.40.0", features = ["filters"] }
+datafusion-physical-plan = { version = "43" }
 
 [features]
 mysql = ["dep:mysql_async", "dep:async-stream"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -103,7 +103,7 @@ postgres-federation = ["postgres"]
 
 [patch.crates-io]
 datafusion-federation = { git = "https://github.com/spiceai/datafusion-federation.git", rev = "8b373f95e3fa0eaa4f13b93435275acc4096bf2f" }
-duckdb = { git = "https://github.com/spiceai/duckdb-rs.git", rev = "a2f4f443601f0fc2a2b1919705a9adf74ec493c2" }
+duckdb = { git = "https://github.com/spiceai/duckdb-rs.git", rev = "e5bd8ecd01e1f6874e2e5595d6f830239c6030c6" }
 
 datafusion = { git = "https://github.com/spiceai/datafusion.git", rev = "37f0f144650db9e07a09c02fdbb69179438316be"}
 datafusion-expr =  { git = "https://github.com/spiceai/datafusion.git", rev = "37f0f144650db9e07a09c02fdbb69179438316be"}

--- a/src/duckdb.rs
+++ b/src/duckdb.rs
@@ -183,6 +183,7 @@ const DUCKDB_DB_PATH_PARAM: &str = "open";
 const DUCKDB_DB_BASE_FOLDER_PARAM: &str = "data_directory";
 const DUCKDB_ATTACH_DATABASES_PARAM: &str = "attach_databases";
 const DUCKDB_SETTING_MEMORY_LIMIT: &str = "memory_limit";
+const DUCKDB_SETTING_TEMP_DIRECTORY: &str = "temp_directory";
 
 impl DuckDBTableProviderFactory {
     #[must_use]
@@ -383,8 +384,12 @@ impl TableProviderFactory for DuckDBTableProviderFactory {
 
         let dyn_pool: Arc<DynDuckDbConnectionPool> = Arc::new(read_pool);
 
-        if let Some(memory_limit) = options.get("memory_limit") {
+        if let Some(memory_limit) = options.get(DUCKDB_SETTING_MEMORY_LIMIT) {
             apply_memory_limit(&dyn_pool, memory_limit).await?;
+        }
+
+        if let Some(temp_directory) = options.get(DUCKDB_SETTING_TEMP_DIRECTORY) {
+            apply_temp_directory(&dyn_pool, temp_directory).await?;
         }
 
         let read_provider = Arc::new(DuckDBTable::new_with_schema(
@@ -609,6 +614,25 @@ async fn apply_memory_limit(
     Ok(())
 }
 
+async fn apply_temp_directory(
+    pool: &Arc<DynDuckDbConnectionPool>,
+    temp_directory: &str,
+) -> DataFusionResult<()> {
+    tracing::debug!("Setting DuckDB temp directory to {temp_directory}");
+
+    let db_conn = pool.connect().await?;
+    let Some(conn) = db_conn.as_sync() else {
+        return Err(to_datafusion_error(Error::DbConnectionError {
+            source: "Failed to get sync DuckDbConnection using DbConnection".into(),
+        }));
+    };
+    conn.execute(
+        &format!("SET {DUCKDB_SETTING_TEMP_DIRECTORY} = '{temp_directory}'"),
+        &[],
+    )?;
+    Ok(())
+}
+
 #[cfg(test)]
 pub(crate) mod tests {
     use crate::duckdb::write::DuckDBTableWriter;
@@ -676,6 +700,67 @@ pub(crate) mod tests {
         assert_eq!(
             memory_limit, "123.0 MiB",
             "Memory limit must be set to 123.0 MiB"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_create_with_temp_directory() {
+        let table_name = TableReference::bare("test_table_temp_dir");
+        let schema = Schema::new(vec![Field::new("dummy", DataType::Int32, false)]);
+
+        let test_temp_directory = "/tmp/duckdb_test_temp";
+        let mut options = HashMap::new();
+        options.insert("mode".to_string(), "memory".to_string());
+        options.insert(
+            "temp_directory".to_string(),
+            test_temp_directory.to_string(),
+        );
+
+        let factory = DuckDBTableProviderFactory::new(duckdb::AccessMode::ReadWrite);
+        let ctx = SessionContext::new();
+        let cmd = CreateExternalTable {
+            schema: Arc::new(schema.to_dfschema().expect("to df schema")),
+            name: table_name,
+            location: "".to_string(),
+            file_type: "".to_string(),
+            table_partition_cols: vec![],
+            if_not_exists: false,
+            definition: None,
+            order_exprs: vec![],
+            unbounded: false,
+            options,
+            constraints: Constraints::empty(),
+            column_defaults: HashMap::new(),
+            temporary: false,
+        };
+
+        let table_provider = factory
+            .create(&ctx.state(), &cmd)
+            .await
+            .expect("table provider created");
+
+        let writer = table_provider
+            .as_any()
+            .downcast_ref::<DuckDBTableWriter>()
+            .expect("cast to DuckDBTableWriter");
+
+        let mut conn_box = writer.pool().connect_sync().expect("to get connection");
+        let conn = DuckDB::duckdb_conn(&mut conn_box).expect("to get DuckDB connection");
+
+        let mut stmt = conn
+            .conn
+            .prepare("SELECT value FROM duckdb_settings() WHERE name = 'temp_directory'")
+            .expect("to prepare statement");
+
+        let temp_directory = stmt
+            .query_row([], |row| row.get::<usize, String>(0))
+            .expect("to query temp directory");
+
+        println!("Temp directory: {temp_directory}");
+
+        assert_eq!(
+            temp_directory, test_temp_directory,
+            "Temp directory must be set to {test_temp_directory}"
         );
     }
 }

--- a/src/duckdb.rs
+++ b/src/duckdb.rs
@@ -375,30 +375,6 @@ impl TableProviderFactory for DuckDBTableProviderFactory {
             .with_pool(Arc::new(pool))
             .set_on_conflict(on_conflict);
 
-        // TODO: re-implement schema validation between tables in the new table->view world
-        // If the table is already created, we don't create it again and don't apply primary keys and remove previously created indexes (if any).
-        // Thus we verify that primary keys and indexes for the table created match the configuration.
-        // let mut table_schema_matches = true;
-        // table_schema_matches &= duckdb
-        //     .verify_primary_keys_match()
-        //     .await
-        //     .map_err(to_datafusion_error)?;
-
-        // table_schema_matches &= duckdb
-        //     .verify_indexes_match(&indexes)
-        //     .await
-        //     .map_err(to_datafusion_error)?;
-
-        // if !table_schema_matches {
-        //     tracing::warn!(
-        //         "Schema mismatch detected for table '{table_name}' in database '{db_path}'.\n\
-        //  The local table definition does not match the expected schema.\n\
-        //  To resolve this issue, drop the existing table. A new table with the correct schema will be created automatically on the next access.",
-        //         db_path = duckdb.pool.db_path(),
-        //         table_name = duckdb.table_name
-        //     );
-        // }
-
         let dyn_pool: Arc<DynDuckDbConnectionPool> = Arc::new(read_pool);
 
         if let Some(memory_limit) = options.get("memory_limit") {
@@ -506,98 +482,6 @@ impl DuckDB {
             });
         result
     }
-
-    // pub async fn verify_primary_keys_match(&self) -> Result<bool> {
-    //     let expected_pk_keys_str_map: HashSet<String> =
-    //         get_primary_keys_from_constraints(&self.constraints, &self.schema)
-    //             .into_iter()
-    //             .collect();
-
-    //     let mut db_conn = self.connect_sync()?;
-
-    //     let actual_pk_keys_str_map = TableCreator::get_existing_primary_keys(
-    //         DuckDB::duckdb_conn(&mut db_conn)?,
-    //         &self.table_name,
-    //     )
-    //     .await?;
-
-    //     tracing::debug!(
-    //         "Expected primary keys: {:?}\nActual primary keys: {:?}",
-    //         expected_pk_keys_str_map,
-    //         actual_pk_keys_str_map
-    //     );
-
-    //     let missing_in_actual = expected_pk_keys_str_map
-    //         .difference(&actual_pk_keys_str_map)
-    //         .collect::<Vec<_>>();
-    //     let extra_in_actual = actual_pk_keys_str_map
-    //         .difference(&expected_pk_keys_str_map)
-    //         .collect::<Vec<_>>();
-
-    //     if !missing_in_actual.is_empty() {
-    //         tracing::warn!(
-    //             "Missing primary key(s) detected for the table '{name}': {:?}.",
-    //             missing_in_actual.iter().join(", "),
-    //             name = self.table_name
-    //         );
-    //     }
-
-    //     if !extra_in_actual.is_empty() {
-    //         tracing::warn!(
-    //             "The table '{name}' has unexpected primary key(s) not defined in the configuration: {:?}.",
-    //             extra_in_actual.iter().join(", "),
-    //             name = self.table_name
-    //         );
-    //     }
-
-    //     Ok(missing_in_actual.is_empty() && extra_in_actual.is_empty())
-    // }
-
-    // async fn verify_indexes_match(&self, indexes: &[(ColumnReference, IndexType)]) -> Result<bool> {
-    //     let expected_indexes_str_map: HashSet<String> = indexes
-    //         .iter()
-    //         .map(|index| TableCreator::get_index_name(&self.table_name, index))
-    //         .collect();
-
-    //     let mut db_conn = self.connect_sync()?;
-
-    //     let actual_indexes_str_map = TableCreator::get_existing_indexes(
-    //         DuckDB::duckdb_conn(&mut db_conn)?,
-    //         &self.table_name,
-    //     )
-    //     .await?;
-
-    //     tracing::debug!(
-    //         "Expected indexes: {:?}\nActual indexes: {:?}",
-    //         expected_indexes_str_map,
-    //         actual_indexes_str_map
-    //     );
-
-    //     let missing_in_actual = expected_indexes_str_map
-    //         .difference(&actual_indexes_str_map)
-    //         .collect::<Vec<_>>();
-    //     let extra_in_actual = actual_indexes_str_map
-    //         .difference(&expected_indexes_str_map)
-    //         .collect::<Vec<_>>();
-
-    //     if !missing_in_actual.is_empty() {
-    //         tracing::warn!(
-    //             "Missing index(es) detected for the table '{name}': {:?}.",
-    //             missing_in_actual.iter().join(", "),
-    //             name = self.table_name
-    //         );
-    //     }
-    //     if !extra_in_actual.is_empty() {
-    //         tracing::warn!(
-    //             "Unexpected index(es) detected in table '{name}': {}.\n\
-    //  These indexes are not defined in the configuration.",
-    //             extra_in_actual.iter().join(", "),
-    //             name = self.table_name
-    //         );
-    //     }
-
-    //     Ok(missing_in_actual.is_empty() && extra_in_actual.is_empty())
-    // }
 }
 
 fn remove_option(options: &mut HashMap<String, String>, key: &str) -> Option<String> {

--- a/src/duckdb.rs
+++ b/src/duckdb.rs
@@ -46,7 +46,7 @@ mod federation;
 mod creator;
 mod sql_table;
 pub mod write;
-pub use creator::{TableDefinition, TableName};
+pub use creator::{RelationName, TableDefinition};
 
 #[derive(Debug, Snafu)]
 pub enum Error {
@@ -372,7 +372,7 @@ impl TableProviderFactory for DuckDBTableProviderFactory {
         let schema: SchemaRef = Arc::new(cmd.schema.as_ref().into());
 
         let table_definition =
-            TableDefinition::new(TableName::new(name.clone()), Arc::clone(&schema))
+            TableDefinition::new(RelationName::new(name.clone()), Arc::clone(&schema))
                 .with_constraints(cmd.constraints.clone())
                 .with_indexes(indexes.clone());
 
@@ -547,7 +547,7 @@ impl DuckDBTableFactory {
         let read_provider = Self::table_provider(self, table_reference.clone()).await?;
         let schema = read_provider.schema();
 
-        let table_name = TableName::from(table_reference);
+        let table_name = RelationName::from(table_reference);
         let table_definition = TableDefinition::new(table_name, Arc::clone(&schema));
         let table_writer_builder = DuckDBTableWriterBuilder::new()
             .with_read_provider(read_provider)

--- a/src/duckdb/creator.rs
+++ b/src/duckdb/creator.rs
@@ -75,8 +75,7 @@ impl TableDefinition {
         self
     }
 
-    #[cfg(test)]
-    pub(crate) fn name(&self) -> &RelationName {
+    pub fn name(&self) -> &RelationName {
         &self.name
     }
 

--- a/src/duckdb/creator.rs
+++ b/src/duckdb/creator.rs
@@ -747,49 +747,49 @@ pub(crate) mod tests {
     }
 
     #[tokio::test]
-    #[skip]
+    #[ignore]
     async fn test_list_related_tables_from_definition() {
         todo!();
     }
 
     #[tokio::test]
-    #[skip]
+    #[ignore]
     async fn test_list_related_tables_from_creator() {
         todo!();
     }
 
     #[tokio::test]
-    #[skip]
+    #[ignore]
     async fn test_create_view() {
         todo!();
     }
 
     #[tokio::test]
-    #[skip]
+    #[ignore]
     async fn test_tables_ddl() {
         todo!();
     }
 
     #[tokio::test]
-    #[skip]
+    #[ignore]
     async fn test_insert_into_tables() {
         todo!();
     }
 
     #[tokio::test]
-    #[skip]
+    #[ignore]
     async fn test_indexes() {
         todo!();
     }
 
     #[tokio::test]
-    #[skip]
+    #[ignore]
     async fn test_indexes_ddl() {
         todo!();
     }
 
     #[tokio::test]
-    #[skip]
+    #[ignore]
     async fn test_lists_base_table_from_definition() {
         todo!();
     }

--- a/src/duckdb/creator.rs
+++ b/src/duckdb/creator.rs
@@ -211,7 +211,7 @@ impl TableManager {
             .collect()
     }
 
-    /// Creates the table for this `TableCreator`. Does not create indexes - use `TableCreator::create_indexes` to apply indexes.
+    /// Creates the table for this `TableManager`. Does not create indexes - use `TableManager::create_indexes` to apply indexes.
     #[tracing::instrument(level = "debug", skip_all)]
     pub(crate) fn create_table(
         &self,
@@ -397,7 +397,7 @@ impl TableManager {
         Ok(create_stmt)
     }
 
-    /// List all internal tables related to this table creators table definition.
+    /// List all internal tables related to this table manager's table definition.
     /// Excludes itself from the list of tables, if created.
     #[tracing::instrument(level = "debug", skip_all)]
     pub(crate) fn list_other_internal_tables(

--- a/src/duckdb/creator.rs
+++ b/src/duckdb/creator.rs
@@ -44,8 +44,7 @@ impl From<TableReference> for RelationName {
 
 /// A table definition, which includes the table name, schema, constraints, and indexes.
 /// This is used to store the definition of a table for a dataset, and can be re-used to create one or more tables (like internal data tables).
-#[derive(Debug, Clone)]
-#[cfg_attr(test, derive(PartialEq))]
+#[derive(Debug, Clone, PartialEq)]
 pub struct TableDefinition {
     name: RelationName,
     schema: SchemaRef,

--- a/src/duckdb/creator.rs
+++ b/src/duckdb/creator.rs
@@ -522,6 +522,19 @@ pub(crate) mod tests {
         Box::pin(MemoryStream::try_new(batches, schema, None).expect("to get stream"))
     }
 
+    pub(crate) fn init_tracing(default_level: Option<&str>) -> DefaultGuard {
+        let filter = match default_level {
+            Some(level) => EnvFilter::new(level),
+            _ => EnvFilter::new("INFO,datafusion_table_providers=TRACE"),
+        };
+
+        let subscriber = tracing_subscriber::FmtSubscriber::builder()
+            .with_env_filter(filter)
+            .with_ansi(true)
+            .finish();
+        tracing::subscriber::set_default(subscriber)
+    }
+
     #[tokio::test]
     async fn test_table_creator() {
         let _guard = init_tracing(None);
@@ -733,16 +746,51 @@ pub(crate) mod tests {
         }
     }
 
-    pub(crate) fn init_tracing(default_level: Option<&str>) -> DefaultGuard {
-        let filter = match default_level {
-            Some(level) => EnvFilter::new(level),
-            _ => EnvFilter::new("INFO,datafusion_table_providers=TRACE"),
-        };
+    #[tokio::test]
+    #[skip]
+    async fn test_list_related_tables_from_definition() {
+        todo!();
+    }
 
-        let subscriber = tracing_subscriber::FmtSubscriber::builder()
-            .with_env_filter(filter)
-            .with_ansi(true)
-            .finish();
-        tracing::subscriber::set_default(subscriber)
+    #[tokio::test]
+    #[skip]
+    async fn test_list_related_tables_from_creator() {
+        todo!();
+    }
+
+    #[tokio::test]
+    #[skip]
+    async fn test_create_view() {
+        todo!();
+    }
+
+    #[tokio::test]
+    #[skip]
+    async fn test_tables_ddl() {
+        todo!();
+    }
+
+    #[tokio::test]
+    #[skip]
+    async fn test_insert_into_tables() {
+        todo!();
+    }
+
+    #[tokio::test]
+    #[skip]
+    async fn test_indexes() {
+        todo!();
+    }
+
+    #[tokio::test]
+    #[skip]
+    async fn test_indexes_ddl() {
+        todo!();
+    }
+
+    #[tokio::test]
+    #[skip]
+    async fn test_lists_base_table_from_definition() {
+        todo!();
     }
 }

--- a/src/duckdb/creator.rs
+++ b/src/duckdb/creator.rs
@@ -57,6 +57,16 @@ impl TableDefinition {
         self
     }
 
+    #[cfg(test)]
+    pub(crate) fn name(&self) -> &TableName {
+        &self.name
+    }
+
+    #[cfg(test)]
+    pub(crate) fn schema(&self) -> SchemaRef {
+        Arc::clone(&self.schema)
+    }
+
     pub(crate) fn generate_internal_name(&self) -> super::Result<TableName> {
         let unix_ms = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
@@ -494,7 +504,7 @@ pub(crate) mod tests {
 
     use super::*;
 
-    fn get_mem_duckdb() -> Arc<DuckDbConnectionPool> {
+    pub(crate) fn get_mem_duckdb() -> Arc<DuckDbConnectionPool> {
         Arc::new(
             DuckDbConnectionPool::new_memory().expect("to get a memory duckdb connection pool"),
         )
@@ -747,7 +757,7 @@ pub(crate) mod tests {
         }
     }
 
-    fn get_basic_table_definition() -> Arc<TableDefinition> {
+    pub(crate) fn get_basic_table_definition() -> Arc<TableDefinition> {
         let schema = Arc::new(arrow::datatypes::Schema::new(vec![
             arrow::datatypes::Field::new("id", arrow::datatypes::DataType::Int64, false),
             arrow::datatypes::Field::new("name", arrow::datatypes::DataType::Utf8, false),
@@ -757,7 +767,6 @@ pub(crate) mod tests {
     }
 
     #[tokio::test]
-    #[ignore]
     async fn test_list_related_tables_from_definition() {
         let _guard = init_tracing(None);
         let pool = get_mem_duckdb();
@@ -791,6 +800,11 @@ pub(crate) mod tests {
 
         assert_eq!(internal_tables.len(), 3);
 
+        // validate the first table is the oldest, and the last table is the newest
+        let first_table = internal_tables.first().expect("to get first table");
+        let last_table = internal_tables.last().expect("to get last table");
+        assert!(first_table.1 < last_table.1);
+
         // validate none of the internal tables are the same, they are not equal to the base table
         let mut seen_tables = vec![];
         for (internal_table, _) in internal_tables {
@@ -804,7 +818,6 @@ pub(crate) mod tests {
     }
 
     #[tokio::test]
-    #[ignore]
     async fn test_list_related_tables_from_creator() {
         let _guard = init_tracing(None);
         let pool = get_mem_duckdb();
@@ -871,7 +884,6 @@ pub(crate) mod tests {
     }
 
     #[tokio::test]
-    #[ignore]
     async fn test_create_view() {
         let _guard = init_tracing(None);
         let pool = get_mem_duckdb();
@@ -915,7 +927,6 @@ pub(crate) mod tests {
     }
 
     #[tokio::test]
-    #[ignore]
     async fn test_insert_into_tables() {
         let _guard = init_tracing(None);
         let pool = get_mem_duckdb();
@@ -982,7 +993,6 @@ pub(crate) mod tests {
     }
 
     #[tokio::test]
-    #[ignore]
     async fn test_lists_base_table_from_definition() {
         let _guard = init_tracing(None);
         let pool = get_mem_duckdb();

--- a/src/duckdb/creator.rs
+++ b/src/duckdb/creator.rs
@@ -75,6 +75,7 @@ impl TableDefinition {
         self
     }
 
+    #[must_use]
     pub fn name(&self) -> &RelationName {
         &self.name
     }

--- a/src/duckdb/creator.rs
+++ b/src/duckdb/creator.rs
@@ -380,7 +380,7 @@ impl TableCreator {
     }
 
     #[tracing::instrument(level = "debug", skip_all)]
-    pub(crate) fn list_internal_tables(
+    pub(crate) fn list_other_internal_tables(
         &self,
         tx: &Transaction<'_>,
     ) -> super::Result<Vec<(Self, u64)>> {
@@ -974,7 +974,7 @@ pub(crate) mod tests {
             .expect("to create table");
 
         let internal_tables = table_creator
-            .list_internal_tables(&tx)
+            .list_other_internal_tables(&tx)
             .expect("should list internal tables");
 
         assert_eq!(internal_tables.len(), 3);
@@ -996,7 +996,7 @@ pub(crate) mod tests {
 
         // list the internal tables again
         let internal_tables = table_creator
-            .list_internal_tables(&tx)
+            .list_other_internal_tables(&tx)
             .expect("should list internal tables");
 
         assert_eq!(internal_tables.len(), 0);

--- a/src/duckdb/creator.rs
+++ b/src/duckdb/creator.rs
@@ -101,6 +101,25 @@ impl TableDefinition {
         self.constraints.as_ref()
     }
 
+    /// Returns true if this table definition has a base table matching the exact `RelationName` of the definition
+    ///
+    /// # Errors
+    ///
+    /// If the transaction fails to query for whether the table exists.
+    pub fn has_table(&self, tx: &Transaction<'_>) -> super::Result<bool> {
+        let mut stmt = tx
+            .prepare("SELECT 1 FROM duckdb_tables() WHERE table_name = ?")
+            .context(super::UnableToQueryDataSnafu)?;
+        let mut rows = stmt
+            .query([self.name.to_string()])
+            .context(super::UnableToQueryDataSnafu)?;
+
+        Ok(rows
+            .next()
+            .context(super::UnableToQueryDataSnafu)?
+            .is_some())
+    }
+
     /// List all internal tables related to this table definition.
     ///
     /// # Errors

--- a/src/duckdb/write.rs
+++ b/src/duckdb/write.rs
@@ -239,7 +239,7 @@ impl DataSink for DuckDBDataSink {
                     .map_err(to_retriable_data_write_error)?;
 
                 let existing_tables = new_table
-                    .list_internal_tables(&tx)
+                    .list_other_internal_tables(&tx)
                     .map_err(to_retriable_data_write_error)?;
                 let base_table = new_table
                     .base_table(&tx)

--- a/src/duckdb/write.rs
+++ b/src/duckdb/write.rs
@@ -407,13 +407,13 @@ fn insert_append(
 
     if !primary_keys_match {
         return Err(DataFusionError::Execution(
-            "Primary keys do not match between the new table and the existing table.".to_string(),
+            "Primary keys do not match between the new table and the existing table.\nEnsure primary key configuration is the same as the existing table, or manually migrate the table.".to_string(),
         ));
     }
 
     if !indexes_match {
         return Err(DataFusionError::Execution(
-            "Indexes do not match between the new table and the existing table.".to_string(),
+            "Indexes do not match between the new table and the existing table.\nEnsure index configuration is the same as the existing table, or manually migrate the table.".to_string(),
         ));
     }
 
@@ -497,14 +497,14 @@ fn insert_overwrite(
 
         if !primary_keys_match {
             return Err(DataFusionError::Execution(
-                "Primary keys do not match between the new table and the existing table."
+                "Primary keys do not match between the new table and the existing table.\nEnsure primary key configuration is the same as the existing table, or manually migrate the table."
                     .to_string(),
             ));
         }
 
         if !indexes_match {
             return Err(DataFusionError::Execution(
-                "Indexes do not match between the new table and the existing table.".to_string(),
+                "Indexes do not match between the new table and the existing table.\nEnsure index configuration is the same as the existing table, or manually migrate the table.".to_string(),
             ));
         }
     }

--- a/src/duckdb/write.rs
+++ b/src/duckdb/write.rs
@@ -33,8 +33,14 @@ use snafu::prelude::*;
 use tokio::sync::mpsc::{self, Receiver, Sender};
 use tokio::task::JoinHandle;
 
-use super::creator::{TableCreator, TableDefinition};
-use super::to_datafusion_error;
+use super::creator::{TableCreator, TableDefinition, ViewCreator};
+use super::{to_datafusion_error, RelationName};
+
+// checking schemas are equivalent is disabled because it incorrectly marks single-level list fields are different when the name of the field is different
+// e.g. List(Field { name: 'a', data_type: Int32 }) != List(Field { name: 'b', data_type: Int32 })
+// but, in this case, they are actually equivalent because the field name does not matter for the schema.
+// related: https://github.com/apache/arrow-rs/issues/6733#issuecomment-2482582556
+const SCHEMA_EQUIVALENCE_ENABLED: bool = false;
 
 #[derive(Default)]
 pub struct DuckDBTableWriterBuilder {
@@ -192,7 +198,6 @@ impl DataSink for DuckDBDataSink {
         None
     }
 
-    #[allow(clippy::too_many_lines)]
     async fn write_all(
         &self,
         mut data: SendableRecordBatchStream,
@@ -209,153 +214,30 @@ impl DataSink for DuckDBDataSink {
         let (batch_tx, batch_rx): (Sender<RecordBatch>, Receiver<RecordBatch>) = mpsc::channel(100);
 
         // Since the main task/stream can be dropped or fail, we use a oneshot channel to signal that all data is received and we should commit the transaction
-        let (notify_commit_transaction, mut on_commit_transaction) =
-            tokio::sync::oneshot::channel();
+        let (notify_commit_transaction, on_commit_transaction) = tokio::sync::oneshot::channel();
 
         let schema = data.schema();
 
         let duckdb_write_handle: JoinHandle<datafusion::common::Result<u64>> =
             tokio::task::spawn_blocking(move || {
-                let cloned_pool = Arc::clone(&pool);
-                let mut db_conn = pool
-                    .connect_sync()
-                    .context(super::DbConnectionPoolSnafu)
-                    .map_err(to_retriable_data_write_error)?;
-
-                let duckdb_conn =
-                    DuckDB::duckdb_conn(&mut db_conn).map_err(to_retriable_data_write_error)?;
-
-                let tx = duckdb_conn
-                    .conn
-                    .transaction()
-                    .context(super::UnableToBeginTransactionSnafu)
-                    .map_err(to_retriable_data_write_error)?;
-
-                let new_table = TableCreator::new(Arc::clone(&table_definition))
-                    .map_err(to_retriable_data_write_error)?
-                    .with_internal(true);
-
-                new_table
-                    .create_table(cloned_pool, &tx)
-                    .map_err(to_retriable_data_write_error)?;
-
-                tracing::debug!("Initial load for {}", new_table.table_name());
-                let num_rows = write_to_table(&new_table, &tx, schema, batch_rx)
-                    .map_err(to_retriable_data_write_error)?;
-
-                let existing_tables = new_table
-                    .list_other_internal_tables(&tx)
-                    .map_err(to_retriable_data_write_error)?;
-                let base_table = new_table
-                    .base_table(&tx)
-                    .map_err(to_retriable_data_write_error)?;
-                let last_table = match (existing_tables.last(), base_table.as_ref()) {
-                    (Some(internal_table), Some(base_table)) => {
-                        return Err(DataFusionError::Execution(
-                            format!("Failed to insert data for DuckDB - both an internal table and definition base table were found.\nManual table migration is required - delete the table '{internal_table}' or '{base_table}' and try again.",
-                            internal_table = internal_table.0.table_name(),
-                            base_table = base_table.table_name())));
-                    }
-                    (Some((table, _)), None) | (None, Some(table)) => Some(table),
-                    (None, None) => None,
+                let num_rows = match overwrite {
+                    InsertOp::Overwrite | InsertOp::Replace => insert_overwrite(
+                        pool,
+                        &table_definition,
+                        batch_rx,
+                        on_conflict.as_ref(),
+                        on_commit_transaction,
+                        schema,
+                    )?,
+                    InsertOp::Append => insert_append(
+                        pool,
+                        &table_definition,
+                        batch_rx,
+                        on_conflict.as_ref(),
+                        on_commit_transaction,
+                        schema,
+                    )?,
                 };
-
-                if matches!(overwrite, InsertOp::Append) && last_table.is_none() {
-                    tracing::debug!(
-                        "Append was requested, but no existing table was found to append from."
-                    );
-                }
-
-                if let Some(last_table) = last_table {
-                    // compare indexes and primary keys
-                    let primary_keys_match = new_table
-                        .verify_primary_keys_match(last_table, &tx)
-                        .map_err(to_retriable_data_write_error)?;
-                    let indexes_match = new_table
-                        .verify_indexes_match(last_table, &tx)
-                        .map_err(to_retriable_data_write_error)?;
-                    let last_table_schema = last_table
-                        .current_schema(&tx)
-                        .map_err(to_retriable_data_write_error)?;
-                    let new_table_schema = new_table
-                        .current_schema(&tx)
-                        .map_err(to_retriable_data_write_error)?;
-
-                    if !new_table_schema.equivalent_names_and_types(&last_table_schema) {
-                        return Err(DataFusionError::Execution(
-                            "Schema does not match between the new table and the existing table."
-                                .to_string(),
-                        ));
-                    }
-
-                    if !primary_keys_match {
-                        return Err(DataFusionError::Execution(
-                            "Primary keys do not match between the new table and the existing table.".to_string(),
-                        ));
-                    }
-
-                    if !indexes_match {
-                        return Err(DataFusionError::Execution(
-                            "Indexes do not match between the new table and the existing table."
-                                .to_string(),
-                        ));
-                    }
-
-                    if matches!(overwrite, InsertOp::Append) {
-                        tracing::debug!(
-                            "Inserting from {} into {}",
-                            last_table.table_name(),
-                            new_table.table_name()
-                        );
-                        last_table
-                            .insert_into(&new_table, &tx, on_conflict.as_ref())
-                            .map_err(to_retriable_data_write_error)?;
-                    }
-                }
-
-                on_commit_transaction
-                    .try_recv()
-                    .map_err(to_retriable_data_write_error)?;
-
-                if let Some(base_table) = base_table {
-                    base_table
-                        .delete_table(&tx)
-                        .map_err(to_retriable_data_write_error)?;
-                }
-
-                new_table
-                    .create_view(&tx)
-                    .map_err(to_retriable_data_write_error)?;
-
-                tx.commit()
-                    .context(super::UnableToCommitTransactionSnafu)
-                    .map_err(to_retriable_data_write_error)?;
-
-                tracing::debug!(
-                    "Load for table {table_name} complete, applying constraints and indexes.",
-                    table_name = new_table.table_name()
-                );
-
-                let tx = duckdb_conn
-                    .conn
-                    .transaction()
-                    .context(super::UnableToBeginTransactionSnafu)
-                    .map_err(to_datafusion_error)?;
-
-                for (table, _) in existing_tables {
-                    table
-                        .delete_table(&tx)
-                        .map_err(to_retriable_data_write_error)?;
-                }
-
-                // Apply constraints and indexes.
-                new_table
-                    .create_indexes(&tx)
-                    .map_err(to_retriable_data_write_error)?;
-
-                tx.commit()
-                    .context(super::UnableToCommitTransactionSnafu)
-                    .map_err(to_retriable_data_write_error)?;
 
                 Ok(num_rows)
             });
@@ -435,6 +317,249 @@ impl DisplayAs for DuckDBDataSink {
     }
 }
 
+fn insert_append(
+    pool: Arc<DuckDbConnectionPool>,
+    table_definition: &Arc<TableDefinition>,
+    batch_rx: Receiver<RecordBatch>,
+    on_conflict: Option<&OnConflict>,
+    mut on_commit_transaction: tokio::sync::oneshot::Receiver<()>,
+    schema: SchemaRef,
+) -> datafusion::common::Result<u64> {
+    let cloned_pool = Arc::clone(&pool);
+    let mut db_conn = pool
+        .connect_sync()
+        .context(super::DbConnectionPoolSnafu)
+        .map_err(to_retriable_data_write_error)?;
+
+    let duckdb_conn = DuckDB::duckdb_conn(&mut db_conn).map_err(to_retriable_data_write_error)?;
+
+    let tx = duckdb_conn
+        .conn
+        .transaction()
+        .context(super::UnableToBeginTransactionSnafu)
+        .map_err(to_retriable_data_write_error)?;
+
+    let append_table = TableCreator::new(Arc::clone(table_definition))
+        .map_err(to_retriable_data_write_error)?
+        .with_internal(false);
+
+    let new_table = append_table
+        .base_table(&tx)
+        .map_err(to_retriable_data_write_error)?
+        .is_none();
+
+    if new_table {
+        append_table
+            .create_table(cloned_pool, &tx)
+            .map_err(to_retriable_data_write_error)?;
+    }
+
+    let append_table_schema = append_table
+        .current_schema(&tx)
+        .map_err(to_retriable_data_write_error)?;
+
+    if SCHEMA_EQUIVALENCE_ENABLED && !schema.equivalent_names_and_types(&append_table_schema) {
+        return Err(DataFusionError::Execution(
+            "Schema of the append table does not match the schema of the new append data."
+                .to_string(),
+        ));
+    }
+
+    tracing::debug!(
+        "Append load for {table_name}",
+        table_name = append_table.table_name()
+    );
+    let num_rows = write_to_table(&append_table, &tx, schema, batch_rx, on_conflict)
+        .map_err(to_retriable_data_write_error)?;
+
+    on_commit_transaction
+        .try_recv()
+        .map_err(to_retriable_data_write_error)?;
+
+    tx.commit()
+        .context(super::UnableToCommitTransactionSnafu)
+        .map_err(to_retriable_data_write_error)?;
+
+    let tx = duckdb_conn
+        .conn
+        .transaction()
+        .context(super::UnableToBeginTransactionSnafu)
+        .map_err(to_datafusion_error)?;
+
+    // apply indexes if new table
+    if new_table {
+        tracing::debug!(
+            "Load for table {table_name} complete, applying constraints and indexes.",
+            table_name = append_table.table_name()
+        );
+
+        append_table
+            .create_indexes(&tx)
+            .map_err(to_retriable_data_write_error)?;
+    }
+
+    let primary_keys_match = append_table
+        .verify_primary_keys_match(&append_table, &tx)
+        .map_err(to_retriable_data_write_error)?;
+    let indexes_match = append_table
+        .verify_indexes_match(&append_table, &tx)
+        .map_err(to_retriable_data_write_error)?;
+
+    if !primary_keys_match {
+        return Err(DataFusionError::Execution(
+            "Primary keys do not match between the new table and the existing table.".to_string(),
+        ));
+    }
+
+    if !indexes_match {
+        return Err(DataFusionError::Execution(
+            "Indexes do not match between the new table and the existing table.".to_string(),
+        ));
+    }
+
+    tx.commit()
+        .context(super::UnableToCommitTransactionSnafu)
+        .map_err(to_retriable_data_write_error)?;
+
+    Ok(num_rows)
+}
+
+#[allow(clippy::too_many_lines)]
+fn insert_overwrite(
+    pool: Arc<DuckDbConnectionPool>,
+    table_definition: &Arc<TableDefinition>,
+    batch_rx: Receiver<RecordBatch>,
+    on_conflict: Option<&OnConflict>,
+    mut on_commit_transaction: tokio::sync::oneshot::Receiver<()>,
+    schema: SchemaRef,
+) -> datafusion::common::Result<u64> {
+    let cloned_pool = Arc::clone(&pool);
+    let mut db_conn = pool
+        .connect_sync()
+        .context(super::DbConnectionPoolSnafu)
+        .map_err(to_retriable_data_write_error)?;
+
+    let duckdb_conn = DuckDB::duckdb_conn(&mut db_conn).map_err(to_retriable_data_write_error)?;
+
+    let tx = duckdb_conn
+        .conn
+        .transaction()
+        .context(super::UnableToBeginTransactionSnafu)
+        .map_err(to_retriable_data_write_error)?;
+
+    let new_table = TableCreator::new(Arc::clone(table_definition))
+        .map_err(to_retriable_data_write_error)?
+        .with_internal(true);
+
+    new_table
+        .create_table(cloned_pool, &tx)
+        .map_err(to_retriable_data_write_error)?;
+
+    let existing_tables = new_table
+        .list_other_internal_tables(&tx)
+        .map_err(to_retriable_data_write_error)?;
+    let base_table = new_table
+        .base_table(&tx)
+        .map_err(to_retriable_data_write_error)?;
+    let last_table = match (existing_tables.last(), base_table.as_ref()) {
+        (Some(internal_table), Some(base_table)) => {
+            return Err(DataFusionError::Execution(
+                format!("Failed to insert data for DuckDB - both an internal table and definition base table were found.\nManual table migration is required - delete the table '{internal_table}' or '{base_table}' and try again.",
+                internal_table = internal_table.0.table_name(),
+                base_table = base_table.table_name())));
+        }
+        (Some((table, _)), None) | (None, Some(table)) => Some(table),
+        (None, None) => None,
+    };
+
+    if let Some(last_table) = last_table {
+        // compare indexes and primary keys
+        let primary_keys_match = new_table
+            .verify_primary_keys_match(last_table, &tx)
+            .map_err(to_retriable_data_write_error)?;
+        let indexes_match = new_table
+            .verify_indexes_match(last_table, &tx)
+            .map_err(to_retriable_data_write_error)?;
+        let last_table_schema = last_table
+            .current_schema(&tx)
+            .map_err(to_retriable_data_write_error)?;
+        let new_table_schema = new_table
+            .current_schema(&tx)
+            .map_err(to_retriable_data_write_error)?;
+
+        if SCHEMA_EQUIVALENCE_ENABLED
+            && !new_table_schema.equivalent_names_and_types(&last_table_schema)
+        {
+            return Err(DataFusionError::Execution(
+                "Schema does not match between the new table and the existing table.".to_string(),
+            ));
+        }
+
+        if !primary_keys_match {
+            return Err(DataFusionError::Execution(
+                "Primary keys do not match between the new table and the existing table."
+                    .to_string(),
+            ));
+        }
+
+        if !indexes_match {
+            return Err(DataFusionError::Execution(
+                "Indexes do not match between the new table and the existing table.".to_string(),
+            ));
+        }
+    }
+
+    tracing::debug!("Initial load for {}", new_table.table_name());
+    let num_rows = write_to_table(&new_table, &tx, schema, batch_rx, on_conflict)
+        .map_err(to_retriable_data_write_error)?;
+
+    on_commit_transaction
+        .try_recv()
+        .map_err(to_retriable_data_write_error)?;
+
+    if let Some(base_table) = base_table {
+        base_table
+            .delete_table(&tx)
+            .map_err(to_retriable_data_write_error)?;
+    }
+
+    new_table
+        .create_view(&tx)
+        .map_err(to_retriable_data_write_error)?;
+
+    tx.commit()
+        .context(super::UnableToCommitTransactionSnafu)
+        .map_err(to_retriable_data_write_error)?;
+
+    tracing::debug!(
+        "Load for table {table_name} complete, applying constraints and indexes.",
+        table_name = new_table.table_name()
+    );
+
+    let tx = duckdb_conn
+        .conn
+        .transaction()
+        .context(super::UnableToBeginTransactionSnafu)
+        .map_err(to_datafusion_error)?;
+
+    for (table, _) in existing_tables {
+        table
+            .delete_table(&tx)
+            .map_err(to_retriable_data_write_error)?;
+    }
+
+    // Apply constraints and indexes.
+    new_table
+        .create_indexes(&tx)
+        .map_err(to_retriable_data_write_error)?;
+
+    tx.commit()
+        .context(super::UnableToCommitTransactionSnafu)
+        .map_err(to_retriable_data_write_error)?;
+
+    Ok(num_rows)
+}
+
 #[allow(clippy::doc_markdown)]
 /// Writes a stream of ``RecordBatch``es to a DuckDB table.
 fn write_to_table(
@@ -442,6 +567,7 @@ fn write_to_table(
     tx: &Transaction<'_>,
     schema: SchemaRef,
     data_batches: Receiver<RecordBatch>,
+    on_conflict: Option<&OnConflict>,
 ) -> datafusion::common::Result<u64> {
     let stream = FFI_ArrowArrayStream::new(Box::new(RecordBatchReaderFromStream::new(
         data_batches,
@@ -459,20 +585,11 @@ fn write_to_table(
         .context(super::UnableToRegisterArrowScanViewSnafu)
         .map_err(to_datafusion_error)?;
 
-    let sql = format!(
-        "INSERT INTO {} SELECT * FROM {view_name}",
-        table.table_name()
-    );
-    let rows = tx
-        .execute(&sql, [])
-        .context(super::UnableToInsertToDuckDBTableSnafu)
+    let view = ViewCreator::from_name(RelationName::new(view_name));
+    let rows = view
+        .insert_into(table, tx, on_conflict)
         .map_err(to_datafusion_error)?;
-
-    // Drop the view
-    let drop_view_sql = format!("DROP VIEW IF EXISTS {view_name}");
-    tx.execute(&drop_view_sql, [])
-        .context(super::UnableToDropArrowScanViewSnafu)
-        .map_err(to_datafusion_error)?;
+    view.drop(tx).map_err(to_datafusion_error)?;
 
     Ok(rows as u64)
 }
@@ -508,10 +625,16 @@ mod test {
     use datafusion_physical_plan::memory::MemoryStream;
 
     use super::*;
-    use crate::duckdb::creator::tests::{get_basic_table_definition, get_mem_duckdb, init_tracing};
+    use crate::{
+        duckdb::creator::tests::{get_basic_table_definition, get_mem_duckdb, init_tracing},
+        util::{column_reference::ColumnReference, indexes::IndexType},
+    };
 
     #[tokio::test]
-    async fn test_write_to_table_overwrite() {
+    async fn test_write_to_table_overwrite_without_previous_table() {
+        // Test scenario: Write to a table with overwrite mode without a previous table
+        // Expected behavior: Data sink creates a new internal table, writes data to it, and creates a view with the table definition name
+
         let _guard = init_tracing(None);
         let pool = get_mem_duckdb();
 
@@ -581,7 +704,215 @@ mod test {
     }
 
     #[tokio::test]
-    async fn test_write_to_table_append() {
+    async fn test_write_to_table_overwrite_with_previous_base_table() {
+        // Test scenario: Write to a table with overwrite mode with a previous base table
+        // Expected behavior: Data sink creates a new internal table, writes data to it.
+        // Before creating the view, the base table needs to get dropped as we need to create a view with the same name.
+
+        let _guard = init_tracing(None);
+        let pool = get_mem_duckdb();
+
+        let table_definition = get_basic_table_definition();
+
+        let cloned_pool = Arc::clone(&pool);
+        let mut conn = cloned_pool.connect_sync().expect("to connect");
+        let duckdb = DuckDB::duckdb_conn(&mut conn).expect("to get duckdb conn");
+        let tx = duckdb.conn.transaction().expect("to begin transaction");
+
+        // make an existing table to overwrite
+        let overwrite_table = TableCreator::new(Arc::clone(&table_definition))
+            .expect("to create table")
+            .with_internal(false);
+
+        overwrite_table
+            .create_table(Arc::clone(&pool), &tx)
+            .expect("to create table");
+
+        tx.execute(
+            &format!(
+                "INSERT INTO {table_name} VALUES (3, 'c')",
+                table_name = overwrite_table.table_name()
+            ),
+            [],
+        )
+        .expect("to insert");
+
+        tx.commit().expect("to commit");
+
+        let duckdb_sink = DuckDBDataSink::new(
+            Arc::clone(&pool),
+            Arc::clone(&table_definition),
+            InsertOp::Overwrite,
+            None,
+        );
+        let data_sink: Arc<dyn DataSink> = Arc::new(duckdb_sink);
+
+        // id, name
+        // 1, "a"
+        // 2, "b"
+        let batches = vec![RecordBatch::try_new(
+            Arc::clone(&table_definition.schema()),
+            vec![
+                Arc::new(Int64Array::from(vec![Some(1), Some(2)])),
+                Arc::new(StringArray::from(vec![Some("a"), Some("b")])),
+            ],
+        )
+        .expect("should create a record batch")];
+
+        let stream = Box::pin(
+            MemoryStream::try_new(batches, table_definition.schema(), None).expect("to get stream"),
+        );
+
+        data_sink
+            .write_all(stream, &Arc::new(TaskContext::default()))
+            .await
+            .expect("to write all");
+
+        let mut conn = pool.connect_sync().expect("to connect");
+        let duckdb = DuckDB::duckdb_conn(&mut conn).expect("to get duckdb conn");
+        let tx = duckdb.conn.transaction().expect("to begin transaction");
+        let mut internal_tables = table_definition
+            .list_internal_tables(&tx)
+            .expect("to list internal tables");
+        assert_eq!(internal_tables.len(), 1);
+
+        let table_name = internal_tables.pop().expect("should have a table").0;
+
+        let rows = tx
+            .query_row(&format!("SELECT COUNT(1) FROM {table_name}"), [], |row| {
+                row.get::<_, i64>(0)
+            })
+            .expect("to get count");
+        assert_eq!(rows, 2);
+
+        let table_creator =
+            TableCreator::from_table_name(Arc::clone(&table_definition), table_name);
+        let base_table = table_creator.base_table(&tx).expect("to get base table");
+
+        assert!(base_table.is_none()); // base table should get deleted
+
+        // expect a view to be created with the table definition name
+        let view_rows = tx
+            .query_row(
+                &format!(
+                    "SELECT COUNT(1) FROM {view_name}",
+                    view_name = table_definition.name()
+                ),
+                [],
+                |row| row.get::<_, i64>(0),
+            )
+            .expect("to get count");
+
+        assert_eq!(view_rows, 2);
+
+        tx.rollback().expect("to rollback");
+    }
+
+    #[tokio::test]
+    async fn test_write_to_table_overwrite_with_previous_internal_table() {
+        // Test scenario: Write to a table with overwrite mode with a previous base table
+        // Expected behavior: Data sink creates a new internal table, writes data to it.
+        // Before creating the view, the base table needs to get dropped as we need to create a view with the same name.
+
+        let _guard = init_tracing(None);
+        let pool = get_mem_duckdb();
+
+        let table_definition = get_basic_table_definition();
+
+        let cloned_pool = Arc::clone(&pool);
+        let mut conn = cloned_pool.connect_sync().expect("to connect");
+        let duckdb = DuckDB::duckdb_conn(&mut conn).expect("to get duckdb conn");
+        let tx = duckdb.conn.transaction().expect("to begin transaction");
+
+        // make an existing table to overwrite
+        let overwrite_table = TableCreator::new(Arc::clone(&table_definition))
+            .expect("to create table")
+            .with_internal(true);
+
+        overwrite_table
+            .create_table(Arc::clone(&pool), &tx)
+            .expect("to create table");
+
+        tx.execute(
+            &format!(
+                "INSERT INTO {table_name} VALUES (3, 'c')",
+                table_name = overwrite_table.table_name()
+            ),
+            [],
+        )
+        .expect("to insert");
+
+        tx.commit().expect("to commit");
+
+        let duckdb_sink = DuckDBDataSink::new(
+            Arc::clone(&pool),
+            Arc::clone(&table_definition),
+            InsertOp::Overwrite,
+            None,
+        );
+        let data_sink: Arc<dyn DataSink> = Arc::new(duckdb_sink);
+
+        // id, name
+        // 1, "a"
+        // 2, "b"
+        let batches = vec![RecordBatch::try_new(
+            Arc::clone(&table_definition.schema()),
+            vec![
+                Arc::new(Int64Array::from(vec![Some(1), Some(2)])),
+                Arc::new(StringArray::from(vec![Some("a"), Some("b")])),
+            ],
+        )
+        .expect("should create a record batch")];
+
+        let stream = Box::pin(
+            MemoryStream::try_new(batches, table_definition.schema(), None).expect("to get stream"),
+        );
+
+        data_sink
+            .write_all(stream, &Arc::new(TaskContext::default()))
+            .await
+            .expect("to write all");
+
+        let mut conn = pool.connect_sync().expect("to connect");
+        let duckdb = DuckDB::duckdb_conn(&mut conn).expect("to get duckdb conn");
+        let tx = duckdb.conn.transaction().expect("to begin transaction");
+        let mut internal_tables = table_definition
+            .list_internal_tables(&tx)
+            .expect("to list internal tables");
+        assert_eq!(internal_tables.len(), 1);
+
+        let table_name = internal_tables.pop().expect("should have a table").0;
+
+        let rows = tx
+            .query_row(&format!("SELECT COUNT(1) FROM {table_name}"), [], |row| {
+                row.get::<_, i64>(0)
+            })
+            .expect("to get count");
+        assert_eq!(rows, 2);
+
+        // expect a view to be created with the table definition name
+        let view_rows = tx
+            .query_row(
+                &format!(
+                    "SELECT COUNT(1) FROM {view_name}",
+                    view_name = table_definition.name()
+                ),
+                [],
+                |row| row.get::<_, i64>(0),
+            )
+            .expect("to get count");
+
+        assert_eq!(view_rows, 2);
+
+        tx.rollback().expect("to rollback");
+    }
+
+    #[tokio::test]
+    async fn test_write_to_table_append_with_previous_table() {
+        // Test scenario: Write to a table with append mode with a previous table
+        // Expected behavior: Data sink appends data to the existing table. No new internal table should be created.
+        // The existing table is re-used.
+
         let _guard = init_tracing(None);
         let pool = get_mem_duckdb();
 
@@ -595,7 +926,7 @@ mod test {
         // make an existing table to append from
         let append_table = TableCreator::new(Arc::clone(&table_definition))
             .expect("to create table")
-            .with_internal(true);
+            .with_internal(false);
 
         append_table
             .create_table(Arc::clone(&pool), &tx)
@@ -643,33 +974,197 @@ mod test {
 
         let tx = duckdb.conn.transaction().expect("to begin transaction");
 
-        let mut internal_tables = table_definition
+        let internal_tables = table_definition
             .list_internal_tables(&tx)
             .expect("to list internal tables");
-        assert_eq!(internal_tables.len(), 1);
+        assert_eq!(internal_tables.len(), 0);
 
-        let table_name = internal_tables.pop().expect("should have a table").0;
+        let base_table = append_table
+            .base_table(&tx)
+            .expect("to get base table")
+            .expect("should have a base table");
 
         let rows = tx
-            .query_row(&format!("SELECT COUNT(1) FROM {table_name}"), [], |row| {
-                row.get::<_, i64>(0)
-            })
-            .expect("to get count");
-        assert_eq!(rows, 3);
-
-        // expect a view to be created with the table definition name
-        let view_rows = tx
             .query_row(
                 &format!(
-                    "SELECT COUNT(1) FROM {view_name}",
-                    view_name = table_definition.name()
+                    "SELECT COUNT(1) FROM {table_name}",
+                    table_name = base_table.table_name()
                 ),
                 [],
                 |row| row.get::<_, i64>(0),
             )
             .expect("to get count");
+        assert_eq!(rows, 3);
 
-        assert_eq!(view_rows, 3);
+        tx.rollback().expect("to rollback");
+    }
+
+    #[tokio::test]
+    async fn test_write_to_table_append_without_previous_table() {
+        // Test scenario: Write to a table with append mode without a previous table
+        // Expected behavior: Data sink creates a new base table, writes data to it.
+
+        let _guard = init_tracing(None);
+        let pool = get_mem_duckdb();
+
+        let cloned_pool = Arc::clone(&pool);
+
+        let table_definition = get_basic_table_definition();
+
+        // make an existing table to append from
+        let append_table = TableCreator::new(Arc::clone(&table_definition))
+            .expect("to create table")
+            .with_internal(false);
+
+        let duckdb_sink = DuckDBDataSink::new(
+            Arc::clone(&pool),
+            Arc::clone(&table_definition),
+            InsertOp::Append,
+            None,
+        );
+        let data_sink: Arc<dyn DataSink> = Arc::new(duckdb_sink);
+
+        // id, name
+        // 1, "a"
+        // 2, "b"
+        let batches = vec![RecordBatch::try_new(
+            Arc::clone(&table_definition.schema()),
+            vec![
+                Arc::new(Int64Array::from(vec![Some(1), Some(2)])),
+                Arc::new(StringArray::from(vec![Some("a"), Some("b")])),
+            ],
+        )
+        .expect("should create a record batch")];
+
+        let stream = Box::pin(
+            MemoryStream::try_new(batches, table_definition.schema(), None).expect("to get stream"),
+        );
+
+        data_sink
+            .write_all(stream, &Arc::new(TaskContext::default()))
+            .await
+            .expect("to write all");
+
+        let mut conn = cloned_pool.connect_sync().expect("to connect");
+        let duckdb = DuckDB::duckdb_conn(&mut conn).expect("to get duckdb conn");
+        let tx = duckdb.conn.transaction().expect("to begin transaction");
+
+        let internal_tables = table_definition
+            .list_internal_tables(&tx)
+            .expect("to list internal tables");
+        assert_eq!(internal_tables.len(), 0);
+
+        let base_table = append_table
+            .base_table(&tx)
+            .expect("to get base table")
+            .expect("should have a base table");
+
+        let rows = tx
+            .query_row(
+                &format!(
+                    "SELECT COUNT(1) FROM {table_name}",
+                    table_name = base_table.table_name()
+                ),
+                [],
+                |row| row.get::<_, i64>(0),
+            )
+            .expect("to get count");
+        assert_eq!(rows, 2);
+
+        tx.rollback().expect("to rollback");
+    }
+
+    #[tokio::test]
+    async fn test_write_to_append_without_previous_table_with_indexes() {
+        // Test scenario: Write to a table with append mode without a previous table with indexes
+        // Expected behavior: Data sink creates a new base table, writes data to it.
+        // The table should have indexes applied.
+
+        let _guard = init_tracing(None);
+        let pool = get_mem_duckdb();
+
+        let cloned_pool = Arc::clone(&pool);
+
+        let schema = Arc::new(arrow::datatypes::Schema::new(vec![
+            arrow::datatypes::Field::new("id", arrow::datatypes::DataType::Int64, false),
+            arrow::datatypes::Field::new("name", arrow::datatypes::DataType::Utf8, false),
+        ]));
+
+        let table_definition = Arc::new(
+            TableDefinition::new(RelationName::new("test_table"), Arc::clone(&schema))
+                .with_indexes(
+                    vec![(
+                        ColumnReference::try_from("id").expect("valid column ref"),
+                        IndexType::Enabled,
+                    )]
+                    .into_iter()
+                    .collect(),
+                ),
+        );
+
+        // make an existing table to append from
+        let append_table = TableCreator::new(Arc::clone(&table_definition))
+            .expect("to create table")
+            .with_internal(false);
+
+        let duckdb_sink = DuckDBDataSink::new(
+            Arc::clone(&pool),
+            Arc::clone(&table_definition),
+            InsertOp::Append,
+            None,
+        );
+        let data_sink: Arc<dyn DataSink> = Arc::new(duckdb_sink);
+
+        // id, name
+        // 1, "a"
+        // 2, "b"
+        let batches = vec![RecordBatch::try_new(
+            Arc::clone(&table_definition.schema()),
+            vec![
+                Arc::new(Int64Array::from(vec![Some(1), Some(2)])),
+                Arc::new(StringArray::from(vec![Some("a"), Some("b")])),
+            ],
+        )
+        .expect("should create a record batch")];
+
+        let stream = Box::pin(
+            MemoryStream::try_new(batches, table_definition.schema(), None).expect("to get stream"),
+        );
+
+        data_sink
+            .write_all(stream, &Arc::new(TaskContext::default()))
+            .await
+            .expect("to write all");
+
+        let mut conn = cloned_pool.connect_sync().expect("to connect");
+        let duckdb = DuckDB::duckdb_conn(&mut conn).expect("to get duckdb conn");
+        let tx = duckdb.conn.transaction().expect("to begin transaction");
+
+        let internal_tables = table_definition
+            .list_internal_tables(&tx)
+            .expect("to list internal tables");
+        assert_eq!(internal_tables.len(), 0);
+
+        let base_table = append_table
+            .base_table(&tx)
+            .expect("to get base table")
+            .expect("should have a base table");
+
+        let rows = tx
+            .query_row(
+                &format!(
+                    "SELECT COUNT(1) FROM {table_name}",
+                    table_name = base_table.table_name()
+                ),
+                [],
+                |row| row.get::<_, i64>(0),
+            )
+            .expect("to get count");
+        assert_eq!(rows, 2);
+
+        // should have 1 index
+        let indexes = append_table.current_indexes(&tx).expect("to get indexes");
+        assert_eq!(indexes.len(), 1);
 
         tx.rollback().expect("to rollback");
     }

--- a/src/duckdb/write.rs
+++ b/src/duckdb/write.rs
@@ -221,7 +221,7 @@ impl DataSink for DuckDBDataSink {
         let duckdb_write_handle: JoinHandle<datafusion::common::Result<u64>> =
             tokio::task::spawn_blocking(move || {
                 let num_rows = match overwrite {
-                    InsertOp::Overwrite | InsertOp::Replace => insert_overwrite(
+                    InsertOp::Overwrite => insert_overwrite(
                         pool,
                         &table_definition,
                         batch_rx,
@@ -229,7 +229,7 @@ impl DataSink for DuckDBDataSink {
                         on_commit_transaction,
                         schema,
                     )?,
-                    InsertOp::Append => insert_append(
+                    InsertOp::Append | InsertOp::Replace => insert_append(
                         pool,
                         &table_definition,
                         batch_rx,

--- a/src/duckdb/write.rs
+++ b/src/duckdb/write.rs
@@ -194,7 +194,6 @@ impl DataSink for DuckDBDataSink {
         mut data: SendableRecordBatchStream,
         _context: &Arc<TaskContext>,
     ) -> datafusion::common::Result<u64> {
-        // let duckdb = Arc::clone(&self.duckdb);
         let pool = Arc::clone(&self.pool);
         let table_definition = Arc::clone(&self.table_definition);
         let overwrite = self.overwrite;

--- a/src/duckdb/write.rs
+++ b/src/duckdb/write.rs
@@ -621,7 +621,7 @@ impl RecordBatchReader for RecordBatchReaderFromStream {
 
 #[cfg(test)]
 mod test {
-    use arrow_array::{Int64Array, StringArray};
+    use arrow::array::{Int64Array, StringArray};
     use datafusion_physical_plan::memory::MemoryStream;
 
     use super::*;

--- a/src/util/on_conflict.rs
+++ b/src/util/on_conflict.rs
@@ -8,7 +8,7 @@ use super::column_reference::{self, ColumnReference};
 
 #[derive(Debug, Snafu)]
 pub enum Error {
-    #[snafu(display(r#"Invalid column reference: {source}"#))]
+    #[snafu(display("Invalid column reference: {source}"))]
     InvalidColumnReference { source: column_reference::Error },
 
     #[snafu(display("Expected do_nothing or upsert, found: {token}"))]


### PR DESCRIPTION
* Updates the DuckDB `TableManager` to be less coupled to a `DuckDB` instance and removes it storing any connection pool. A `TableManager` is now detached from a connection pool, and most functions require a transaction instance to operate.
* Updates the `TableManager` with a concept of internal vs base tables. Internal tables are prefixed with `__data_` and have a unix timestamp appended to the end with `_{timestamp}` to create unique table names over time. This allows new data inserts to avoid `ALTER TABLE` to rename a table, and instead `CREATE OR REPLACE VIEW` with the name of the table definition.
* Updates to use the `arrow_scan` function to insert data into tables. Wraps the view the table function creates in a `ViewCreator`, so that we can use `ViewCreator::insert_into` to insert the data into our tables with `OnConflict` resolution.
* General refactoring as a result of the above changes
* More unit tests covering additional cases in the writer and covering most functions from the `TableManager`