### PR TITLE
Switch from Appender to duckdb_arrow_scan

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -103,7 +103,7 @@ postgres-federation = ["postgres"]
 
 [patch.crates-io]
 datafusion-federation = { git = "https://github.com/spiceai/datafusion-federation.git", rev = "8b373f95e3fa0eaa4f13b93435275acc4096bf2f" }
-duckdb = { git = "https://github.com/spiceai/duckdb-rs.git", rev = "a2f4f443601f0fc2a2b1919705a9adf74ec493c2" }
+duckdb = { git = "https://github.com/spiceai/duckdb-rs.git", rev = "a513c37bed485b761f27191070f4be318bdc9200" }
 
 datafusion = { git = "https://github.com/spiceai/datafusion.git", rev = "37f0f144650db9e07a09c02fdbb69179438316be"}
 datafusion-expr =  { git = "https://github.com/spiceai/datafusion.git", rev = "37f0f144650db9e07a09c02fdbb69179438316be"}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -103,7 +103,7 @@ postgres-federation = ["postgres"]
 
 [patch.crates-io]
 datafusion-federation = { git = "https://github.com/spiceai/datafusion-federation.git", rev = "8b373f95e3fa0eaa4f13b93435275acc4096bf2f" }
-duckdb = { git = "https://github.com/spiceai/duckdb-rs.git", rev = "a513c37bed485b761f27191070f4be318bdc9200" }
+duckdb = { git = "https://github.com/spiceai/duckdb-rs.git", rev = "e5bd8ecd01e1f6874e2e5595d6f830239c6030c6" }
 
 datafusion = { git = "https://github.com/spiceai/datafusion.git", rev = "37f0f144650db9e07a09c02fdbb69179438316be"}
 datafusion-expr =  { git = "https://github.com/spiceai/datafusion.git", rev = "37f0f144650db9e07a09c02fdbb69179438316be"}

--- a/src/duckdb.rs
+++ b/src/duckdb.rs
@@ -152,10 +152,10 @@ pub enum Error {
     #[snafu(display("A table definition is required to create a DuckDBTableWriter"))]
     MissingTableDefinition,
 
-    #[snafu(display("Unexpected error during data ingestion for a DuckDB table.\nUnable to register arrow scan view: {source}"))]
+    #[snafu(display("Failed to register Arrow scan view for DuckDB ingestion: {source}"))]
     UnableToRegisterArrowScanView { source: duckdb::Error },
 
-    #[snafu(display("Unexpected error during data ingestion for a DuckDB table.\nUnable to drop arrow scan view: {source}"))]
+    #[snafu(display("Failed to drop Arrow scan view for DuckDB ingestion: {source}"))]
     UnableToDropArrowScanView { source: duckdb::Error },
 }
 

--- a/src/duckdb/write.rs
+++ b/src/duckdb/write.rs
@@ -1,3 +1,4 @@
+use std::time::{SystemTime, UNIX_EPOCH};
 use std::{any::Any, fmt, sync::Arc};
 
 use crate::duckdb::DuckDB;
@@ -7,7 +8,10 @@ use crate::util::{
     on_conflict::OnConflict,
     retriable_error::{check_and_mark_retriable_error, to_retriable_data_write_error},
 };
+use arrow::array::RecordBatchReader;
+use arrow::ffi_stream::FFI_ArrowArrayStream;
 use arrow::{array::RecordBatch, datatypes::SchemaRef};
+use arrow_schema::ArrowError;
 use async_trait::async_trait;
 use datafusion::catalog::Session;
 use datafusion::common::Constraints;
@@ -209,6 +213,8 @@ impl DataSink for DuckDBDataSink {
         let (notify_commit_transaction, mut on_commit_transaction) =
             tokio::sync::oneshot::channel();
 
+        let schema = data.schema();
+
         let duckdb_write_handle: JoinHandle<datafusion::common::Result<u64>> =
             tokio::task::spawn_blocking(move || {
                 let cloned_pool = Arc::clone(&pool);
@@ -235,7 +241,7 @@ impl DataSink for DuckDBDataSink {
                     .map_err(to_retriable_data_write_error)?;
 
                 tracing::debug!("Initial load for {}", new_table.table_name());
-                let num_rows = write_to_table(&new_table, &tx, batch_rx)
+                let num_rows = write_to_table(&new_table, &tx, schema, batch_rx)
                     .map_err(to_retriable_data_write_error)?;
 
                 // TODO: validate schema of these incoming tables to see if they match?
@@ -392,31 +398,64 @@ impl DisplayAs for DuckDBDataSink {
 fn write_to_table(
     table: &TableCreator,
     tx: &Transaction<'_>,
-    mut data_batches: Receiver<RecordBatch>,
+    schema: SchemaRef,
+    data_batches: Receiver<RecordBatch>,
 ) -> datafusion::common::Result<u64> {
-    let mut num_rows = 0;
-    let mut appender = tx
-        .appender(&table.table_name().to_string())
-        .context(super::UnableToGetAppenderToDuckDBTableSnafu)
+    let stream = FFI_ArrowArrayStream::new(Box::new(RecordBatchReaderFromStream::new(
+        data_batches,
+        schema,
+    )));
+
+    let current_ts = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .context(super::UnableToGetSystemTimeSnafu)
+        .map_err(to_datafusion_error)?
+        .as_millis();
+
+    let view_name = format!("__scan_{}_{current_ts}", table.table_name());
+    tx.register_arrow_scan_view(&view_name, &stream)
+        .context(super::UnableToRegisterArrowScanViewSnafu)
         .map_err(to_datafusion_error)?;
 
-    while let Some(batch) = data_batches.blocking_recv() {
-        num_rows += u64::try_from(batch.num_rows()).map_err(|e| {
-            DataFusionError::Execution(format!("Unable to convert num_rows() to u64: {e}"))
-        })?;
-
-        for batch in DuckDB::split_batch(&batch) {
-            appender
-                .append_record_batch(batch.clone())
-                .context(super::UnableToInsertToDuckDBTableSnafu)
-                .map_err(to_datafusion_error)?;
-        }
-    }
-
-    appender
-        .flush()
+    let sql = format!(
+        "INSERT INTO {} SELECT * FROM {view_name}",
+        table.table_name()
+    );
+    let rows = tx
+        .execute(&sql, [])
         .context(super::UnableToInsertToDuckDBTableSnafu)
         .map_err(to_datafusion_error)?;
 
-    Ok(num_rows)
+    // Drop the view
+    let drop_view_sql = format!("DROP VIEW IF EXISTS {view_name}");
+    tx.execute(&drop_view_sql, [])
+        .context(super::UnableToDropArrowScanViewSnafu)
+        .map_err(to_datafusion_error)?;
+
+    Ok(rows as u64)
+}
+
+struct RecordBatchReaderFromStream {
+    stream: Receiver<RecordBatch>,
+    schema: SchemaRef,
+}
+
+impl RecordBatchReaderFromStream {
+    fn new(stream: Receiver<RecordBatch>, schema: SchemaRef) -> Self {
+        Self { stream, schema }
+    }
+}
+
+impl Iterator for RecordBatchReaderFromStream {
+    type Item = Result<RecordBatch, ArrowError>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.stream.blocking_recv().map(Ok)
+    }
+}
+
+impl RecordBatchReader for RecordBatchReaderFromStream {
+    fn schema(&self) -> SchemaRef {
+        Arc::clone(&self.schema)
+    }
 }


### PR DESCRIPTION
Switches from using the Appender API to insert Arrow batches into DuckDB to using the `duckdb_arrow_scan` API.

This gives us several benefits:
- The `duckdb_arrow_scan` API is more efficient - it leverages zero-copy semantics for Arrow batches whereas the current VTab implementation for Arrow in the duckdb-rs crate will copy data when converting from Arrow to the internal DuckDB format.
- It allows for streaming of the record batches - which allows for processing data that is larger than memory.