### PR TITLE
fix: Make an initial table during `TableProviderFactory::create()` for DuckDB

### DIFF
--- a/src/duckdb.rs
+++ b/src/duckdb.rs
@@ -641,7 +641,7 @@ fn make_initial_table(
     table_definition: Arc<TableDefinition>,
     pool: &Arc<DuckDbConnectionPool>,
 ) -> DataFusionResult<()> {
-    let cloned_pool = Arc::clone(&pool);
+    let cloned_pool = Arc::clone(pool);
     let mut db_conn = Arc::clone(&cloned_pool)
         .connect_sync()
         .context(DbConnectionPoolSnafu)

--- a/src/duckdb.rs
+++ b/src/duckdb.rs
@@ -637,7 +637,7 @@ async fn apply_temp_directory(
     Ok(())
 }
 
-fn make_initial_table(
+pub(crate) fn make_initial_table(
     table_definition: Arc<TableDefinition>,
     pool: &Arc<DuckDbConnectionPool>,
 ) -> DataFusionResult<()> {

--- a/src/duckdb.rs
+++ b/src/duckdb.rs
@@ -671,9 +671,6 @@ fn make_initial_table(
     table_manager
         .create_table(cloned_pool, &tx)
         .map_err(to_datafusion_error)?;
-    table_manager
-        .create_indexes(&tx)
-        .map_err(to_datafusion_error)?;
 
     tx.commit()
         .context(UnableToCommitTransactionSnafu)

--- a/src/duckdb/creator.rs
+++ b/src/duckdb/creator.rs
@@ -725,8 +725,11 @@ impl ViewCreator {
 
 #[cfg(test)]
 pub(crate) mod tests {
-    use crate::sql::db_connection_pool::{
-        dbconnection::duckdbconn::DuckDbConnection, duckdbpool::DuckDbConnectionPool,
+    use crate::{
+        duckdb::make_initial_table,
+        sql::db_connection_pool::{
+            dbconnection::duckdbconn::DuckDbConnection, duckdbpool::DuckDbConnectionPool,
+        },
     };
     use arrow::array::RecordBatch;
     use datafusion::{
@@ -828,6 +831,9 @@ pub(crate) mod tests {
 
         for overwrite in &[InsertOp::Append, InsertOp::Overwrite] {
             let pool = get_mem_duckdb();
+
+            make_initial_table(Arc::clone(&table_definition), &pool)
+                .expect("to make initial table");
 
             let duckdb_sink = DuckDBDataSink::new(
                 Arc::clone(&pool),
@@ -938,6 +944,10 @@ pub(crate) mod tests {
 
         for overwrite in &[InsertOp::Append, InsertOp::Overwrite] {
             let pool = get_mem_duckdb();
+
+            make_initial_table(Arc::clone(&table_definition), &pool)
+                .expect("to make initial table");
+
             let duckdb_sink = DuckDBDataSink::new(
                 Arc::clone(&pool),
                 Arc::clone(&table_definition),

--- a/src/duckdb/creator.rs
+++ b/src/duckdb/creator.rs
@@ -230,7 +230,7 @@ impl TableManager {
         }
     }
 
-    fn indexes_vec(&self) -> Vec<(Vec<&str>, IndexType)> {
+    pub(crate) fn indexes_vec(&self) -> Vec<(Vec<&str>, IndexType)> {
         self.table_definition
             .indexes
             .iter()
@@ -655,6 +655,18 @@ impl TableManager {
             .query_arrow([])
             .context(super::UnableToQueryDataSnafu)?;
         Ok(result.get_schema())
+    }
+
+    pub(crate) fn get_row_count(&self, tx: &Transaction<'_>) -> super::Result<u64> {
+        let sql = format!(
+            "SELECT COUNT(1) FROM {table_name}",
+            table_name = quote_identifier(&self.table_name().to_string())
+        );
+        let count = tx
+            .query_row(&sql, [], |r| r.get::<usize, u64>(0))
+            .context(super::UnableToQueryDataSnafu)?;
+
+        Ok(count)
     }
 }
 


### PR DESCRIPTION
* Make an initial table during `TableProviderFactory::create()` for DuckDB