### PR TITLE
Upgrade mysql_async, expose metrics and remove unnecessary type parameters

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ duckdb = { version = "1", features = [
 ], optional = true }
 fallible-iterator = "0.3.0"
 futures = "0.3.30"
-mysql_async = { version = "0.34.1", features = ["native-tls-tls", "chrono"], optional = true }
+mysql_async = { version = "0.35.1", features = ["native-tls-tls", "chrono", "hdrhistogram", "bigdecimal", "time"], optional = true }
 prost = { version = "0.13.2", optional = true }
 rand = "0.8.5"
 r2d2 = { version = "0.8.10", optional = true }

--- a/src/flight/exec.rs
+++ b/src/flight/exec.rs
@@ -183,7 +183,7 @@ async fn flight_stream(
             Err(e) => errors.push(Box::new(e)),
         }
     }
-    let err = errors.into_iter().last().unwrap_or_else(|| {
+    let err = errors.into_iter().next_back().unwrap_or_else(|| {
         Box::new(FlightError::ProtocolError(format!(
             "No available location for endpoint {:?}",
             partition.locations

--- a/src/mysql.rs
+++ b/src/mysql.rs
@@ -14,16 +14,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-use crate::sql::db_connection_pool::DbConnectionPool;
+use crate::sql::db_connection_pool::mysqlpool::MySQLConnectionPool;
 use crate::sql::sql_provider_datafusion::{self};
 use datafusion::{datasource::TableProvider, sql::TableReference};
-use mysql_async::prelude::ToValue;
 use snafu::prelude::*;
 use sql_table::MySQLTable;
 use std::sync::Arc;
-
-pub type MySQLConnectionPool =
-    dyn DbConnectionPool<mysql_async::Conn, &'static (dyn ToValue + Sync)> + Send + Sync;
 
 pub mod federation;
 pub(crate) mod mysql_window;

--- a/src/mysql/federation.rs
+++ b/src/mysql/federation.rs
@@ -20,7 +20,7 @@ use datafusion::{
     sql::TableReference,
 };
 
-impl<T, P> MySQLTable<T, P> {
+impl MySQLTable {
     fn create_federated_table_source(
         self: Arc<Self>,
     ) -> DataFusionResult<Arc<dyn FederatedTableSource>> {
@@ -61,7 +61,7 @@ fn mysql_ast_analyzer(ast: ast::Statement) -> Result<ast::Statement, DataFusionE
 }
 
 #[async_trait]
-impl<T, P> SQLExecutor for MySQLTable<T, P> {
+impl SQLExecutor for MySQLTable {
     fn name(&self) -> &str {
         self.base_table.name()
     }

--- a/src/mysql/sql_table.rs
+++ b/src/mysql/sql_table.rs
@@ -1,9 +1,11 @@
+use crate::sql::db_connection_pool::mysqlpool::MySQLConnectionPool;
 use crate::sql::db_connection_pool::DbConnectionPool;
 use crate::sql::sql_provider_datafusion::expr::Engine;
 use async_trait::async_trait;
 use datafusion::catalog::Session;
 use datafusion::sql::unparser::dialect::MySqlDialect;
 use futures::TryStreamExt;
+use mysql_async::prelude::ToValue;
 use std::fmt::Display;
 use std::{any::Any, fmt, sync::Arc};
 
@@ -23,11 +25,12 @@ use datafusion::{
     sql::TableReference,
 };
 
-pub struct MySQLTable<T: 'static, P: 'static> {
-    pub(crate) base_table: SqlTable<T, P>,
+pub struct MySQLTable {
+    pool: Arc<MySQLConnectionPool>,
+    pub(crate) base_table: SqlTable<mysql_async::Conn, &'static (dyn ToValue + Sync)>,
 }
 
-impl<T, P> std::fmt::Debug for MySQLTable<T, P> {
+impl std::fmt::Debug for MySQLTable {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("MySQLTable")
             .field("base_table", &self.base_table)
@@ -35,16 +38,25 @@ impl<T, P> std::fmt::Debug for MySQLTable<T, P> {
     }
 }
 
-impl<T, P> MySQLTable<T, P> {
+impl MySQLTable {
     pub async fn new(
-        pool: &Arc<dyn DbConnectionPool<T, P> + Send + Sync>,
+        pool: &Arc<MySQLConnectionPool>,
         table_reference: impl Into<TableReference>,
     ) -> Result<Self, sql_provider_datafusion::Error> {
-        let base_table = SqlTable::new("mysql", pool, table_reference, None)
+        let dyn_pool = Arc::clone(pool)
+            as Arc<
+                dyn DbConnectionPool<mysql_async::Conn, &'static (dyn ToValue + Sync)>
+                    + Send
+                    + Sync,
+            >;
+        let base_table = SqlTable::new("mysql", &dyn_pool, table_reference, None)
             .await?
             .with_dialect(Arc::new(MySqlDialect {}));
 
-        Ok(Self { base_table })
+        Ok(Self {
+            pool: Arc::clone(pool),
+            base_table,
+        })
     }
 
     fn create_physical_plan(
@@ -58,7 +70,7 @@ impl<T, P> MySQLTable<T, P> {
             projections,
             schema,
             &self.base_table.table_reference,
-            self.base_table.clone_pool(),
+            Arc::clone(&self.pool),
             filters,
             limit,
         )?))
@@ -66,7 +78,7 @@ impl<T, P> MySQLTable<T, P> {
 }
 
 #[async_trait]
-impl<T, P> TableProvider for MySQLTable<T, P> {
+impl TableProvider for MySQLTable {
     fn as_any(&self) -> &dyn Any {
         self
     }
@@ -97,23 +109,22 @@ impl<T, P> TableProvider for MySQLTable<T, P> {
     }
 }
 
-impl<T, P> Display for MySQLTable<T, P> {
+impl Display for MySQLTable {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "MySQLTable {}", self.base_table.name())
     }
 }
 
-#[derive(Clone)]
-struct MySQLSQLExec<T, P> {
-    base_exec: SqlExec<T, P>,
+struct MySQLSQLExec {
+    base_exec: SqlExec<mysql_async::Conn, &'static (dyn ToValue + Sync)>,
 }
 
-impl<T, P> MySQLSQLExec<T, P> {
+impl MySQLSQLExec {
     fn new(
         projections: Option<&Vec<usize>>,
         schema: &SchemaRef,
         table_reference: &TableReference,
-        pool: Arc<dyn DbConnectionPool<T, P> + Send + Sync>,
+        pool: Arc<MySQLConnectionPool>,
         filters: &[Expr],
         limit: Option<usize>,
     ) -> DataFusionResult<Self> {
@@ -135,21 +146,21 @@ impl<T, P> MySQLSQLExec<T, P> {
     }
 }
 
-impl<T, P> std::fmt::Debug for MySQLSQLExec<T, P> {
+impl std::fmt::Debug for MySQLSQLExec {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         let sql = self.sql().unwrap_or_default();
         write!(f, "MySQLSQLExec sql={sql}")
     }
 }
 
-impl<T, P> DisplayAs for MySQLSQLExec<T, P> {
+impl DisplayAs for MySQLSQLExec {
     fn fmt_as(&self, _t: DisplayFormatType, f: &mut fmt::Formatter) -> std::fmt::Result {
         let sql = self.sql().unwrap_or_default();
         write!(f, "MySQLSQLExec sql={sql}")
     }
 }
 
-impl<T: 'static, P: 'static> ExecutionPlan for MySQLSQLExec<T, P> {
+impl ExecutionPlan for MySQLSQLExec {
     fn name(&self) -> &'static str {
         "MySQLSQLExec"
     }

--- a/src/sql/arrow_sql_gen/mysql.rs
+++ b/src/sql/arrow_sql_gen/mysql.rs
@@ -613,7 +613,8 @@ pub fn map_column_to_data_type(
         | ColumnType::MYSQL_TYPE_LONG_BLOB 
         | ColumnType::MYSQL_TYPE_TINY_BLOB
         | ColumnType::MYSQL_TYPE_MEDIUM_BLOB
-        | ColumnType::MYSQL_TYPE_GEOMETRY => {
+        | ColumnType::MYSQL_TYPE_GEOMETRY
+        | ColumnType::MYSQL_TYPE_VECTOR => {
             unimplemented!("Unsupported column type {:?}", column_type)
         }
     }

--- a/src/sql/db_connection_pool/mysqlpool.rs
+++ b/src/sql/db_connection_pool/mysqlpool.rs
@@ -3,7 +3,7 @@ use std::{collections::HashMap, path::PathBuf, sync::Arc};
 use async_trait::async_trait;
 use mysql_async::{
     prelude::{Queryable, ToValue},
-    DriverError, Opts, Params, Row, SslOpts,
+    DriverError, Metrics, Opts, Params, Row, SslOpts,
 };
 use secrecy::{ExposeSecret, SecretBox, SecretString};
 use snafu::{ResultExt, Snafu};
@@ -50,6 +50,7 @@ pub enum Error {
     UnknownMySQLDatabase { message: String },
 }
 
+#[derive(Debug, Clone)]
 pub struct MySQLConnectionPool {
     pool: Arc<mysql_async::Pool>,
     join_push_down: JoinPushDown,
@@ -195,6 +196,10 @@ impl MySQLConnectionPool {
             .context(MySQLConnectionSnafu)?;
 
         Ok(MySQLConnection::new(conn))
+    }
+
+    pub fn metrics(&self) -> Arc<Metrics> {
+        self.pool.metrics()
     }
 }
 


### PR DESCRIPTION
Upgrades `mysql_async` to `35.1` which adds support for various metrics around the connection pooler. Add a new `metrics()` function on the `MySQLConnectionPool` struct to expose these metrics.

Also removes the unnecessary type parameters on the `MySQLTable` struct - we know exactly what the types of the underlying DbConnectionPool trait should be in this case. This makes it easier for consumers as well, as they now just need to pass `MySQLConnectionPool` instead of the `DbConnectionPool` trait.