### PR TITLE
Postgres: Make json/jsonb schema type and record types consistent (Utf8)

### DIFF
--- a/src/sql/arrow_sql_gen/postgres.rs
+++ b/src/sql/arrow_sql_gen/postgres.rs
@@ -324,7 +324,7 @@ pub fn rows_to_arrow(rows: &[Row], projected_schema: &Option<SchemaRef>) -> Resu
                     let Some(builder) = builder else {
                         return NoBuilderForIndexSnafu { index: i }.fail();
                     };
-                    let Some(builder) = builder.as_any_mut().downcast_mut::<LargeStringBuilder>()
+                    let Some(builder) = builder.as_any_mut().downcast_mut::<StringBuilder>()
                     else {
                         return FailedToDowncastBuilderSnafu {
                             postgres_type: format!("{postgres_type}"),
@@ -845,7 +845,7 @@ fn map_column_type_to_data_type(column_type: &Type, field_name: &str) -> Result<
         Type::BYTEA => Ok(Some(DataType::Binary)),
         Type::BOOL => Ok(Some(DataType::Boolean)),
         // Schema validation will only allow JSONB columns when `UnsupportedTypeAction` is set to `String`, so it is safe to handle JSONB here as strings.
-        Type::JSON | Type::JSONB => Ok(Some(DataType::LargeUtf8)),
+        Type::JSON | Type::JSONB => Ok(Some(DataType::Utf8)),
         // Inspect the scale from the first row. Precision will always be 38 for Decimal128.
         Type::NUMERIC => Ok(None),
         Type::TIMESTAMPTZ => Ok(Some(DataType::Timestamp(

--- a/tests/postgres/mod.rs
+++ b/tests/postgres/mod.rs
@@ -281,7 +281,7 @@ async fn test_postgres_jsonb_type(port: usize) {
 
     let schema = Arc::new(Schema::new(vec![Field::new(
         "data",
-        DataType::LargeUtf8,
+        DataType::Utf8,
         true,
     )]));
 
@@ -304,7 +304,7 @@ async fn test_postgres_jsonb_type(port: usize) {
 
     let expected_record = RecordBatch::try_new(
         Arc::clone(&schema),
-        vec![Arc::new(arrow::array::LargeStringArray::from(
+        vec![Arc::new(arrow::array::StringArray::from(
             expected_values,
         ))],
     )


### PR DESCRIPTION
Follow up fix for the following change
- https://github.com/datafusion-contrib/datafusion-table-providers/pull/231

Schema type for JSON and JSONB has been updated but the query logic was not updated to reflect the change. As a result the DataFusion schema does not match actual record batch schema returned by query and result in unpredicted behavior like crash when accelerating the data
 - https://github.com/spiceai/spiceai/issues/5439