### PR TITLE
Postgres: Make json/jsonb schema type and record types consistent (Utf8) 

### DIFF
--- a/core/src/sql/arrow_sql_gen/postgres.rs
+++ b/core/src/sql/arrow_sql_gen/postgres.rs
@@ -356,7 +356,7 @@ pub fn rows_to_arrow(rows: &[Row], projected_schema: &Option<SchemaRef>) -> Resu
                     let Some(builder) = builder else {
                         return NoBuilderForIndexSnafu { index: i }.fail();
                     };
-                    let Some(builder) = builder.as_any_mut().downcast_mut::<LargeStringBuilder>()
+                    let Some(builder) = builder.as_any_mut().downcast_mut::<StringBuilder>()
                     else {
                         return FailedToDowncastBuilderSnafu {
                             postgres_type: format!("{postgres_type}"),
@@ -889,7 +889,7 @@ fn map_column_type_to_data_type(column_type: &Type, field_name: &str) -> Result<
         Type::BYTEA => Ok(Some(DataType::Binary)),
         Type::BOOL => Ok(Some(DataType::Boolean)),
         // Schema validation will only allow JSONB columns when `UnsupportedTypeAction` is set to `String`, so it is safe to handle JSONB here as strings.
-        Type::JSON | Type::JSONB => Ok(Some(DataType::LargeUtf8)),
+        Type::JSON | Type::JSONB => Ok(Some(DataType::Utf8)),
         // Inspect the scale from the first row. Precision will always be 38 for Decimal128.
         Type::NUMERIC => Ok(None),
         Type::TIMESTAMPTZ => Ok(Some(DataType::Timestamp(

--- a/core/src/sql/arrow_sql_gen/postgres/schema.rs
+++ b/core/src/sql/arrow_sql_gen/postgres/schema.rs
@@ -84,7 +84,7 @@ pub(crate) fn pg_data_type_to_arrow_type(
         "inet" | "cidr" | "macaddr" => Ok(DataType::Utf8),
         "bit" | "bit varying" => Ok(DataType::Binary),
         "tsvector" | "tsquery" => Ok(DataType::LargeUtf8),
-        "xml" | "json" => Ok(DataType::LargeUtf8),
+        "xml" | "json" => Ok(DataType::Utf8),
         "aclitem" | "pg_node_tree" => Ok(DataType::Utf8),
         "array" => parse_array_type(context),
         "anyarray" => Ok(DataType::List(Arc::new(Field::new(
@@ -101,7 +101,7 @@ pub(crate) fn pg_data_type_to_arrow_type(
 
         // `jsonb` is currently not supported, but if the user has set the `UnsupportedTypeAction` to `String` we'll return `Utf8`.
         "jsonb" if context.unsupported_type_action == UnsupportedTypeAction::String => {
-            Ok(DataType::LargeUtf8)
+            Ok(DataType::Utf8)
         }
         _ => Err(ArrowError::ParseError(format!(
             "Unsupported PostgreSQL type: {}",
@@ -509,7 +509,7 @@ mod tests {
         // Test JSON types
         assert_eq!(
             pg_data_type_to_arrow_type("json", &context).expect("Failed to convert json"),
-            DataType::LargeUtf8
+            DataType::Utf8
         );
 
         let jsonb_context = context
@@ -517,7 +517,7 @@ mod tests {
             .with_unsupported_type_action(UnsupportedTypeAction::String);
         assert_eq!(
             pg_data_type_to_arrow_type("jsonb", &jsonb_context).expect("Failed to convert jsonb"),
-            DataType::LargeUtf8
+            DataType::Utf8
         );
 
         // Test UUID type

--- a/core/tests/postgres/mod.rs
+++ b/core/tests/postgres/mod.rs
@@ -291,7 +291,7 @@ async fn test_postgres_jsonb_type(port: usize) {
 
     let schema = Arc::new(Schema::new(vec![Field::new(
         "data",
-        DataType::LargeUtf8,
+        DataType::Utf8,
         true,
     )]));
 
@@ -314,7 +314,7 @@ async fn test_postgres_jsonb_type(port: usize) {
 
     let expected_record = RecordBatch::try_new(
         Arc::clone(&schema),
-        vec![Arc::new(arrow::array::LargeStringArray::from(
+        vec![Arc::new(arrow::array::StringArray::from(
             expected_values,
         ))],
     )

--- a/core/tests/postgres/snapshots/integration__postgres__schema__postgres_materialized_view_schema_inference.snap
+++ b/core/tests/postgres/snapshots/integration__postgres__schema__postgres_materialized_view_schema_inference.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/postgres/schema.rs
+source: core/tests/postgres/schema.rs
 expression: pretty_schema
 ---
 Schema {
@@ -221,6 +221,33 @@ Schema {
                     dict_is_ordered: false,
                     metadata: {},
                 },
+            ),
+            nullable: true,
+            dict_id: 0,
+            dict_is_ordered: false,
+            metadata: {},
+        },
+        Field {
+            name: "int_range_col",
+            data_type: Struct(
+                [
+                    Field {
+                        name: "lower",
+                        data_type: Int32,
+                        nullable: true,
+                        dict_id: 0,
+                        dict_is_ordered: false,
+                        metadata: {},
+                    },
+                    Field {
+                        name: "upper",
+                        data_type: Int32,
+                        nullable: true,
+                        dict_id: 0,
+                        dict_is_ordered: false,
+                        metadata: {},
+                    },
+                ],
             ),
             nullable: true,
             dict_id: 0,

--- a/core/tests/postgres/snapshots/integration__postgres__schema__postgres_schema_inference_complex_types.snap
+++ b/core/tests/postgres/snapshots/integration__postgres__schema__postgres_schema_inference_complex_types.snap
@@ -187,7 +187,7 @@ Schema {
         },
         Field {
             name: "json_col",
-            data_type: LargeUtf8,
+            data_type: Utf8,
             nullable: true,
             dict_id: 0,
             dict_is_ordered: false,

--- a/core/tests/postgres/snapshots/integration__postgres__schema__postgres_view_schema_inference.snap
+++ b/core/tests/postgres/snapshots/integration__postgres__schema__postgres_view_schema_inference.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/postgres/schema.rs
+source: core/tests/postgres/schema.rs
 expression: pretty_schema
 ---
 Schema {
@@ -221,6 +221,33 @@ Schema {
                     dict_is_ordered: false,
                     metadata: {},
                 },
+            ),
+            nullable: true,
+            dict_id: 0,
+            dict_is_ordered: false,
+            metadata: {},
+        },
+        Field {
+            name: "int_range_col",
+            data_type: Struct(
+                [
+                    Field {
+                        name: "lower",
+                        data_type: Int32,
+                        nullable: true,
+                        dict_id: 0,
+                        dict_is_ordered: false,
+                        metadata: {},
+                    },
+                    Field {
+                        name: "upper",
+                        data_type: Int32,
+                        nullable: true,
+                        dict_id: 0,
+                        dict_is_ordered: false,
+                        metadata: {},
+                    },
+                ],
             ),
             nullable: true,
             dict_id: 0,


### PR DESCRIPTION
Add Postgres query result schema compatibility fix for  json and jsonb
 - https://github.com/datafusion-contrib/datafusion-table-providers/pull/317

Include changes from the following PR that were not fully merged into main (I see [merge PR ](https://github.com/datafusion-contrib/datafusion-table-providers/pull/255/files) included the changes partially only)
 - https://github.com/datafusion-contrib/datafusion-table-providers/pull/231

Fix snapshots (unrelated to this change, but I found them failing while testing json/jsonb)