### PR TITLE
DuckDB: don't use ArrowVTab while creating the table (more types support)

### DIFF
--- a/src/duckdb.rs
+++ b/src/duckdb.rs
@@ -156,6 +156,9 @@ pub enum Error {
     #[snafu(display("Failed to register Arrow scan view for DuckDB ingestion: {source}"))]
     UnableToRegisterArrowScanView { source: duckdb::Error },
 
+    #[snafu(display("Failed to register Arrow scan view to build table creation statement: {source}"))]
+    UnableToRegisterArrowScanViewForTableCreation { source: duckdb::Error },
+
     #[snafu(display("Failed to drop Arrow scan view for DuckDB ingestion: {source}"))]
     UnableToDropArrowScanView { source: duckdb::Error },
 }

--- a/src/duckdb/creator.rs
+++ b/src/duckdb/creator.rs
@@ -428,8 +428,6 @@ impl TableManager {
         // DuckDB doesn't add IF NOT EXISTS to CREATE TABLE statements, so we add it here.
         let create_stmt = create_stmt.replace("CREATE TABLE", "CREATE TABLE IF NOT EXISTS");
 
-        tracing::trace!("{create_stmt}");
-
         tx.rollback()
             .context(super::UnableToRollbackTransactionSnafu)?;
 

--- a/tests/arrow_record_batch_gen/mod.rs
+++ b/tests/arrow_record_batch_gen/mod.rs
@@ -706,7 +706,6 @@ pub(crate) fn get_arrow_map_record_batch() -> (RecordBatch, SchemaRef) {
     let schema = Arc::new(Schema::new(vec![Field::new("map_array", map_array.data_type().clone(), true)]));
     let rb = RecordBatch::try_new(Arc::clone(&schema), vec![Arc::new(map_array)]).expect("Failed to created arrow Map array record batch");
     (rb, schema)
-
 }
 
 // Custom Test Case for Sqlite <-> Arrow Decimal Roundtrip

--- a/tests/arrow_record_batch_gen/mod.rs
+++ b/tests/arrow_record_batch_gen/mod.rs
@@ -687,6 +687,28 @@ pub(crate) fn get_arrow_dictionary_array_record_batch() -> (RecordBatch, SchemaR
     (record_batch, schema)
 }
 
+pub(crate) fn get_arrow_map_record_batch() -> (RecordBatch, SchemaRef) {
+    let keys = vec!["a", "b", "c", "d", "e", "f", "g", "h"];
+    let values_data = UInt32Array::from(vec![
+        Some(0u32),
+        None,
+        Some(20),
+        Some(30),
+        None,
+        Some(50),
+        Some(60),
+        Some(70),
+    ]);
+    // Construct a buffer for value offsets, for the nested array:
+    //  [[a, b, c], [d, e, f], [g, h]]
+    let entry_offsets = [0, 3, 6, 8];
+    let map_array = MapArray::new_from_strings(keys.clone().into_iter(), &values_data, &entry_offsets).expect("Failed to create MapArray");
+    let schema = Arc::new(Schema::new(vec![Field::new("map_array", map_array.data_type().clone(), true)]));
+    let rb = RecordBatch::try_new(Arc::clone(&schema), vec![Arc::new(map_array)]).expect("Failed to created arrow Map array record batch");
+    (rb, schema)
+
+}
+
 // Custom Test Case for Sqlite <-> Arrow Decimal Roundtrip
 // SQLite supports up to 16 precision for decimal numbers through REAL type, conforming to IEEE 754 Binary-64 format - https://www.sqlite.org/floatingpoint.html
 pub(crate) fn get_sqlite_arrow_decimal_record_batch() -> (RecordBatch, SchemaRef) {

--- a/tests/duckdb/mod.rs
+++ b/tests/duckdb/mod.rs
@@ -79,8 +79,6 @@ async fn arrow_duckdb_round_trip(
 }
 
 #[rstest]
-#[ignore]
-// Binder Error: Unsupported data type: FixedSizeBinary(2), please file an issue https://github.com/wangfenjin/duckdb-rs"
 #[case::binary(get_arrow_binary_record_batch(), "binary")]
 #[case::int(get_arrow_int_record_batch(), "int")]
 #[case::float(get_arrow_float_record_batch(), "float")]
@@ -89,11 +87,11 @@ async fn arrow_duckdb_round_trip(
 #[case::timestamp(get_arrow_timestamp_record_batch(), "timestamp")]
 #[case::date(get_arrow_date_record_batch(), "date")]
 #[case::struct_type(get_arrow_struct_record_batch(), "struct")]
-#[ignore] // Decimal256(76,10) is not yet supported for ArrowVTab
+#[ignore] // External(UnableToCreateDuckDBTable { source: DuckDBFailure(Error { code: Unknown, extended_code: 1 }, Some("Invalid Input Error: Data type \"Decimal256(76, 10)\" not yet supported by ArrowVTab")) })
 #[case::decimal(get_arrow_decimal_record_batch(), "decimal")]
-#[ignore] // Interval(DayTime) is not yet supported for ArrowVTab
+#[ignore] // External(DataWriteError { source: External(UnableToInsertToDuckDBTable { source: DuckDBFailure(Error { code: Unknown, extended_code: 1 }, Some("Conversion Error: Could not convert Interval to Microsecond")) }) })
 #[case::interval(get_arrow_interval_record_batch(), "interval")]
-#[ignore] // Duration(NanoSecond) is not yet supported for ArrowVTab
+#[ignore] // TimeUnit::Nanosecond is not correctly supported; written values are zeros
 #[case::duration(get_arrow_duration_record_batch(), "duration")]
 #[case::list(get_arrow_list_record_batch(), "list")]
 #[case::null(get_arrow_null_record_batch(), "null")]
@@ -103,6 +101,8 @@ async fn arrow_duckdb_round_trip(
     "list_of_fixed_size_lists"
 )]
 #[case::list_of_lists(get_arrow_list_of_lists_record_batch(), "list_of_lists")]
+#[case::map(get_arrow_map_record_batch(), "map")]
+#[case::dictionary(get_arrow_dictionary_array_record_batch(), "dictionary")]
 #[test_log::test(tokio::test)]
 async fn test_arrow_duckdb_roundtrip(
     #[case] arrow_result: (RecordBatch, SchemaRef),

--- a/tests/duckdb/mod.rs
+++ b/tests/duckdb/mod.rs
@@ -87,9 +87,9 @@ async fn arrow_duckdb_round_trip(
 #[case::timestamp(get_arrow_timestamp_record_batch(), "timestamp")]
 #[case::date(get_arrow_date_record_batch(), "date")]
 #[case::struct_type(get_arrow_struct_record_batch(), "struct")]
-#[ignore] // External(UnableToCreateDuckDBTable { source: DuckDBFailure(Error { code: Unknown, extended_code: 1 }, Some("Invalid Input Error: Data type \"Decimal256(76, 10)\" not yet supported by ArrowVTab")) })
+#[ignore] // DuckDB does not support Decimal256 / duckdb_arrow_scan failed to register view
 #[case::decimal(get_arrow_decimal_record_batch(), "decimal")]
-#[ignore] // External(DataWriteError { source: External(UnableToInsertToDuckDBTable { source: DuckDBFailure(Error { code: Unknown, extended_code: 1 }, Some("Conversion Error: Could not convert Interval to Microsecond")) }) })
+#[ignore] // Interval(DayTime) is not supported: / "Conversion Error: Could not convert Interval to Microsecond"
 #[case::interval(get_arrow_interval_record_batch(), "interval")]
 #[ignore] // TimeUnit::Nanosecond is not correctly supported; written values are zeros
 #[case::duration(get_arrow_duration_record_batch(), "duration")]


### PR DESCRIPTION
Similar to writing logic use Arrow Scan view instead of ArrowVTab to create table creation statement. This adds support for all DuckDB natively supported types, including Dictionary.

1. Added tests for Map and Dictionary for DuckDB

```
successes:
    duckdb::test_arrow_duckdb_roundtrip::case_01_binary
    duckdb::test_arrow_duckdb_roundtrip::case_02_int
    duckdb::test_arrow_duckdb_roundtrip::case_03_float
    duckdb::test_arrow_duckdb_roundtrip::case_04_utf8
    duckdb::test_arrow_duckdb_roundtrip::case_05_time
    duckdb::test_arrow_duckdb_roundtrip::case_06_timestamp
    duckdb::test_arrow_duckdb_roundtrip::case_07_date
    duckdb::test_arrow_duckdb_roundtrip::case_08_struct_type
    duckdb::test_arrow_duckdb_roundtrip::case_12_list
    duckdb::test_arrow_duckdb_roundtrip::case_13_null
    duckdb::test_arrow_duckdb_roundtrip::case_14_list_of_structs
    duckdb::test_arrow_duckdb_roundtrip::case_15_list_of_fixed_size_lists
    duckdb::test_arrow_duckdb_roundtrip::case_16_list_of_lists
    duckdb::test_arrow_duckdb_roundtrip::case_17_map
    duckdb::test_arrow_duckdb_roundtrip::case_18_dictionary

test result: ok. 15 passed; 0 failed; 3 ignored; 0 measured; 19 filtered out; finished in 0.36s
```

Related to 
- https://github.com/spiceai/spiceai/issues/5438
