### PR TITLE
fix: Add option for SQLite for perform decimal_cmp instead of BETWEEN

### DIFF
--- a/src/sqlite/between.rs
+++ b/src/sqlite/between.rs
@@ -23,8 +23,8 @@ impl VisitorMut for SQLiteBetweenVisitor {
     }
 }
 
-/// This AST visitor is used to convert BETWEEN expressions into decimal_cmp expressions.
-/// This is necessary with SQLite because some floating point values are not accurately comparable when used in the <low> or <high> position of the BETWEEN expression.
+/// This AST visitor is used to convert BETWEEN expressions into `decimal_cmp` expressions.
+/// This is necessary with `SQLite` because some floating point values are not accurately comparable when used in the <low> or <high> position of the BETWEEN expression.
 /// For example, `BETWEEN 0.06+0.01` will cause a floating point precision error that returns invalid results.
 ///
 /// This visitor instead converts the expression into two equivalent `decimal_cmp` expressions, for accurate arbitrary precision comparisons.

--- a/src/sqlite/between.rs
+++ b/src/sqlite/between.rs
@@ -1,0 +1,546 @@
+use datafusion::sql::sqlparser::ast::{
+    self, BinaryOperator, Expr, FunctionArg, FunctionArgExpr, FunctionArgumentList, Ident,
+    VisitorMut,
+};
+use std::ops::ControlFlow;
+
+#[derive(Default)]
+pub struct SQLiteBetweenVisitor {}
+
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub enum OpSide {
+    Left,
+    Right,
+}
+
+impl VisitorMut for SQLiteBetweenVisitor {
+    type Break = ();
+
+    fn pre_visit_expr(&mut self, expr: &mut Expr) -> ControlFlow<Self::Break> {
+        Self::rebuild_between(expr);
+
+        ControlFlow::Continue(())
+    }
+}
+
+impl SQLiteBetweenVisitor {
+    fn rebuild_between(expr: &mut Expr) {
+        // <expr> [ NOT ] BETWEEN <low> AND <high>
+        if let Expr::Between {
+            expr: input_expr,
+            negated,
+            low,
+            high,
+        } = expr
+        {
+            // if low or high contains numeric values (including in an expression), we can convert it to
+            // decimal_cmp(<expr>, <low>) >= 0 and decimal_cmp(<expr>, <high>) <= 0
+            // when negated is true, >= becomes < and <= becomes >
+
+            if Self::between_value_is_numeric(low) && Self::between_value_is_numeric(high) {
+                Self::wrap_numeric_values_in_decimal(low);
+                Self::wrap_numeric_values_in_decimal(high);
+
+                // right now, <expr> BETWEEN decimal(<low>) AND decimal(<high>)
+                // build each new half as a new Expr::BinaryOp
+
+                // lhs - decimal_cmp(<expr>, decimal(<low>)) [>= | <] 0
+                let lhs = Self::build_decimal_cmp_side(
+                    input_expr,
+                    low,
+                    Self::build_cmp_operator(OpSide::Left, *negated),
+                );
+
+                // rhs - decimal_cmp(<expr>, decimal(<high>)) [<= | >] 0
+                let rhs = Self::build_decimal_cmp_side(
+                    input_expr,
+                    high,
+                    Self::build_cmp_operator(OpSide::Right, *negated),
+                );
+
+                // replace the original BETWEEN expr with the new AND binary op
+                *expr = Expr::BinaryOp {
+                    left: Box::new(lhs),
+                    op: BinaryOperator::And,
+                    right: Box::new(rhs),
+                };
+            }
+        }
+    }
+
+    fn between_value_is_numeric(expr: &mut Expr) -> bool {
+        match expr {
+            Expr::Value(ast::Value::Number(_, _)) => true,
+            Expr::BinaryOp { left, op, right } => {
+                if matches!(op, BinaryOperator::Plus | BinaryOperator::Minus) {
+                    if let Expr::Value(ast::Value::Number(_, _)) = left.as_ref() {
+                        if let Expr::Value(ast::Value::Number(_, _)) = right.as_ref() {
+                            return true;
+                        }
+                    }
+                }
+                false
+            }
+            Expr::Nested(nested_expr) => Self::between_value_is_numeric(nested_expr),
+            _ => false,
+        }
+    }
+
+    fn wrap_numeric_values_in_decimal(expr: &mut Expr) {
+        match expr {
+            Expr::Value(ast::Value::Number(s, _)) => {
+                // if expr is a numeric literal, wrap it in a decimal scalar
+                *expr = Expr::Function(ast::Function {
+                    name: ast::ObjectName(vec![Ident::new("decimal")]),
+                    args: ast::FunctionArguments::List(FunctionArgumentList {
+                        duplicate_treatment: None,
+                        args: vec![FunctionArg::Unnamed(FunctionArgExpr::Expr(Expr::Value(
+                            ast::Value::SingleQuotedString(s.clone()),
+                        )))],
+                        clauses: Vec::new(),
+                    }),
+                    over: None,
+                    uses_odbc_syntax: false,
+                    parameters: ast::FunctionArguments::None,
+                    filter: None,
+                    null_treatment: None,
+                    within_group: Vec::new(),
+                });
+            }
+            Expr::BinaryOp { left, op: _, right } => {
+                Self::wrap_numeric_values_in_decimal(left);
+                Self::wrap_numeric_values_in_decimal(right);
+            }
+            Expr::Nested(nested_expr) => {
+                Self::wrap_numeric_values_in_decimal(nested_expr);
+            }
+            _ => {}
+        }
+    }
+
+    fn build_cmp_operator(side: OpSide, negated: bool) -> BinaryOperator {
+        match side {
+            OpSide::Left => {
+                if negated {
+                    BinaryOperator::Lt
+                } else {
+                    BinaryOperator::GtEq
+                }
+            }
+            OpSide::Right => {
+                if negated {
+                    BinaryOperator::Gt
+                } else {
+                    BinaryOperator::LtEq
+                }
+            }
+        }
+    }
+
+    fn build_decimal_cmp_side(
+        input_expr: &mut Expr,
+        comparison_expr: &mut Expr,
+        comparison_op: BinaryOperator,
+    ) -> Expr {
+        let right = Expr::Value(ast::Value::Number("0".to_string(), false));
+        let left = Expr::Function(ast::Function {
+            name: ast::ObjectName(vec![Ident::new("decimal_cmp")]),
+            args: ast::FunctionArguments::List(FunctionArgumentList {
+                duplicate_treatment: None,
+                args: vec![
+                    FunctionArg::Unnamed(FunctionArgExpr::Expr(input_expr.clone())),
+                    FunctionArg::Unnamed(FunctionArgExpr::Expr(comparison_expr.clone())),
+                ],
+                clauses: Vec::new(),
+            }),
+            over: None,
+            uses_odbc_syntax: false,
+            parameters: ast::FunctionArguments::None,
+            filter: None,
+            null_treatment: None,
+            within_group: Vec::new(),
+        });
+
+        Expr::BinaryOp {
+            left: Box::new(left),
+            op: comparison_op,
+            right: Box::new(right),
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    #[allow(clippy::too_many_lines)]
+    fn test_rebuild_between_into_decimal_cmp() {
+        let mut expr = Expr::Between {
+            expr: Box::new(Expr::Value(ast::Value::Number("1".to_string(), false))),
+            negated: false,
+            low: Box::new(Expr::Value(ast::Value::Number("2".to_string(), false))),
+            high: Box::new(Expr::Value(ast::Value::Number("3".to_string(), false))),
+        };
+
+        SQLiteBetweenVisitor::default().pre_visit_expr(&mut expr);
+
+        assert_eq!(
+            expr,
+            Expr::BinaryOp {
+                left: Box::new(Expr::BinaryOp {
+                    left: Box::new(Expr::Function(ast::Function {
+                        name: ast::ObjectName(vec![Ident::new("decimal_cmp")]),
+                        args: ast::FunctionArguments::List(FunctionArgumentList {
+                            duplicate_treatment: None,
+                            args: vec![
+                                FunctionArg::Unnamed(FunctionArgExpr::Expr(Expr::Value(
+                                    ast::Value::Number("1".to_string(), false)
+                                ))),
+                                FunctionArg::Unnamed(FunctionArgExpr::Expr(Expr::Function(
+                                    ast::Function {
+                                        name: ast::ObjectName(vec![Ident::new("decimal")]),
+                                        args: ast::FunctionArguments::List(FunctionArgumentList {
+                                            duplicate_treatment: None,
+                                            args: vec![FunctionArg::Unnamed(
+                                                FunctionArgExpr::Expr(Expr::Value(
+                                                    ast::Value::SingleQuotedString("2".to_string())
+                                                ),),
+                                            )],
+                                            clauses: Vec::new(),
+                                        },),
+                                        over: None,
+                                        uses_odbc_syntax: false,
+                                        parameters: ast::FunctionArguments::None,
+                                        filter: None,
+                                        null_treatment: None,
+                                        within_group: Vec::<ast::OrderByExpr>::new(),
+                                    }
+                                ),)),
+                            ],
+                            clauses: Vec::new(),
+                        }),
+                        over: None,
+                        uses_odbc_syntax: false,
+                        parameters: ast::FunctionArguments::None,
+                        filter: None,
+                        null_treatment: None,
+                        within_group: Vec::<ast::OrderByExpr>::new(),
+                    })),
+                    op: BinaryOperator::GtEq,
+                    right: Box::<Expr>::from(Expr::Value(ast::Value::Number(
+                        "0".to_string(),
+                        false
+                    ))),
+                }),
+                op: BinaryOperator::And,
+                right: Box::new(Expr::BinaryOp {
+                    left: Box::new(Expr::Function(ast::Function {
+                        name: ast::ObjectName(vec![Ident::new("decimal_cmp")]),
+                        args: ast::FunctionArguments::List(FunctionArgumentList {
+                            duplicate_treatment: None,
+                            args: vec![
+                                FunctionArg::Unnamed(FunctionArgExpr::Expr(Expr::Value(
+                                    ast::Value::Number("1".to_string(), false)
+                                ))),
+                                FunctionArg::Unnamed(FunctionArgExpr::Expr(Expr::Function(
+                                    ast::Function {
+                                        name: ast::ObjectName(vec![Ident::new("decimal")]),
+                                        args: ast::FunctionArguments::List(FunctionArgumentList {
+                                            duplicate_treatment: None,
+                                            args: vec![FunctionArg::Unnamed(
+                                                FunctionArgExpr::Expr(Expr::Value(
+                                                    ast::Value::SingleQuotedString("3".to_string())
+                                                ),),
+                                            )],
+                                            clauses: Vec::new(),
+                                        },),
+                                        over: None,
+                                        uses_odbc_syntax: false,
+                                        parameters: ast::FunctionArguments::None,
+                                        filter: None,
+                                        null_treatment: None,
+                                        within_group: Vec::<ast::OrderByExpr>::new(),
+                                    }
+                                ),)),
+                            ],
+                            clauses: Vec::new(),
+                        }),
+                        over: None,
+                        uses_odbc_syntax: false,
+                        parameters: ast::FunctionArguments::None,
+                        filter: None,
+                        null_treatment: None,
+                        within_group: Vec::<ast::OrderByExpr>::new(),
+                    })),
+                    op: BinaryOperator::LtEq,
+                    right: Box::<Expr>::from(Expr::Value(ast::Value::Number(
+                        "0".to_string(),
+                        false
+                    ))),
+                }),
+            }
+        );
+    }
+
+    #[test]
+    #[allow(clippy::too_many_lines)]
+    fn test_rebuild_between_numeric_low_binary_op() {
+        let mut expr = Expr::Between {
+            expr: Box::new(Expr::Value(ast::Value::Number("10".to_string(), false))),
+            negated: false,
+            low: Box::new(Expr::BinaryOp {
+                left: Box::new(Expr::Value(ast::Value::Number("1".to_string(), false))),
+                op: BinaryOperator::Plus,
+                right: Box::new(Expr::Value(ast::Value::Number("2".to_string(), false))),
+            }),
+            high: Box::new(Expr::Value(ast::Value::Number("20".to_string(), false))),
+        };
+
+        SQLiteBetweenVisitor::default().pre_visit_expr(&mut expr);
+
+        assert_eq!(
+            expr,
+            Expr::BinaryOp {
+                left: Box::new(Expr::BinaryOp {
+                    left: Box::new(Expr::Function(ast::Function {
+                        name: ast::ObjectName(vec![Ident::new("decimal_cmp")]),
+                        args: ast::FunctionArguments::List(FunctionArgumentList {
+                            duplicate_treatment: None,
+                            args: vec![
+                                FunctionArg::Unnamed(FunctionArgExpr::Expr(Expr::Value(
+                                    ast::Value::Number("10".to_string(), false)
+                                ))),
+                                FunctionArg::Unnamed(FunctionArgExpr::Expr(Expr::BinaryOp {
+                                    left: Box::new(Expr::Function(ast::Function {
+                                        name: ast::ObjectName(vec![Ident::new("decimal")]),
+                                        args: ast::FunctionArguments::List(FunctionArgumentList {
+                                            duplicate_treatment: None,
+                                            args: vec![FunctionArg::Unnamed(
+                                                FunctionArgExpr::Expr(Expr::Value(
+                                                    ast::Value::SingleQuotedString("1".to_string())
+                                                ))
+                                            )],
+                                            clauses: Vec::new(),
+                                        }),
+                                        over: None,
+                                        uses_odbc_syntax: false,
+                                        parameters: ast::FunctionArguments::None,
+                                        filter: None,
+                                        null_treatment: None,
+                                        within_group: Vec::new(),
+                                    })),
+                                    op: BinaryOperator::Plus,
+                                    right: Box::new(Expr::Function(ast::Function {
+                                        name: ast::ObjectName(vec![Ident::new("decimal")]),
+                                        args: ast::FunctionArguments::List(FunctionArgumentList {
+                                            duplicate_treatment: None,
+                                            args: vec![FunctionArg::Unnamed(
+                                                FunctionArgExpr::Expr(Expr::Value(
+                                                    ast::Value::SingleQuotedString("2".to_string())
+                                                ))
+                                            )],
+                                            clauses: Vec::new(),
+                                        }),
+                                        over: None,
+                                        uses_odbc_syntax: false,
+                                        parameters: ast::FunctionArguments::None,
+                                        filter: None,
+                                        null_treatment: None,
+                                        within_group: Vec::new(),
+                                    })),
+                                })),
+                            ],
+                            clauses: Vec::new(),
+                        }),
+                        over: None,
+                        uses_odbc_syntax: false,
+                        parameters: ast::FunctionArguments::None,
+                        filter: None,
+                        null_treatment: None,
+                        within_group: Vec::new(),
+                    })),
+                    op: BinaryOperator::GtEq,
+                    right: Box::<Expr>::from(Expr::Value(ast::Value::Number(
+                        "0".to_string(),
+                        false
+                    ))),
+                }),
+                op: BinaryOperator::And,
+                right: Box::new(Expr::BinaryOp {
+                    left: Box::new(Expr::Function(ast::Function {
+                        name: ast::ObjectName(vec![Ident::new("decimal_cmp")]),
+                        args: ast::FunctionArguments::List(FunctionArgumentList {
+                            duplicate_treatment: None,
+                            args: vec![
+                                FunctionArg::Unnamed(FunctionArgExpr::Expr(Expr::Value(
+                                    ast::Value::Number("10".to_string(), false)
+                                ))),
+                                FunctionArg::Unnamed(FunctionArgExpr::Expr(Expr::Function(
+                                    ast::Function {
+                                        name: ast::ObjectName(vec![Ident::new("decimal")]),
+                                        args: ast::FunctionArguments::List(FunctionArgumentList {
+                                            duplicate_treatment: None,
+                                            args: vec![FunctionArg::Unnamed(
+                                                FunctionArgExpr::Expr(Expr::Value(
+                                                    ast::Value::SingleQuotedString(
+                                                        "20".to_string()
+                                                    )
+                                                ),),
+                                            )],
+                                            clauses: Vec::new(),
+                                        },),
+                                        over: None,
+                                        uses_odbc_syntax: false,
+                                        parameters: ast::FunctionArguments::None,
+                                        filter: None,
+                                        null_treatment: None,
+                                        within_group: Vec::new(),
+                                    }
+                                ),)),
+                            ],
+                            clauses: Vec::new(),
+                        }),
+                        over: None,
+                        uses_odbc_syntax: false,
+                        parameters: ast::FunctionArguments::None,
+                        filter: None,
+                        null_treatment: None,
+                        within_group: Vec::new(),
+                    })),
+                    op: BinaryOperator::LtEq,
+                    right: Box::<Expr>::from(Expr::Value(ast::Value::Number(
+                        "0".to_string(),
+                        false
+                    ))),
+                }),
+            }
+        );
+    }
+
+    #[test]
+    #[allow(clippy::too_many_lines)]
+    fn test_rebuild_not_between_into_decimal_cmp() {
+        let mut expr = Expr::Between {
+            expr: Box::new(Expr::Value(ast::Value::Number("1".to_string(), false))),
+            negated: true,
+            low: Box::new(Expr::Value(ast::Value::Number("2".to_string(), false))),
+            high: Box::new(Expr::Value(ast::Value::Number("3".to_string(), false))),
+        };
+
+        SQLiteBetweenVisitor::default().pre_visit_expr(&mut expr);
+
+        assert_eq!(
+            expr,
+            Expr::BinaryOp {
+                left: Box::new(Expr::BinaryOp {
+                    left: Box::new(Expr::Function(ast::Function {
+                        name: ast::ObjectName(vec![Ident::new("decimal_cmp")]),
+                        args: ast::FunctionArguments::List(FunctionArgumentList {
+                            duplicate_treatment: None,
+                            args: vec![
+                                FunctionArg::Unnamed(FunctionArgExpr::Expr(Expr::Value(
+                                    ast::Value::Number("1".to_string(), false)
+                                ))),
+                                FunctionArg::Unnamed(FunctionArgExpr::Expr(Expr::Function(
+                                    ast::Function {
+                                        name: ast::ObjectName(vec![Ident::new("decimal")]),
+                                        args: ast::FunctionArguments::List(FunctionArgumentList {
+                                            duplicate_treatment: None,
+                                            args: vec![FunctionArg::Unnamed(
+                                                FunctionArgExpr::Expr(Expr::Value(
+                                                    ast::Value::SingleQuotedString("2".to_string())
+                                                ),),
+                                            )],
+                                            clauses: Vec::new(),
+                                        },),
+                                        over: None,
+                                        uses_odbc_syntax: false,
+                                        parameters: ast::FunctionArguments::None,
+                                        filter: None,
+                                        null_treatment: None,
+                                        within_group: Vec::new(),
+                                    }
+                                ),)),
+                            ],
+                            clauses: Vec::new(),
+                        }),
+                        over: None,
+                        uses_odbc_syntax: false,
+                        parameters: ast::FunctionArguments::None,
+                        filter: None,
+                        null_treatment: None,
+                        within_group: Vec::new(),
+                    })),
+                    op: BinaryOperator::Lt, // Negated: GtEq becomes Lt
+                    right: Box::<Expr>::from(Expr::Value(ast::Value::Number(
+                        "0".to_string(),
+                        false
+                    ))),
+                }),
+                op: BinaryOperator::And,
+                right: Box::new(Expr::BinaryOp {
+                    left: Box::new(Expr::Function(ast::Function {
+                        name: ast::ObjectName(vec![Ident::new("decimal_cmp")]),
+                        args: ast::FunctionArguments::List(FunctionArgumentList {
+                            duplicate_treatment: None,
+                            args: vec![
+                                FunctionArg::Unnamed(FunctionArgExpr::Expr(Expr::Value(
+                                    ast::Value::Number("1".to_string(), false)
+                                ))),
+                                FunctionArg::Unnamed(FunctionArgExpr::Expr(Expr::Function(
+                                    ast::Function {
+                                        name: ast::ObjectName(vec![Ident::new("decimal")]),
+                                        args: ast::FunctionArguments::List(FunctionArgumentList {
+                                            duplicate_treatment: None,
+                                            args: vec![FunctionArg::Unnamed(
+                                                FunctionArgExpr::Expr(Expr::Value(
+                                                    ast::Value::SingleQuotedString("3".to_string())
+                                                ),),
+                                            )],
+                                            clauses: Vec::new(),
+                                        },),
+                                        over: None,
+                                        uses_odbc_syntax: false,
+                                        parameters: ast::FunctionArguments::None,
+                                        filter: None,
+                                        null_treatment: None,
+                                        within_group: Vec::new(),
+                                    }
+                                ),)),
+                            ],
+                            clauses: Vec::new(),
+                        }),
+                        over: None,
+                        uses_odbc_syntax: false,
+                        parameters: ast::FunctionArguments::None,
+                        filter: None,
+                        null_treatment: None,
+                        within_group: Vec::new(),
+                    })),
+                    op: BinaryOperator::Gt, // Negated: LtEq becomes Gt
+                    right: Box::<Expr>::from(Expr::Value(ast::Value::Number(
+                        "0".to_string(),
+                        false
+                    ))),
+                }),
+            }
+        );
+    }
+
+    #[test]
+    fn test_rebuild_between_string_low_not_modified() {
+        let original_expr = Expr::Between {
+            expr: Box::new(Expr::Value(ast::Value::Number("1".to_string(), false))),
+            negated: false,
+            low: Box::new(Expr::Value(ast::Value::SingleQuotedString("2".to_string()))),
+            high: Box::new(Expr::Value(ast::Value::Number("3".to_string(), false))),
+        };
+        let mut expr = original_expr.clone();
+
+        SQLiteBetweenVisitor::default().pre_visit_expr(&mut expr);
+
+        // Expect no change because 'low' is a string
+        assert_eq!(expr, original_expr);
+    }
+}

--- a/src/sqlite/between.rs
+++ b/src/sqlite/between.rs
@@ -23,6 +23,11 @@ impl VisitorMut for SQLiteBetweenVisitor {
     }
 }
 
+/// This AST visitor is used to convert BETWEEN expressions into decimal_cmp expressions.
+/// This is necessary with SQLite because some floating point values are not accurately comparable when used in the <low> or <high> position of the BETWEEN expression.
+/// For example, `BETWEEN 0.06+0.01` will cause a floating point precision error that returns invalid results.
+///
+/// This visitor instead converts the expression into two equivalent `decimal_cmp` expressions, for accurate arbitrary precision comparisons.
 impl SQLiteBetweenVisitor {
     fn rebuild_between(expr: &mut Expr) {
         // <expr> [ NOT ] BETWEEN <low> AND <high>

--- a/src/sqlite/sql_table.rs
+++ b/src/sqlite/sql_table.rs
@@ -25,12 +25,14 @@ use datafusion::{
 
 pub struct SQLiteTable<T: 'static, P: 'static> {
     pub(crate) base_table: SqlTable<T, P>,
+    pub(crate) decimal_between: bool,
 }
 
 impl<T, P> std::fmt::Debug for SQLiteTable<T, P> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("SQLiteTable")
             .field("base_table", &self.base_table)
+            .field("decimal_between", &self.decimal_between)
             .finish()
     }
 }
@@ -50,7 +52,16 @@ impl<T, P> SQLiteTable<T, P> {
         )
         .with_dialect(Arc::new(SqliteDialect {}));
 
-        Self { base_table }
+        Self {
+            base_table,
+            decimal_between: false,
+        }
+    }
+
+    #[must_use]
+    pub fn with_decimal_between(mut self, decimal_between: bool) -> Self {
+        self.decimal_between = decimal_between;
+        self
     }
 
     fn create_physical_plan(


### PR DESCRIPTION
* Introduces a new AST analzyer rule for the SQLite table provider, to rewrite `BETWEEN` rules that use numerics in the low and high values to use `decimal_cmp()` instead.
* `decimal_cmp()` and associated `decimal()` functions are only supported when the SQLite library is built with `decimal.c`, which a user may not always. Because of this, the analyzer rule is opt-in by specifying `.with_decimal_between(true)` in the provider factory or builder.

This resolves situations like `l_discount BETWEEN 0.06-0.01 AND 0.06+0.01` into `decimal_cmp(l_discount, decimal('0.06')-decimal('0.01')) >= 0 AND ...` to perform accurate arbitrary-precision `BETWEEN` queries against SQLite numeric values.

