### PR TITLE
MySQL: Set the `character_set_results`/`character_set_client`/`character_set_connection` session variables on connection setup

### DIFF
--- a/src/sql/db_connection_pool/mysqlpool.rs
+++ b/src/sql/db_connection_pool/mysqlpool.rs
@@ -49,9 +49,6 @@ pub enum Error {
 
     #[snafu(display("{message}\nEnsure the given MySQL database exists"))]
     UnknownMySQLDatabase { message: String },
-
-    #[snafu(display("Unsupported value: '{value}' for 'character_set_results'. Only 'utf8mb3' and 'utf8mb4' are supported."))]
-    InvalidCharacterSetResults { value: String },
 }
 
 #[derive(Debug, Clone)]


### PR DESCRIPTION
Sets the `character_set_results`/`character_set_client`/`character_set_connection` session variables on connection setup. Also moves the `SET time_zone = '+00:00'` query into the same setup function.

See MySQL character set results doc for an explanation on these variables: https://dev.mysql.com/doc/refman/8.4/en/charset-connection.html

This is required to ensure that the results we receive from MySQL are encoded correctly into UTF8