### PR TITLE
Add `application_name` parameter to postgres options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ Cargo.lock
 *.db
 
 .vscode/settings.json
+.zed/settings.json
 
 .DS_Store
 

--- a/src/sql/db_connection_pool/duckdbpool.rs
+++ b/src/sql/db_connection_pool/duckdbpool.rs
@@ -360,7 +360,6 @@ mod test {
 
     use super::*;
     use crate::sql::db_connection_pool::DbConnectionPool;
-    use std::sync::Arc;
 
     fn random_db_name() -> String {
         let mut rng = rand::thread_rng();

--- a/src/sql/db_connection_pool/postgrespool.rs
+++ b/src/sql/db_connection_pool/postgrespool.rs
@@ -164,7 +164,14 @@ impl PostgresConnectionPool {
         };
 
         connection_string.push_str(format!("sslmode={mode} ").as_str());
-        let config = Config::from_str(connection_string.as_str()).context(ConnectionPoolSnafu)?;
+        let mut config =
+            Config::from_str(connection_string.as_str()).context(ConnectionPoolSnafu)?;
+
+        if let Some(application_name) = params.get("application_name").map(SecretBox::expose_secret)
+        {
+            config.application_name(application_name);
+        }
+
         verify_postgres_config(&config).await?;
 
         let mut certs: Option<Vec<Certificate>> = None;


### PR DESCRIPTION
Allow specifying the `application_name` parameter in the Postgres options.

https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNECT-APPLICATION-NAME