### PR TITLE
Don't display bb8 Postgres pool errors by default

### DIFF
--- a/src/sql/db_connection_pool/postgrespool.rs
+++ b/src/sql/db_connection_pool/postgrespool.rs
@@ -365,7 +365,7 @@ where
     E: std::fmt::Display,
 {
     fn sink(&self, error: E) {
-        tracing::debug!("Postgres Connection Error: {:?}", error);
+        tracing::debug!("Postgres Pool Error: {}", error);
     }
 
     fn boxed_clone(&self) -> Box<dyn ErrorSink<E>> {

--- a/src/sql/db_connection_pool/postgrespool.rs
+++ b/src/sql/db_connection_pool/postgrespool.rs
@@ -365,7 +365,7 @@ where
     E: std::fmt::Display,
 {
     fn sink(&self, error: E) {
-        tracing::error!("Postgres Connection Error: {:?}", error);
+        tracing::debug!("Postgres Connection Error: {:?}", error);
     }
 
     fn boxed_clone(&self) -> Box<dyn ErrorSink<E>> {


### PR DESCRIPTION
Don't display Postgres connection pool errors by default. These errors are not associated with any particular request on a connection but rather with the operation of the pool itself. This manifests itself for benign operations like when a connection is closed, i.e.:

```bash
2025-05-11T16:35:44.147310Z ERROR datafusion_table_providers::sql::db_connection_pool::postgrespool: Postgres Connection Error: Error { kind: Closed, cause: None }
```

This isn't helpful or useful - so bump this error logging down to `debug`.