### PR TITLE
use dialect in SqlExec::sql

### DIFF
--- a/src/duckdb/sql_table.rs
+++ b/src/duckdb/sql_table.rs
@@ -143,6 +143,7 @@ impl<T, P> DuckSqlExec<T, P> {
             filters,
             limit,
             Some(Engine::DuckDB),
+            None,
         )?;
 
         Ok(Self {

--- a/src/mysql/sql_table.rs
+++ b/src/mysql/sql_table.rs
@@ -136,6 +136,7 @@ impl MySQLSQLExec {
             filters,
             limit,
             Some(Engine::MySQL),
+            None,
         )?;
 
         Ok(Self { base_exec })

--- a/src/sql/db_connection_pool/dbconnection.rs
+++ b/src/sql/db_connection_pool/dbconnection.rs
@@ -167,3 +167,17 @@ pub async fn query_arrow<T, P>(
         return Err(Error::UnableToDowncastConnection {});
     }
 }
+
+#[cfg(test)]
+pub(crate) struct DummyDbConnection(pub ());
+
+#[cfg(test)]
+impl DbConnection<(), ()> for DummyDbConnection {
+    fn as_any(&self) -> &dyn Any {
+        &self.0
+    }
+
+    fn as_any_mut(&mut self) -> &mut dyn Any {
+        &mut self.0
+    }
+}

--- a/src/sql/db_connection_pool/mod.rs
+++ b/src/sql/db_connection_pool/mod.rs
@@ -68,3 +68,18 @@ impl DbInstanceKey {
         DbInstanceKey::File(path)
     }
 }
+
+#[cfg(test)]
+pub(crate) struct DummyDbConnectionPool;
+
+#[cfg(test)]
+#[async_trait]
+impl DbConnectionPool<(), ()> for DummyDbConnectionPool {
+    async fn connect(&self) -> Result<Box<dyn DbConnection<(), ()>>> {
+        Ok(Box::new(dbconnection::DummyDbConnection(())))
+    }
+
+    fn join_push_down(&self) -> JoinPushDown {
+        JoinPushDown::Disallow
+    }
+}

--- a/src/sqlite/sql_table.rs
+++ b/src/sqlite/sql_table.rs
@@ -142,6 +142,7 @@ impl<T, P> SQLiteSqlExec<T, P> {
             filters,
             limit,
             Some(Engine::SQLite),
+            None,
         )?;
 
         Ok(Self { base_exec })


### PR DESCRIPTION
Use the dialect given to `SqlTable` in `SqlExec::sql`.