### PR TITLE
Support custom scalar functions in MySQL unparser dialect

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,7 +81,7 @@ datafusion-physical-plan = { version = "46" }
 tempfile = "3.8.1"
 
 [features]
-mysql = ["dep:mysql_async", "dep:async-stream"]
+mysql = ["dep:mysql_async", "dep:async-stream", "dep:arrow-schema"]
 postgres = ["dep:tokio-postgres", "dep:uuid", "dep:postgres-native-tls", "dep:bb8", "dep:bb8-postgres", "dep:native-tls", "dep:pem", "dep:async-stream", "dep:arrow-schema"]
 sqlite = ["dep:rusqlite", "dep:tokio-rusqlite", "dep:arrow-schema"]
 duckdb = ["dep:duckdb", "dep:r2d2", "dep:uuid", "dep:dyn-clone", "dep:async-stream", "dep:arrow-schema", "dep:byte-unit"]

--- a/src/mysql/builder.rs
+++ b/src/mysql/builder.rs
@@ -1,0 +1,54 @@
+use std::sync::Arc;
+
+use datafusion::sql::{unparser::dialect::Dialect, TableReference};
+use mysql_async::prelude::ToValue;
+
+use crate::sql::{
+    db_connection_pool::{mysqlpool::MySQLConnectionPool, DbConnectionPool},
+    sql_provider_datafusion::{self, SqlTable},
+};
+
+use super::{dialect::MySqlDialect, sql_table::MySQLTable};
+
+pub struct MySQLTableBuilder {
+    pool: Arc<MySQLConnectionPool>,
+    table_reference: TableReference,
+    dialect: Option<Arc<dyn Dialect>>,
+}
+
+impl MySQLTableBuilder {
+    pub fn new(pool: Arc<MySQLConnectionPool>, table_reference: TableReference) -> Self {
+        Self {
+            pool,
+            table_reference,
+            dialect: None,
+        }
+    }
+
+    pub fn with_dialect(mut self, dialect: Arc<dyn Dialect>) -> Self {
+        self.dialect = Some(dialect);
+        self
+    }
+}
+
+impl MySQLTableBuilder {
+    pub async fn build(self) -> Result<MySQLTable, sql_provider_datafusion::Error> {
+        let dyn_pool = Arc::clone(&self.pool)
+            as Arc<
+                dyn DbConnectionPool<mysql_async::Conn, &'static (dyn ToValue + Sync)>
+                    + Send
+                    + Sync,
+            >;
+        let base_table = SqlTable::new("mysql", &dyn_pool, self.table_reference, None)
+            .await?
+            .with_dialect(
+                self.dialect
+                    .unwrap_or_else(|| Arc::new(MySqlDialect::default())),
+            );
+
+        Ok(MySQLTable {
+            pool: self.pool,
+            base_table,
+        })
+    }
+}

--- a/src/mysql/dialect.rs
+++ b/src/mysql/dialect.rs
@@ -1,0 +1,95 @@
+use std::sync::Arc;
+
+use arrow_schema::TimeUnit;
+use datafusion::{
+    common::HashMap,
+    sql::unparser::{
+        dialect::{
+            DateFieldExtractStyle, Dialect, IntervalStyle, MySqlDialect as DFMySqlDialect,
+            ScalarFnToSqlHandler,
+        },
+        Unparser,
+    },
+};
+use datafusion_expr::{sqlparser::ast, Expr};
+
+pub struct MySqlDialect {
+    inner: DFMySqlDialect,
+    custom_scalar_fn_overrides: HashMap<String, ScalarFnToSqlHandler>,
+}
+
+impl Default for MySqlDialect {
+    fn default() -> Self {
+        Self {
+            inner: DFMySqlDialect {},
+            custom_scalar_fn_overrides: HashMap::new(),
+        }
+    }
+}
+
+impl Dialect for MySqlDialect {
+    fn identifier_quote_style(&self, identifier: &str) -> Option<char> {
+        self.inner.identifier_quote_style(identifier)
+    }
+
+    fn supports_nulls_first_in_sort(&self) -> bool {
+        self.inner.supports_nulls_first_in_sort()
+    }
+
+    fn interval_style(&self) -> IntervalStyle {
+        self.inner.interval_style()
+    }
+
+    fn utf8_cast_dtype(&self) -> ast::DataType {
+        self.inner.utf8_cast_dtype()
+    }
+
+    fn large_utf8_cast_dtype(&self) -> ast::DataType {
+        self.inner.large_utf8_cast_dtype()
+    }
+
+    fn date_field_extract_style(&self) -> DateFieldExtractStyle {
+        self.inner.date_field_extract_style()
+    }
+
+    fn int64_cast_dtype(&self) -> ast::DataType {
+        self.inner.int64_cast_dtype()
+    }
+
+    fn int32_cast_dtype(&self) -> ast::DataType {
+        self.inner.int32_cast_dtype()
+    }
+
+    fn timestamp_cast_dtype(&self, _time_unit: &TimeUnit, _tz: &Option<Arc<str>>) -> ast::DataType {
+        self.inner.timestamp_cast_dtype(_time_unit, _tz)
+    }
+
+    fn requires_derived_table_alias(&self) -> bool {
+        true
+    }
+
+    fn scalar_function_to_sql_overrides(
+        &self,
+        unparser: &Unparser,
+        func_name: &str,
+        args: &[Expr],
+    ) -> datafusion::error::Result<Option<ast::Expr>> {
+        if let Some(handler) = self.custom_scalar_fn_overrides.get(func_name) {
+            return handler(unparser, args);
+        }
+
+        self.inner
+            .scalar_function_to_sql_overrides(unparser, func_name, args)
+    }
+
+    fn with_custom_scalar_overrides(mut self, handlers: Vec<(&str, ScalarFnToSqlHandler)>) -> Self
+    where
+        Self: Sized,
+    {
+        for (func_name, handler) in handlers {
+            self.custom_scalar_fn_overrides
+                .insert(func_name.to_string(), handler);
+        }
+        self
+    }
+}

--- a/src/mysql/dialect.rs
+++ b/src/mysql/dialect.rs
@@ -3,15 +3,18 @@ use std::sync::Arc;
 use arrow_schema::TimeUnit;
 use datafusion::{
     common::HashMap,
-    sql::unparser::{
-        dialect::{
-            DateFieldExtractStyle, Dialect, IntervalStyle, MySqlDialect as DFMySqlDialect,
-            ScalarFnToSqlHandler,
+    logical_expr::Expr,
+    sql::{
+        sqlparser::ast,
+        unparser::{
+            dialect::{
+                DateFieldExtractStyle, Dialect, IntervalStyle, MySqlDialect as DFMySqlDialect,
+                ScalarFnToSqlHandler,
+            },
+            Unparser,
         },
-        Unparser,
     },
 };
-use datafusion_expr::{sqlparser::ast, Expr};
 
 pub struct MySqlDialect {
     inner: DFMySqlDialect,

--- a/src/mysql/sql_table.rs
+++ b/src/mysql/sql_table.rs
@@ -8,7 +8,7 @@ use std::fmt::Display;
 use std::{any::Any, fmt, sync::Arc};
 
 use crate::sql::sql_provider_datafusion::{
-    get_stream, to_execution_error, Result as SqlResult, SqlExec, SqlTable,
+    self, get_stream, to_execution_error, Result as SqlResult, SqlExec, SqlTable,
 };
 use datafusion::{
     arrow::datatypes::SchemaRef,
@@ -39,6 +39,13 @@ impl std::fmt::Debug for MySQLTable {
 }
 
 impl MySQLTable {
+    pub async fn new(
+        pool: &Arc<MySQLConnectionPool>,
+        table_reference: impl Into<TableReference>,
+    ) -> Result<Self, sql_provider_datafusion::Error> {
+        Self::builder(pool, table_reference).build().await
+    }
+
     pub fn builder(
         pool: &Arc<MySQLConnectionPool>,
         table_reference: impl Into<TableReference>,


### PR DESCRIPTION
Allows the MySQLTableFactory to have an optional customized MySQL dialect.

Adds a new MySQLDialect that implements `with_custom_scalar_overrides` to allow consumers to specify their own MySQL scalar function overrides.