### PR TITLE
Clickhouse: Remove unused AstAnalyzer from executor

### DIFF
--- a/core/src/clickhouse.rs
+++ b/core/src/clickhouse.rs
@@ -44,7 +44,8 @@ impl ClickHouseTableFactory {
         &self,
         table_reference: TableReference,
         args: Option<Vec<(String, Arg)>>,
-    ) -> Result<Arc<dyn TableProvider + 'static>, Box<dyn std::error::Error + Send + Sync>> {
+    ) -> Result<Arc<dyn TableProvider + 'static>, Box<dyn std::error::Error + Send + Sync + 'static>>
+    {
         let client: &dyn AsyncDbConnection<Client, ()> = &self.pool.client();
         let schema = client.get_schema(&table_reference).await?;
         let table_provider = Arc::new(ClickHouseTable::new(

--- a/core/src/clickhouse/federation.rs
+++ b/core/src/clickhouse/federation.rs
@@ -4,7 +4,6 @@ use crate::sql::sql_provider_datafusion::{get_stream, to_execution_error};
 use arrow::datatypes::SchemaRef;
 use async_trait::async_trait;
 use datafusion::sql::unparser::dialect::Dialect;
-use datafusion_federation::sql::ast_analyzer::TableArgReplace;
 use datafusion_federation::sql::{
     AstAnalyzer, RemoteTableRef, SQLExecutor, SQLFederationProvider, SQLTableSource,
 };
@@ -65,13 +64,7 @@ impl SQLExecutor for ClickHouseTable {
     }
 
     fn ast_analyzer(&self) -> Option<AstAnalyzer> {
-        if let Some(args) = &self.args {
-            let args = super::into_table_args(args.clone());
-            let table_args = TableArgReplace::new(vec![(self.table_reference.clone(), args)]);
-            Some(table_args.into_analyzer())
-        } else {
-            None
-        }
+        None
     }
 
     fn execute(


### PR DESCRIPTION
For table sources with functional arguments, `AstAnalyzer` is already applied in the default `SqlTable` implementation. 