### PR TITLE
Build on docs.rs with all features enabled

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -155,6 +155,13 @@ sqlite = ["dep:rusqlite", "dep:tokio-rusqlite", "dep:arrow-schema"]
 sqlite-federation = ["sqlite", "federation"]
 sqlite-bundled = ["sqlite", "rusqlite/bundled"]
 
+# docs.rs-specific configuration
+[package.metadata.docs.rs]
+# document all features
+all-features = true
+# defines the configuration attribute `docsrs`
+rustdoc-args = ["--cfg", "docsrs"]
+
 [[example]]
 name = "odbc_sqlite"
 path = "examples/odbc_sqlite.rs"

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+
 use serde::{Deserialize, Serialize};
 use snafu::prelude::*;
 


### PR DESCRIPTION
This PR enables building documentation on docs site with all features enabled. Additionally applies the nightly `docs_auto_cfg` flag when built with cfg attributes `docsrs`  

To test run locally: 
```sh
RUSTDOCFLAGS="--cfg docsrs" cargo +nightly doc --all-features
```
## Reference
https://stackoverflow.com/questions/61417452/how-to-get-a-feature-requirement-tag-in-the-documentation-generated-by-cargo-do