### PR TITLE
Clickhouse: Remove pub visibility from two unused modules

### DIFF
--- a/core/src/clickhouse.rs
+++ b/core/src/clickhouse.rs
@@ -28,8 +28,8 @@ use crate::sql::db_connection_pool::clickhousepool::ClickHouseConnectionPool;
 use crate::sql::db_connection_pool::dbconnection::AsyncDbConnection;
 
 #[cfg(feature = "clickhouse-federation")]
-pub mod federation;
-pub mod sql_table;
+mod federation;
+mod sql_table;
 
 pub struct ClickHouseTableFactory {
     pool: Arc<ClickHouseConnectionPool>,


### PR DESCRIPTION
### Description
This PR removes public visibility from two internal modules that were accidentally marked as public. These modules are currently unused and contain no structs, functions, or other items, so this change does not impact any public APIs or external usage.