### PR TITLE
Enable session time zone override for MySQL

### DIFF
--- a/src/duckdb/creator.rs
+++ b/src/duckdb/creator.rs
@@ -297,6 +297,7 @@ impl TableManager {
 
     /// Inserts data from this table into the target table.
     #[tracing::instrument(level = "debug", skip_all)]
+    #[allow(dead_code)]
     pub(crate) fn insert_into(
         &self,
         table: &TableManager,

--- a/src/sql/db_connection_pool/mysqlpool.rs
+++ b/src/sql/db_connection_pool/mysqlpool.rs
@@ -57,12 +57,16 @@ pub struct MySQLConnectionPool {
     join_push_down: JoinPushDown,
 }
 
-const SETUP_QUERIES: [&str; 4] = [
-    "SET time_zone = '+00:00'",
-    "SET character_set_results = 'utf8mb4'",
-    "SET character_set_client = 'utf8mb4'",
-    "SET character_set_connection = 'utf8mb4'",
-];
+/// Returns the setup queries for the MySQL connection, optionally overriding default time zone (UTC).
+fn get_setup_queries(time_zone: Option<&str>) -> Vec<String> {
+    let tz = time_zone.unwrap_or("+00:00");
+    vec![
+        format!("SET time_zone = '{tz}'"),
+        "SET character_set_results = 'utf8mb4'".to_string(),
+        "SET character_set_client = 'utf8mb4'".to_string(),
+        "SET character_set_connection = 'utf8mb4'".to_string(),
+    ]
+}
 
 impl MySQLConnectionPool {
     /// Creates a new instance of `MySQLConnectionPool`.
@@ -80,6 +84,7 @@ impl MySQLConnectionPool {
     ///   * `sslrootcert` - The path to the root certificate to use when connecting to the MySQL database.
     ///   * `pool_min` - The minimum number of connections to keep open in the pool, lazily created when requested.
     ///   * `pool_max` - The maximum number of connections to allow in the pool.
+    ///   * `time_zone` - The time zone to use for the MySQL connection (e.g., "+2:00", "UTC", etc.). Default is "+00:00" (UTC).
     ///
     /// # Errors
     ///
@@ -167,7 +172,9 @@ impl MySQLConnectionPool {
 
         connection_string = connection_string.ssl_opts(ssl_opts);
 
-        connection_string = connection_string.setup(SETUP_QUERIES.to_vec());
+        connection_string = connection_string.setup(get_setup_queries(
+            params.get("time_zone").map(SecretBox::expose_secret),
+        ));
 
         let opts = mysql_async::Opts::from(connection_string);
 

--- a/tests/docker/mod.rs
+++ b/tests/docker/mod.rs
@@ -134,7 +134,7 @@ impl<'a> ContainerRunner<'a> {
                 format!("{container_port}/tcp"),
                 Some(vec![PortBinding {
                     host_ip: Some("127.0.0.1".to_string()),
-                    host_port: Some(format!("{host_port}/tcp")),
+                    host_port: Some(format!("{host_port}")),
                 }]),
             );
         }

--- a/tests/mysql/common.rs
+++ b/tests/mysql/common.rs
@@ -12,7 +12,7 @@ use crate::{
 const MYSQL_ROOT_PASSWORD: &str = "integration-test-pw";
 const MYSQL_DOCKER_CONTAINER: &str = "runtime-integration-test-mysql";
 
-fn get_mysql_params(port: usize) -> HashMap<String, SecretString> {
+fn get_mysql_params(port: usize, time_zone: Option<&str>) -> HashMap<String, SecretString> {
     let mut params = HashMap::new();
     params.insert(
         "mysql_host".to_string(),
@@ -46,6 +46,9 @@ fn get_mysql_params(port: usize) -> HashMap<String, SecretString> {
         "mysql_pool_max".to_string(),
         SecretString::from("10".to_string()),
     );
+    if let Some(tz) = time_zone {
+        params.insert("mysql_time_zone".to_string(), SecretString::from(tz));
+    }
     params
 }
 
@@ -87,8 +90,9 @@ pub async fn start_mysql_docker_container(port: usize) -> Result<RunningContaine
 #[instrument]
 pub(super) async fn get_mysql_connection_pool(
     port: usize,
+    time_zone: Option<&str>,
 ) -> Result<MySQLConnectionPool, anyhow::Error> {
-    let mysql_pool = MySQLConnectionPool::new(get_mysql_params(port))
+    let mysql_pool = MySQLConnectionPool::new(get_mysql_params(port, time_zone))
         .await
         .expect("Failed to create MySQL Connection Pool");
 


### PR DESCRIPTION
PR adds support for `mysql_time_zone` parameter that can be used to override default session time zone (UTC). 

MySQL stores TIMESTAMP values in UTC and automatically converts them to the session time zone upon retrieval. This allows crate users to specify the desired time zone for retrieval.


Note: 

When we infer MySQL Timestamp schema we specify None as a Timezone. Despite we then retrieve and show correct value inferred type is still `Timestamp(TimeUnit, None)` with no time zone information where the more correct type must be `Timestamp(TimeUnit, Some("UTC"))` or `Timestamp(TimeUnit, Some("something"))`. This could be improved later.
