### PR TITLE
Update spiceai-1.3.2 tag / fix DuckDB install core extensions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -103,7 +103,7 @@ postgres-federation = ["postgres"]
 
 [patch.crates-io]
 datafusion-federation = { git = "https://github.com/spiceai/datafusion-federation.git", rev = "9db74a4b360df6be1bb554c59a474a2fd4bfb7e9" } # spiceai-47
-duckdb = { git = "https://github.com/spiceai/duckdb-rs.git", rev = "f7afdee8069d544b2b1151eecfccede40bb498cb" } # spiceai-1.3.2
+duckdb = { git = "https://github.com/spiceai/duckdb-rs.git", rev = "a4b83432acfe1dfdd140e35d4603701ae76f6607" } # spiceai-1.3.2
 
 datafusion = { git = "https://github.com/spiceai/datafusion.git", rev = "b5c62f29d2c70c5331ff50015b67b5e1cafcd578" }               # spiceai-47
 datafusion-expr = { git = "https://github.com/spiceai/datafusion.git", rev = "b5c62f29d2c70c5331ff50015b67b5e1cafcd578" }          # spiceai-47


### PR DESCRIPTION
#### Changes

See https://github.com/spiceai/duckdb-rs/pull/22

Updates tag to a `duckdb-rs` version that sets `DUCKDB_VERSION` when doing a `bundled` build.