### PR TITLE
Bump datafusion-federation to 0.4.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1662,9 +1662,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-federation"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88c63d4eb0cd33b8762247005486372d9a8c4cce33c75e1157a43df51e939b6a"
+checksum = "a9f0d8ad060844213548bc54885261270ae7a9e2c66f8daaf46139bf3e7e7f7c"
 dependencies = [
  "arrow-json",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ arrow-json = "55.0.0"
 arrow-odbc = { version = "16.0.2" }
 datafusion = { version = "48", default-features = false }
 datafusion-expr = { version = "48" }
-datafusion-federation = { version = "=0.4.5" }
+datafusion-federation = { version = "0.4.6" }
 datafusion-ffi = { version = "48" }
 datafusion-proto = { version = "48" }
 datafusion-physical-expr = { version = "48" }


### PR DESCRIPTION
Also removed the exact version requirement, to avoid forcing `datafusion-table-providers` to be updated when `datafusion-federation` receives a minor update.