### PR TITLE
Add controls for upsert behavior to modify batches to remove duplicates and/or pick the latest row on constraint violations that occur within a batch

### DIFF
--- a/src/duckdb/write.rs
+++ b/src/duckdb/write.rs
@@ -245,10 +245,12 @@ impl DataSink for DuckDBDataSink {
                 Ok(num_rows)
             });
 
-        let upsert_options = self.on_conflict.as_ref().map_or_else(
-            || UpsertOptions::default(),
-            |conflict| conflict.get_upsert_options(),
-        );
+        let upsert_options = self
+            .on_conflict
+            .as_ref()
+            .map_or_else(UpsertOptions::default, |conflict| {
+                conflict.get_upsert_options()
+            });
 
         while let Some(batch) = data.next().await {
             let batch = batch.map_err(check_and_mark_retriable_error)?;

--- a/src/postgres/write.rs
+++ b/src/postgres/write.rs
@@ -165,10 +165,12 @@ impl DataSink for PostgresDataSink {
 
         let postgres_schema = Arc::new(Schema::new(postgres_fields));
 
-        let upsert_options = self.on_conflict.as_ref().map_or_else(
-            || UpsertOptions::default(),
-            |conflict| conflict.get_upsert_options(),
-        );
+        let upsert_options = self
+            .on_conflict
+            .as_ref()
+            .map_or_else(UpsertOptions::default, |conflict| {
+                conflict.get_upsert_options()
+            });
 
         while let Some(batch) = data.next().await {
             let batch = batch.map_err(check_and_mark_retriable_error)?;

--- a/src/sqlite/write.rs
+++ b/src/sqlite/write.rs
@@ -142,10 +142,12 @@ impl DataSink for SqliteDataSink {
 
         let constraints = self.sqlite.constraints().clone();
         let mut data = data;
-        let upsert_options = self.on_conflict.as_ref().map_or_else(
-            || UpsertOptions::default(),
-            |conflict| conflict.get_upsert_options(),
-        );
+        let upsert_options = self
+            .on_conflict
+            .as_ref()
+            .map_or_else(UpsertOptions::default, |conflict| {
+                conflict.get_upsert_options()
+            });
         let task = tokio::spawn(async move {
             let mut num_rows: u64 = 0;
             while let Some(data_batch) = data.next().await {

--- a/src/util/constraints.rs
+++ b/src/util/constraints.rs
@@ -47,18 +47,14 @@ impl UpsertOptions {
         Self::default()
     }
 
-    pub fn with_remove_duplicates(self: Self, remove_duplicates: bool) -> Self {
-        Self {
-            remove_duplicates,
-            ..self
-        }
+    pub fn with_remove_duplicates(mut self, remove_duplicates: bool) -> Self {
+        self.remove_duplicates = remove_duplicates;
+        self
     }
 
-    pub fn with_last_write_wins(self: Self, last_write_wins: bool) -> Self {
-        Self {
-            last_write_wins,
-            ..self
-        }
+    pub fn with_last_write_wins(mut self, last_write_wins: bool) -> Self {
+        self.last_write_wins = last_write_wins;
+        self
     }
 
     pub fn is_default(&self) -> bool {

--- a/src/util/constraints.rs
+++ b/src/util/constraints.rs
@@ -29,7 +29,7 @@ pub type Result<T, E = Error> = std::result::Result<T, E>;
 /// Configuration options for upsert behavior
 #[derive(Debug, Clone, Default, PartialEq)]
 pub struct UpsertOptions {
-    /// Remove duplicates before validation to resolve primary key conflicts
+    /// Remove duplicates after validation to resolve primary key conflicts
     pub remove_duplicates: bool,
     /// Use "last write wins" behavior - when duplicates are found, keep the row with the highest row number
     pub last_write_wins: bool,

--- a/src/util/on_conflict.rs
+++ b/src/util/on_conflict.rs
@@ -4,6 +4,8 @@ use sea_query::{self, Alias};
 use snafu::prelude::*;
 use std::fmt::Display;
 
+use crate::util::constraints::{self, UpsertOptions};
+
 use super::column_reference::{self, ColumnReference};
 
 #[derive(Debug, Snafu)]
@@ -16,13 +18,16 @@ pub enum Error {
 
     #[snafu(display("Expected semicolon in: {token}"))]
     ExpectedSemicolon { token: String },
+
+    #[snafu(display("Invalid upsert options: {source}"))]
+    InvalidUpsertOptions { source: constraints::Error },
 }
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum OnConflict {
     DoNothingAll,
     DoNothing(ColumnReference),
-    Upsert(ColumnReference),
+    Upsert(ColumnReference, UpsertOptions),
 }
 
 impl OnConflict {
@@ -36,7 +41,7 @@ impl OnConflict {
                     column.iter().join(r#"", ""#)
                 )
             }
-            OnConflict::Upsert(column) => {
+            OnConflict::Upsert(column, _) => {
                 let non_constraint_columns = schema
                     .fields()
                     .iter()
@@ -80,7 +85,7 @@ impl OnConflict {
                 on_conflict.do_nothing();
                 on_conflict
             }
-            OnConflict::Upsert(column) => {
+            OnConflict::Upsert(column, _) => {
                 let mut on_conflict = sea_query::OnConflict::columns::<Vec<Alias>, Alias>(
                     column.iter().map(Alias::new).collect(),
                 );
@@ -105,7 +110,7 @@ impl Display for OnConflict {
         match self {
             OnConflict::DoNothingAll => write!(f, "do_nothing_all"),
             OnConflict::DoNothing(column) => write!(f, "do_nothing:{column}"),
-            OnConflict::Upsert(column) => write!(f, "upsert:{column}"),
+            OnConflict::Upsert(column, options) => write!(f, "upsert:{column}#{options}"),
         }
     }
 }
@@ -126,13 +131,25 @@ impl TryFrom<&str> for OnConflict {
             .fail();
         }
 
+        let upsert_parts: Vec<&str> = parts[1].split('#').collect();
+
         let column_ref =
-            ColumnReference::try_from(parts[1]).context(InvalidColumnReferenceSnafu)?;
+            ColumnReference::try_from(upsert_parts[0]).context(InvalidColumnReferenceSnafu)?;
+
+        let upsert_options = if parts[0] == "upsert" {
+            if upsert_parts.len() == 2 {
+                UpsertOptions::try_from(upsert_parts[1]).context(InvalidUpsertOptionsSnafu)?
+            } else {
+                UpsertOptions::default()
+            }
+        } else {
+            UpsertOptions::default()
+        };
 
         let on_conflict_behavior = parts[0];
         match on_conflict_behavior {
             "do_nothing" => Ok(OnConflict::DoNothing(column_ref)),
-            "upsert" => Ok(OnConflict::Upsert(column_ref)),
+            "upsert" => Ok(OnConflict::Upsert(column_ref, upsert_options)),
             _ => UnexpectedTokenSnafu {
                 token: parts[0].to_string(),
             }
@@ -147,7 +164,9 @@ mod tests {
 
     use arrow::datatypes::{DataType, Field, Schema};
 
-    use crate::util::{column_reference::ColumnReference, on_conflict::OnConflict};
+    use crate::util::{
+        column_reference::ColumnReference, constraints::UpsertOptions, on_conflict::OnConflict,
+    };
 
     #[test]
     fn test_on_conflict_from_str() {
@@ -163,7 +182,10 @@ mod tests {
         let on_conflict = OnConflict::try_from("upsert:col2").expect("valid on conflict");
         assert_eq!(
             on_conflict,
-            OnConflict::Upsert(ColumnReference::new(vec!["col2".to_string()]))
+            OnConflict::Upsert(
+                ColumnReference::new(vec!["col2".to_string()]),
+                UpsertOptions::default()
+            )
         );
 
         let err = OnConflict::try_from("do_nothing").expect_err("invalid on conflict");
@@ -188,12 +210,174 @@ mod tests {
             OnConflict::DoNothing(ColumnReference::new(vec!["col1".to_string()]))
         );
 
-        let on_conflict =
-            OnConflict::Upsert(ColumnReference::new(vec!["col2".to_string()])).to_string();
+        let on_conflict = OnConflict::Upsert(
+            ColumnReference::new(vec!["col2".to_string()]),
+            UpsertOptions::default(),
+        )
+        .to_string();
         assert_eq!(
             OnConflict::try_from(on_conflict.as_str()).expect("valid on conflict"),
-            OnConflict::Upsert(ColumnReference::new(vec!["col2".to_string()]))
+            OnConflict::Upsert(
+                ColumnReference::new(vec!["col2".to_string()]),
+                UpsertOptions::default()
+            )
         );
+    }
+
+    #[test]
+    fn test_upsert_parsing_with_default_options() {
+        let on_conflict = OnConflict::try_from("upsert:col1").expect("valid on conflict");
+        assert_eq!(
+            on_conflict,
+            OnConflict::Upsert(
+                ColumnReference::new(vec!["col1".to_string()]),
+                UpsertOptions::default()
+            )
+        );
+
+        // Test explicit empty options string
+        let on_conflict = OnConflict::try_from("upsert:col1#").expect("valid on conflict");
+        assert_eq!(
+            on_conflict,
+            OnConflict::Upsert(
+                ColumnReference::new(vec!["col1".to_string()]),
+                UpsertOptions::default()
+            )
+        );
+    }
+
+    #[test]
+    fn test_upsert_parsing_with_remove_duplicates() {
+        let on_conflict =
+            OnConflict::try_from("upsert:col1#remove_duplicates").expect("valid on conflict");
+        assert_eq!(
+            on_conflict,
+            OnConflict::Upsert(
+                ColumnReference::new(vec!["col1".to_string()]),
+                UpsertOptions::new().with_remove_duplicates(true)
+            )
+        );
+    }
+
+    #[test]
+    fn test_upsert_parsing_with_last_write_wins() {
+        let on_conflict =
+            OnConflict::try_from("upsert:col1#last_write_wins").expect("valid on conflict");
+        assert_eq!(
+            on_conflict,
+            OnConflict::Upsert(
+                ColumnReference::new(vec!["col1".to_string()]),
+                UpsertOptions::new().with_last_write_wins(true)
+            )
+        );
+    }
+
+    #[test]
+    fn test_upsert_parsing_with_both_options() {
+        let on_conflict = OnConflict::try_from("upsert:col1#remove_duplicates,last_write_wins")
+            .expect("valid on conflict");
+        assert_eq!(
+            on_conflict,
+            OnConflict::Upsert(
+                ColumnReference::new(vec!["col1".to_string()]),
+                UpsertOptions::new()
+                    .with_remove_duplicates(true)
+                    .with_last_write_wins(true)
+            )
+        );
+
+        // Test reverse order
+        let on_conflict = OnConflict::try_from("upsert:col1#last_write_wins,remove_duplicates")
+            .expect("valid on conflict");
+        assert_eq!(
+            on_conflict,
+            OnConflict::Upsert(
+                ColumnReference::new(vec!["col1".to_string()]),
+                UpsertOptions::new()
+                    .with_remove_duplicates(true)
+                    .with_last_write_wins(true)
+            )
+        );
+    }
+
+    #[test]
+    fn test_upsert_parsing_with_spaces_in_options() {
+        let on_conflict = OnConflict::try_from("upsert:col1# remove_duplicates , last_write_wins ")
+            .expect("valid on conflict");
+        assert_eq!(
+            on_conflict,
+            OnConflict::Upsert(
+                ColumnReference::new(vec!["col1".to_string()]),
+                UpsertOptions::new()
+                    .with_remove_duplicates(true)
+                    .with_last_write_wins(true)
+            )
+        );
+    }
+
+    #[test]
+    fn test_upsert_parsing_with_invalid_options() {
+        let err =
+            OnConflict::try_from("upsert:col1#invalid_option").expect_err("invalid upsert option");
+        assert!(err.to_string().contains("Invalid upsert options"));
+
+        let err = OnConflict::try_from("upsert:col1#remove_duplicates,invalid_option")
+            .expect_err("invalid upsert option");
+        assert!(err.to_string().contains("Invalid upsert options"));
+    }
+
+    #[test]
+    fn test_upsert_parsing_with_composite_columns() {
+        let on_conflict = OnConflict::try_from("upsert:(col1,col2)#remove_duplicates")
+            .expect("valid on conflict");
+        assert_eq!(
+            on_conflict,
+            OnConflict::Upsert(
+                ColumnReference::new(vec!["col1".to_string(), "col2".to_string()]),
+                UpsertOptions::new().with_remove_duplicates(true)
+            )
+        );
+    }
+
+    #[test]
+    fn test_upsert_roundtrip_with_options() {
+        // Test default options
+        let on_conflict = OnConflict::Upsert(
+            ColumnReference::new(vec!["col1".to_string()]),
+            UpsertOptions::default(),
+        );
+        let roundtrip =
+            OnConflict::try_from(on_conflict.to_string().as_str()).expect("valid roundtrip");
+        assert_eq!(roundtrip, on_conflict);
+
+        // Test with remove_duplicates
+        let on_conflict = OnConflict::Upsert(
+            ColumnReference::new(vec!["col1".to_string()]),
+            UpsertOptions::new().with_remove_duplicates(true),
+        );
+        let roundtrip =
+            OnConflict::try_from(on_conflict.to_string().as_str()).expect("valid roundtrip");
+        assert_eq!(roundtrip, on_conflict);
+
+        // Test with last_write_wins
+        let on_conflict = OnConflict::Upsert(
+            ColumnReference::new(vec!["col1".to_string()]),
+            UpsertOptions::new().with_last_write_wins(true),
+        );
+        let roundtrip =
+            OnConflict::try_from(on_conflict.to_string().as_str()).expect("valid roundtrip");
+        assert_eq!(roundtrip, on_conflict);
+
+        // Test with both options
+        let on_conflict = OnConflict::Upsert(
+            ColumnReference::new(vec!["col1".to_string()]),
+            UpsertOptions::new()
+                .with_remove_duplicates(true)
+                .with_last_write_wins(true),
+        );
+        let roundtrip =
+            OnConflict::try_from(on_conflict.to_string().as_str()).expect("valid roundtrip");
+        assert_eq!(roundtrip, on_conflict);
     }
 
     #[test]
@@ -214,9 +398,25 @@ mod tests {
             r#"ON CONFLICT ("col1") DO NOTHING"#.to_string()
         );
 
-        let on_conflict = OnConflict::Upsert(ColumnReference::new(vec!["col2".to_string()]));
+        let on_conflict = OnConflict::Upsert(
+            ColumnReference::new(vec!["col2".to_string()]),
+            UpsertOptions::default(),
+        );
         assert_eq!(
             on_conflict.build_on_conflict_statement(&schema),
+            r#"ON CONFLICT ("col2") DO UPDATE SET "col1" = EXCLUDED."col1""#.to_string()
+        );
+
+        // Test that upsert options don't affect SQL statement generation
+        // (the options are used during batch validation, not SQL generation)
+        let on_conflict_with_options = OnConflict::Upsert(
+            ColumnReference::new(vec!["col2".to_string()]),
+            UpsertOptions::new()
+                .with_remove_duplicates(true)
+                .with_last_write_wins(true),
+        );
+        assert_eq!(
+            on_conflict_with_options.build_on_conflict_statement(&schema),
             r#"ON CONFLICT ("col2") DO UPDATE SET "col1" = EXCLUDED."col1""#.to_string()
         );
     }

--- a/src/util/on_conflict.rs
+++ b/src/util/on_conflict.rs
@@ -103,6 +103,13 @@ impl OnConflict {
             }
         }
     }
+
+    pub fn get_upsert_options(&self) -> UpsertOptions {
+        match self {
+            OnConflict::Upsert(_, options) => options.clone(),
+            _ => UpsertOptions::default(),
+        }
+    }
 }
 
 impl Display for OnConflict {


### PR DESCRIPTION
Adds two new behaviors for the `OnConflict::Upsert` behavior that affects conflicts that occur within a batch. The previous behavior was to error out, as this matches the behavior of most database systems. However, we can be smarter and apply some mitigations to the data of the incoming batch to allow these updates to proceed. These mitigations are opt-in, as they do introduce some overhead compared to not using them.

- `remove_duplicates`: Will run the equivalent of a `SELECT DISTINCT * FROM <batch>` if a violation is detected in the batch.
- `last_write_wins`: When duplicates are found in the batch, keep the row with the highest row number (i.e. the equivalent behavior if upsert were to happen one row at a time)

These options are specified using the existing `on_conflict` option in the `TableProviderFactory::create` method and are given by suffixing the `upsert:{col}` with a `#` and then specifying the options (comma separated). i.e.:

Examples:
`on_conflict: upsert:col1#remove_duplicates` -> Specifies that when a constraint violation occurs on `col1` in the incoming batch, attempt to remove duplicates.
`on_conflict: upsert:(col1,col2)#remove_duplicates,last_write_wins` -> When a constraint violation occurs on the compound primary key `(col1, col2)` then attempt to remove duplicates, and also keep only the last row.