### PR TITLE
Use DuckDBDialect

### DIFF
--- a/src/sql/sql_provider_datafusion/expr.rs
+++ b/src/sql/sql_provider_datafusion/expr.rs
@@ -5,7 +5,7 @@ use datafusion::{
     logical_expr::{Cast, Expr},
     scalar::ScalarValue,
     sql::unparser::dialect::{
-        DefaultDialect, Dialect, MySqlDialect, PostgreSqlDialect, SqliteDialect,
+        DefaultDialect, Dialect, DuckDBDialect, MySqlDialect, PostgreSqlDialect, SqliteDialect,
     },
 };
 
@@ -39,7 +39,8 @@ impl Engine {
             Engine::SQLite => Arc::new(SqliteDialect {}),
             Engine::Postgres => Arc::new(PostgreSqlDialect {}),
             Engine::MySQL => Arc::new(MySqlDialect {}),
-            Engine::Spark | Engine::DuckDB | Engine::ODBC => Arc::new(DefaultDialect {}),
+            Engine::DuckDB => Arc::new(DuckDBDialect::new()),
+            Engine::Spark | Engine::ODBC => Arc::new(DefaultDialect {}),
         }
     }
 }


### PR DESCRIPTION
We were using `DefaultDialect` for duckdb, which causes issues - for example with formatting timestamps which was fixed in https://github.com/spiceai/datafusion/pull/102.

