### PR TITLE
Add `connection_pool_min_idle` to PostgreSQL

### DIFF
--- a/src/sql/db_connection_pool/postgrespool.rs
+++ b/src/sql/db_connection_pool/postgrespool.rs
@@ -196,13 +196,30 @@ impl PostgresConnectionPool {
             .map(SecretBox::expose_secret)
         {
             connection_pool_size = pg_pool_size.parse().context(InvalidIntegerParameterSnafu {
-                parameter_name: "pool_size".to_string(),
+                parameter_name: "connection_pool_size".to_string(),
             })?;
         }
 
-        let pool = bb8::Pool::builder()
+        let mut connection_pool_min_idle: Option<u32> = None;
+        if let Some(pg_pool_min) = params
+            .get("connection_pool_min_idle")
+            .map(SecretBox::expose_secret)
+        {
+            connection_pool_min_idle =
+                Some(pg_pool_min.parse().context(InvalidIntegerParameterSnafu {
+                    parameter_name: "connection_pool_min_idle".to_string(),
+                })?);
+        }
+
+        let mut pool_builder = bb8::Pool::builder()
             .max_size(connection_pool_size)
-            .error_sink(Box::new(error_sink))
+            .error_sink(Box::new(error_sink));
+
+        if let Some(min_idle) = connection_pool_min_idle {
+            pool_builder = pool_builder.min_idle(Some(min_idle));
+        }
+
+        let pool = pool_builder
             .build(manager)
             .await
             .context(ConnectionPoolSnafu)?;


### PR DESCRIPTION
This pull request enhances the configuration flexibility of the Postgres connection pool by introducing support for a minimum idle connection parameter and improving parameter naming consistency.

**Connection pool configuration improvements:**

* Added support for the `connection_pool_min_idle` parameter, allowing the minimum number of idle connections in the pool to be configured. The code now parses this parameter and applies it to the pool builder if specified.
* Updated the error context for the pool size parameter to use the more descriptive name `connection_pool_size` instead of `pool_size`, improving clarity and consistency in error reporting.