### PR TITLE
feat: [sqlite] Delegate supports_filters_pushdown to read provider

### DIFF
--- a/core/src/sqlite/write.rs
+++ b/core/src/sqlite/write.rs
@@ -78,7 +78,7 @@ impl TableProvider for SqliteTableWriter {
                 self.sqlite.table_name()
             );
         }
-        
+
         self.read_provider.supports_filters_pushdown(filters)
     }
 
@@ -415,11 +415,8 @@ mod tests {
         // Insert initial data
         let arr1 = Int64Array::from(vec![1, 2, 3]);
         let arr2 = Int64Array::from(vec![10, 20, 30]);
-        let data = RecordBatch::try_new(
-            Arc::clone(&schema),
-            vec![Arc::new(arr1), Arc::new(arr2)],
-        )
-        .expect("data should be created");
+        let data = RecordBatch::try_new(Arc::clone(&schema), vec![Arc::new(arr1), Arc::new(arr2)])
+            .expect("data should be created");
 
         let exec = MockExec::new(vec![Ok(data)], Arc::clone(&schema));
         let insertion = table


### PR DESCRIPTION
This pull request enhances the `SqliteTableWriter` to improve support for filter pushdown and adds comprehensive tests to ensure correct behavior, especially in scenarios involving concurrent reads and writes. The main changes focus on delegating filter pushdown capability checks to the underlying read provider while validating schema consistency, and verifying this functionality through new tests.

Closes #354 

### Filter Pushdown Support

* Added a `supports_filters_pushdown` method to `SqliteTableWriter`, which checks for schema consistency and delegates filter pushdown capability checks to the underlying read provider. If a schema mismatch is detected, a warning is logged.

### Testing Improvements

* Introduced a test (`test_filter_pushdown_support`) to verify that simple filter pushdown (e.g., `id > 10`) is supported and returns the expected result.
* Added a test (`test_concurrent_read_write_with_filter_pushdown`) to ensure that filter pushdown works correctly after inserting data and that filtered scans return the correct results, even in scenarios involving concurrent read and write operations.