### PR TITLE
[DuckSqlExec]: Allow optimized_sql to override schema

### DIFF
--- a/core/src/duckdb/sql_table.rs
+++ b/core/src/duckdb/sql_table.rs
@@ -6,7 +6,6 @@ use crate::sql::sql_provider_datafusion::{
 use crate::util::column_reference::ColumnReference;
 use crate::util::indexes::IndexType;
 use crate::util::supported_functions::FunctionSupport;
-use arrow_schema::Schema;
 use async_trait::async_trait;
 use datafusion::catalog::Session;
 use datafusion::common::Constraints;


### PR DESCRIPTION
Small change to allow schema override for more complex pushdown cases.