### PR TITLE
Prevent `InsertBuilder` from taking ownership of record batches

### DIFF
--- a/core/src/mysql.rs
+++ b/core/src/mysql.rs
@@ -382,8 +382,9 @@ impl MySQL {
         batch: RecordBatch,
         on_conflict: Option<OnConflict>,
     ) -> Result<()> {
+        let batches = vec![batch];
         let insert_table_builder =
-            InsertBuilder::new(&TableReference::bare(self.table_name.clone()), vec![batch]);
+            InsertBuilder::new(&TableReference::bare(self.table_name.clone()), &batches);
 
         let sea_query_on_conflict =
             on_conflict.map(|oc| oc.build_sea_query_on_conflict(&self.schema));

--- a/core/src/postgres.rs
+++ b/core/src/postgres.rs
@@ -419,7 +419,8 @@ impl Postgres {
         batch: RecordBatch,
         on_conflict: Option<OnConflict>,
     ) -> Result<()> {
-        let insert_table_builder = InsertBuilder::new(&self.table, vec![batch]);
+        let batches = vec![batch];
+        let insert_table_builder = InsertBuilder::new(&self.table, &batches);
 
         let sea_query_on_conflict =
             on_conflict.map(|oc| oc.build_sea_query_on_conflict(&self.schema));

--- a/core/src/sqlite.rs
+++ b/core/src/sqlite.rs
@@ -71,13 +71,17 @@ pub enum Error {
     },
 
     #[snafu(display("Unable to create table in Sqlite: {source}"))]
-    UnableToCreateTable { source: tokio_rusqlite::Error<rusqlite::Error> },
+    UnableToCreateTable {
+        source: tokio_rusqlite::Error<rusqlite::Error>,
+    },
 
     #[snafu(display("Unable to insert data into the Sqlite table: {source}"))]
     UnableToInsertIntoTable { source: rusqlite::Error },
 
     #[snafu(display("Unable to insert data into the Sqlite table: {source}"))]
-    UnableToInsertIntoTableAsync { source: tokio_rusqlite::Error<rusqlite::Error> },
+    UnableToInsertIntoTableAsync {
+        source: tokio_rusqlite::Error<rusqlite::Error>,
+    },
 
     #[snafu(display("Unable to insert data into the Sqlite table. The disk is full."))]
     DiskFull {},
@@ -549,7 +553,8 @@ impl Sqlite {
         batch: RecordBatch,
         on_conflict: Option<&OnConflict>,
     ) -> rusqlite::Result<()> {
-        let insert_table_builder = InsertBuilder::new(&self.table, vec![batch]);
+        let batches = vec![batch];
+        let insert_table_builder = InsertBuilder::new(&self.table, &batches);
 
         let sea_query_on_conflict =
             on_conflict.map(|oc| oc.build_sea_query_on_conflict(&self.schema));

--- a/core/tests/sqlite/mod.rs
+++ b/core/tests/sqlite/mod.rs
@@ -52,12 +52,10 @@ async fn arrow_sqlite_round_trip(
     // Create sqlite table from arrow records and insert arrow records
     let schema = Arc::clone(&arrow_record.schema());
     let create_table_stmts = CreateTableBuilder::new(schema, table_name).build_sqlite();
-    let insert_table_stmt = InsertBuilder::new(
-        &TableReference::from(table_name),
-        vec![arrow_record.clone()],
-    )
-    .build_sqlite(None)
-    .expect("SQLite insert statement should be constructed");
+    let batches = vec![arrow_record.clone()];
+    let insert_table_stmt = InsertBuilder::new(&TableReference::from(table_name), &batches)
+        .build_sqlite(None)
+        .expect("SQLite insert statement should be constructed");
 
     // Test arrow -> Sqlite row coverage
     let _ = conn
@@ -211,9 +209,18 @@ fn create_comprehensive_test_data() -> (RecordBatch, SchemaRef) {
         None,
         Some(500000u64),
     ]);
-    let col_float32 = Float32Array::from(vec![Some(1.5), None, Some(-std::f32::consts::PI), Some(2.71)]);
-    let col_float64 =
-        Float64Array::from(vec![None, Some(std::f64::consts::E), Some(-1.414), Some(std::f64::consts::PI)]);
+    let col_float32 = Float32Array::from(vec![
+        Some(1.5),
+        None,
+        Some(-std::f32::consts::PI),
+        Some(2.71),
+    ]);
+    let col_float64 = Float64Array::from(vec![
+        None,
+        Some(std::f64::consts::E),
+        Some(-1.414),
+        Some(std::f64::consts::PI),
+    ]);
     let col_utf8 = StringArray::from(vec![Some("hello"), Some("world"), None, Some("test")]);
     let col_large_utf8 = LargeStringArray::from(vec![
         None,


### PR DESCRIPTION
This PR changes the `InsertBuilder { ..., Vec<RecordBatch> }` to `InsertBuilder<'a> { ..., &a' Vec<RecordBatch> }` to avoid taking ownership of the record batches, given it only needs a reference to generate the respective SQL code.
