### PR TITLE
Add write support for Decimal32 and Decimal64

### DIFF
--- a/core/src/sql/arrow_sql_gen/arrow.rs
+++ b/core/src/sql/arrow_sql_gen/arrow.rs
@@ -1,13 +1,13 @@
 use datafusion::arrow::{
     array::{
         types::Int8Type, ArrayBuilder, BinaryBuilder, BooleanBuilder, Date32Builder, Date64Builder,
-        Decimal128Builder, Decimal256Builder, FixedSizeBinaryBuilder, FixedSizeListBuilder,
-        Float32Builder, Float64Builder, Int16Builder, Int32Builder, Int64Builder, Int8Builder,
-        IntervalMonthDayNanoBuilder, LargeBinaryBuilder, LargeStringBuilder, ListBuilder,
-        NullBuilder, StringBuilder, StringDictionaryBuilder, StructBuilder,
-        Time64NanosecondBuilder, TimestampMicrosecondBuilder, TimestampMillisecondBuilder,
-        TimestampNanosecondBuilder, TimestampSecondBuilder, UInt16Builder, UInt32Builder,
-        UInt64Builder, UInt8Builder,
+        Decimal128Builder, Decimal256Builder, Decimal32Builder, Decimal64Builder,
+        FixedSizeBinaryBuilder, FixedSizeListBuilder, Float32Builder, Float64Builder, Int16Builder,
+        Int32Builder, Int64Builder, Int8Builder, IntervalMonthDayNanoBuilder, LargeBinaryBuilder,
+        LargeStringBuilder, ListBuilder, NullBuilder, StringBuilder, StringDictionaryBuilder,
+        StructBuilder, Time64NanosecondBuilder, TimestampMicrosecondBuilder,
+        TimestampMillisecondBuilder, TimestampNanosecondBuilder, TimestampSecondBuilder,
+        UInt16Builder, UInt32Builder, UInt64Builder, UInt8Builder,
     },
     datatypes::{DataType, TimeUnit, UInt16Type},
 };
@@ -40,6 +40,16 @@ pub fn map_data_type_to_array_builder(data_type: &DataType) -> Box<dyn ArrayBuil
         DataType::Binary => Box::new(BinaryBuilder::new()),
         DataType::LargeBinary => Box::new(LargeBinaryBuilder::new()),
         DataType::Interval(_) => Box::new(IntervalMonthDayNanoBuilder::new()),
+        DataType::Decimal32(precision, scale) => Box::new(
+            Decimal32Builder::new()
+                .with_precision_and_scale(*precision, *scale)
+                .unwrap_or_default(),
+        ),
+        DataType::Decimal64(precision, scale) => Box::new(
+            Decimal64Builder::new()
+                .with_precision_and_scale(*precision, *scale)
+                .unwrap_or_default(),
+        ),
         DataType::Decimal128(precision, scale) => Box::new(
             Decimal128Builder::new()
                 .with_precision_and_scale(*precision, *scale)

--- a/core/src/sql/arrow_sql_gen/statement.rs
+++ b/core/src/sql/arrow_sql_gen/statement.rs
@@ -175,6 +175,20 @@ macro_rules! push_value {
     }};
 }
 
+macro_rules! push_big_decimal_value {
+    ($row_values:expr, $column:expr, $row:expr, $scale:expr, $array_type:ident) => {{
+        let array = $column.as_any().downcast_ref::<array::$array_type>();
+        if let Some(valid_array) = array {
+            if valid_array.is_null($row) {
+                $row_values.push(Keyword::Null.into());
+                continue;
+            }
+            $row_values
+                .push(BigDecimal::new(valid_array.value($row).into(), i64::from(*$scale)).into());
+        }
+    }};
+}
+
 macro_rules! push_list_values {
     ($data_type:expr, $list_array:expr, $row_values:expr, $array_type:ty, $vec_type:ty, $sql_type:expr) => {{
         let mut list_values: Vec<$vec_type> = Vec::new();
@@ -260,18 +274,14 @@ impl<'a> InsertBuilder<'a> {
                     DataType::LargeUtf8 => push_value!(row_values, column, row, LargeStringArray),
                     DataType::Utf8View => push_value!(row_values, column, row, StringViewArray),
                     DataType::Boolean => push_value!(row_values, column, row, BooleanArray),
+                    DataType::Decimal32(_, scale) => {
+                        push_big_decimal_value!(row_values, column, row, scale, Decimal32Array)
+                    }
+                    DataType::Decimal64(_, scale) => {
+                        push_big_decimal_value!(row_values, column, row, scale, Decimal64Array)
+                    }
                     DataType::Decimal128(_, scale) => {
-                        let array = column.as_any().downcast_ref::<array::Decimal128Array>();
-                        if let Some(valid_array) = array {
-                            if valid_array.is_null(row) {
-                                row_values.push(Keyword::Null.into());
-                                continue;
-                            }
-                            row_values.push(
-                                BigDecimal::new(valid_array.value(row).into(), i64::from(*scale))
-                                    .into(),
-                            );
-                        }
+                        push_big_decimal_value!(row_values, column, row, scale, Decimal128Array)
                     }
                     DataType::Decimal256(_, scale) => {
                         let array = column.as_any().downcast_ref::<array::Decimal256Array>();
@@ -1321,9 +1331,10 @@ pub(crate) fn map_data_type_to_column_type(data_type: &DataType) -> ColumnType {
         DataType::Utf8 | DataType::LargeUtf8 | DataType::Utf8View => ColumnType::Text,
         DataType::Boolean => ColumnType::Boolean,
         #[allow(clippy::cast_sign_loss)] // This is safe because scale will never be negative
-        DataType::Decimal128(p, s) | DataType::Decimal256(p, s) => {
-            ColumnType::Decimal(Some((u32::from(*p), *s as u32)))
-        }
+        DataType::Decimal32(p, s)
+        | DataType::Decimal64(p, s)
+        | DataType::Decimal128(p, s)
+        | DataType::Decimal256(p, s) => ColumnType::Decimal(Some((u32::from(*p), *s as u32))),
         DataType::Timestamp(_unit, time_zone) => {
             if time_zone.is_some() {
                 return ColumnType::TimestampWithTimeZone;
@@ -1468,10 +1479,14 @@ mod tests {
             Field::new("id", DataType::Int32, false),
             Field::new("name", DataType::Utf8, false),
             Field::new("age", DataType::Int32, true),
+            Field::new("balance", DataType::Decimal64(10, 2), true),
         ]);
         let id_array = array::Int32Array::from(vec![1, 2, 3]);
         let name_array = array::StringArray::from(vec!["a", "b", "c"]);
         let age_array = array::Int32Array::from(vec![10, 20, 30]);
+        let balance_array = array::Decimal64Array::from(vec![12345, -12345, 12300])
+            .with_precision_and_scale(10, 2)
+            .unwrap();
 
         let batch1 = RecordBatch::try_new(
             Arc::new(schema1.clone()),
@@ -1479,6 +1494,7 @@ mod tests {
                 Arc::new(id_array.clone()),
                 Arc::new(name_array.clone()),
                 Arc::new(age_array.clone()),
+                Arc::new(balance_array.clone()),
             ],
         )
         .expect("Unable to build record batch");
@@ -1487,6 +1503,7 @@ mod tests {
             Field::new("id", DataType::Int32, false),
             Field::new("name", DataType::Utf8, false),
             Field::new("blah", DataType::Int32, true),
+            Field::new("balance", DataType::Decimal64(10, 2), true),
         ]);
 
         let batch2 = RecordBatch::try_new(
@@ -1495,6 +1512,7 @@ mod tests {
                 Arc::new(id_array),
                 Arc::new(name_array),
                 Arc::new(age_array),
+                Arc::new(balance_array),
             ],
         )
         .expect("Unable to build record batch");
@@ -1503,7 +1521,16 @@ mod tests {
         let sql = InsertBuilder::new(&TableReference::from("users"), &record_batches)
             .build_postgres(None)
             .expect("Failed to build insert statement");
-        assert_eq!(sql, "INSERT INTO \"users\" (\"id\", \"name\", \"age\") VALUES (1, 'a', 10), (2, 'b', 20), (3, 'c', 30), (1, 'a', 10), (2, 'b', 20), (3, 'c', 30)");
+        assert_eq!(
+            sql,
+            "INSERT INTO \"users\" (\"id\", \"name\", \"age\", \"balance\") VALUES \
+            (1, 'a', 10, 123.45), \
+            (2, 'b', 20, -123.45), \
+            (3, 'c', 30, 123.00), \
+            (1, 'a', 10, 123.45), \
+            (2, 'b', 20, -123.45), \
+            (3, 'c', 30, 123.00)"
+        );
     }
 
     #[test]

--- a/core/tests/arrow_record_batch_gen/mod.rs
+++ b/core/tests/arrow_record_batch_gen/mod.rs
@@ -395,21 +395,31 @@ pub(crate) fn get_arrow_struct_record_batch() -> (RecordBatch, SchemaRef) {
     (record_batch, schema)
 }
 
-// Decimal128/Decimal256
 pub(crate) fn get_arrow_decimal_record_batch() -> (RecordBatch, SchemaRef) {
+    let decimal32_array =
+        Decimal32Array::from(vec![i32::from(123), i32::from(222), i32::from(321)]);
+    let decimal64_array =
+        Decimal64Array::from(vec![i64::from(123), i64::from(222), i64::from(321)]);
     let decimal128_array =
         Decimal128Array::from(vec![i128::from(123), i128::from(222), i128::from(321)]);
     let decimal256_array =
         Decimal256Array::from(vec![i256::from(-123), i256::from(222), i256::from(0)]);
 
     let schema = Arc::new(Schema::new(vec![
+        Field::new("decimal32", DataType::Decimal32(9, 2), false),
+        Field::new("decimal64", DataType::Decimal64(18, 6), false),
         Field::new("decimal128", DataType::Decimal128(38, 10), false),
         Field::new("decimal256", DataType::Decimal256(76, 10), false),
     ]));
 
     let record_batch = RecordBatch::try_new(
         Arc::clone(&schema),
-        vec![Arc::new(decimal128_array), Arc::new(decimal256_array)],
+        vec![
+            Arc::new(decimal32_array),
+            Arc::new(decimal64_array),
+            Arc::new(decimal128_array),
+            Arc::new(decimal256_array),
+        ],
     )
     .expect("Failed to created arrow decimal record batch");
 
@@ -417,6 +427,10 @@ pub(crate) fn get_arrow_decimal_record_batch() -> (RecordBatch, SchemaRef) {
 }
 
 pub(crate) fn get_mysql_arrow_decimal_record() -> (RecordBatch, SchemaRef) {
+    let decimal32_array =
+        Decimal32Array::from(vec![i32::from(123), i32::from(222), i32::from(321)]);
+    let decimal64_array =
+        Decimal64Array::from(vec![i64::from(123), i64::from(222), i64::from(321)]);
     let decimal128_array =
         Decimal128Array::from(vec![i128::from(123), i128::from(222), i128::from(321)]);
     let decimal256_array =
@@ -425,13 +439,20 @@ pub(crate) fn get_mysql_arrow_decimal_record() -> (RecordBatch, SchemaRef) {
             .expect("Fail to create Decimal256(65, 10) array");
 
     let schema = Arc::new(Schema::new(vec![
+        Field::new("decimal32", DataType::Decimal32(9, 2), false),
+        Field::new("decimal64", DataType::Decimal64(18, 6), false),
         Field::new("decimal128", DataType::Decimal128(38, 10), false),
         Field::new("decimal256", DataType::Decimal256(65, 10), false), // Maximum is 65.
     ]));
 
     let record_batch = RecordBatch::try_new(
         Arc::clone(&schema),
-        vec![Arc::new(decimal128_array), Arc::new(decimal256_array)],
+        vec![
+            Arc::new(decimal32_array),
+            Arc::new(decimal64_array),
+            Arc::new(decimal128_array),
+            Arc::new(decimal256_array),
+        ],
     )
     .expect("Failed to created arrow decimal record batch");
 


### PR DESCRIPTION
Adds write support for `Decimal32` and `Decimal64`. The implementation is the same as with `Decimal128` (in fact, the existing `Decimal128` implementation got converted into a `push_big_decimal_value` macro, used by the other two).

Also updated the existing tests.