### PR TITLE
fix(adbc): fix column order mismatch and improve error propagation in query_arrow

### DIFF
--- a/core/src/sql/db_connection_pool/dbconnection/adbcconn.rs
+++ b/core/src/sql/db_connection_pool/dbconnection/adbcconn.rs
@@ -215,37 +215,12 @@ where
         _projected_schema: Option<SchemaRef>,
     ) -> Result<SendableRecordBatchStream> {
         let (batch_tx, mut batch_rx) = tokio::sync::mpsc::channel::<RecordBatch>(4);
+        let (schema_tx, schema_rx) = std::sync::mpsc::channel::<
+            std::result::Result<SchemaRef, Box<dyn std::error::Error + Send + Sync>>,
+        >();
 
         let create_stream = || -> Result<SendableRecordBatchStream> {
-            let schema: SchemaRef;
-            {
-                let conn_mx = self.conn.lock().unwrap();
-                let mut conn = conn_mx.borrow_mut();
-                let mut stmt = conn
-                    .new_statement()
-                    .boxed()
-                    .context(super::UnableToQueryArrowSnafu)?;
-                stmt.set_sql_query(sql)?;
-
-                match stmt.execute_schema() {
-                    Ok(s) => schema = s.into(),
-                    // not all drivers implement execute_schema, so fall back to executing
-                    // with LIMIT 0 to get the schema.
-                    Err(_) => {
-                        stmt.set_sql_query(format!(
-                            "WITH fetch_schema AS ({sql}) SELECT * FROM fetch_schema LIMIT 0"
-                        ))?;
-                        let result = stmt
-                            .execute()
-                            .boxed()
-                            .context(super::UnableToQueryArrowSnafu)?;
-                        schema = result.schema();
-                    }
-                }
-            }
-
             let cloned_conn = Arc::clone(&self.conn);
-
             let sql_owned = sql.to_string();
             let params_owned = params.to_vec();
 
@@ -272,16 +247,38 @@ where
                     }
                 }
 
-                let results = stmt
-                    .execute()
-                    .boxed()
-                    .context(super::UnableToQueryArrowSnafu)?;
+                // Send the schema from the actual execution results.
+                // execute_schema() may return columns in table-definition order
+                // rather than in SQL SELECT order, causing type mismatches when
+                // multiple columns are projected in a non-matching order.
+                let results = match stmt.execute().boxed() {
+                    Ok(r) => {
+                        let _ = schema_tx.send(Ok(r.schema()));
+                        r
+                    }
+                    Err(e) => {
+                        let _ = schema_tx.send(Err(e.into()));
+                        return Ok(());
+                    }
+                };
+
                 for batch in results {
                     let b = batch.boxed().context(super::UnableToQueryArrowSnafu)?;
                     blocking_channel_send(&batch_tx, b)?;
                 }
                 Ok::<_, Box<dyn std::error::Error + Send + Sync>>(())
             });
+
+            // Block until the spawned task sends the schema derived from the
+            // real query results (which reflects the actual column order).
+            let schema = schema_rx
+                .recv()
+                .map_err(|_| Error::ChannelError {
+                    message: "Query execution task terminated unexpectedly".to_string(),
+                })?
+                .map_err(|e| Error::ChannelError {
+                    message: format!("Failed to execute ADBC query: {e}"),
+                })?;
 
             let output_stream = stream! {
                 while let Some(batch) = batch_rx.recv().await {


### PR DESCRIPTION

**Problem**

When querying multiple columns via an ADBC BigQuery connection, the query fails with:

> An internal error occurred. Arrow error: Invalid argument error: column types must match schema types, expected Int64 but found Utf8 at column index 0

Single-column queries work fine. The root cause is in `query_arrow`: it made a separate `execute_schema()` call to obtain the schema before running the actual query. The BigQuery ADBC driver returns columns from `execute_schema()` in **table-definition order**, but `execute()` returns them in **SQL SELECT order**. The `RecordBatchStreamAdapter` was built with the schema from `execute_schema()`, so when DataFusion validated incoming batches against it, column types at each index didn't match.

The query plan makes this visible — DataFusion pushes down `SELECT "gameId", "year"` (alphabetical), so `gameId` is at index 0 and `year` at index 1 in the actual results. But `execute_schema()` returned them as `year` (Int64) at index 0, `gameId` (Utf8) at index 1 — opposite order:

```
sql> explain SELECT year, gameId FROM spice.public.my_table LIMIT 5;
+---------------+-------------------------------------------------------------------------+
|   plan_type   |                                   plan                                  |
|    varchar    |                                 varchar                                 |
+---------------+-------------------------------------------------------------------------+
| logical_plan  | Projection: spice.public.my_table.year, spice.public.my_table.gameId    |
|               |   Limit: skip=0, fetch=5                                                |
|               |     TableScan: spice.public.my_table projection=[gameId, year], fetch=5 |
| physical_plan | ProjectionExec: expr=[year@1 as year, gameId@0 as gameId]               |
|               |   GlobalLimitExec: skip=0, fetch=5                                      |
|               |     CooperativeExec                                                     |
|               |       BytesProcessedExec                                                |
|               |         AdbcSqlExec sql=SELECT "gameId", "year" FROM schedules  LIMIT 5 |
|               |                                                                         |
+---------------+-------------------------------------------------------------------------+

Time: 0.4336375 seconds. 2 rows.
```

**Fix**

Remove the separate `execute_schema()` call. Instead, derive the schema directly from the `execute()` result reader (`results.schema()`), which is always consistent with the actual column order of the returned batches — a guaranteed contract of Arrow's `RecordBatchReader`. The schema is passed back from the `spawn_blocking` task to the stream setup via a channel.

Additional improvements:
- Execution errors from `execute()` now propagate the real driver error to the caller instead of a generic channel error message
- Eliminates an extra round-trip to BigQuery (two queries → one)

