### PR TITLE
Upgrade DataFusion to v52.5 and datafusion-federation to spiceai-52.5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,13 +39,13 @@ arrow-ipc = { version = "57.1.0" }
 arrow-schema = { version = "57.2.0", features = ["serde"] }
 arrow-json = "57.1.0"
 arrow-odbc = { version = "21.0.0" }
-datafusion = { version = "52.3.0", default-features = false }
-datafusion-expr = { version = "52.3.0" }
-datafusion-federation = { git = "https://github.com/spiceai/datafusion-federation.git", rev = "9b7e0f48c00deefe1276a46890562523b4b97c41" }
-datafusion-ffi = { version = "52.3.0" }
-datafusion-proto = { version = "52.3.0" }
-datafusion-physical-expr = { version = "52.3.0" }
-datafusion-physical-plan = { version = "52.3.0" }
+datafusion = { version = "52", default-features = false }
+datafusion-expr = { version = "52" }
+datafusion-federation = { git = "https://github.com/spiceai/datafusion-federation.git", rev = "e1318d3f7530234356caa87ba59e4bbc05dbe72a" }
+datafusion-ffi = { version = "52" }
+datafusion-proto = { version = "52" }
+datafusion-physical-expr = { version = "52" }
+datafusion-physical-plan = { version = "52" }
 datafusion-table-providers = { path = "core" }
 duckdb = { git = "https://github.com/spiceai/duckdb-rs.git", rev = "f4096c7592ed46b9e68755a49252d69783dece96" } # Forked to add support for duckdb_scan_arrow, pending: https://github.com/duckdb/duckdb-rs/pull/488
 adbc_core = { version = "0.21.0" }


### PR DESCRIPTION
Updates DataFusion dependency version requirements from `"52.3.0"` to `"52"` and upgrades `datafusion-federation` git dependency to the spiceai-52.5 branch commit.

## Changes
- Updated `datafusion`, `datafusion-expr`, `datafusion-ffi`, `datafusion-proto`, `datafusion-physical-expr`, `datafusion-physical-plan` from `"52.3.0"` to `"52"`
- Updated `datafusion-federation` git rev to `e1318d3f7530234356caa87ba59e4bbc05dbe72a` (spiceai-52.5 branch)

Tracking issue: https://github.com/spiceai/spiceai/issues/10234