### PR TITLE
Add comprehensive MongoDB pushdown support and Arrow type coverage

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -47,6 +47,7 @@ jobs:
           - 'mysql'
           - 'flight'
           - 'adbc'
+          - 'mongodb'
 
     steps:
       - uses: actions/checkout@v6
@@ -70,7 +71,7 @@ jobs:
 
     env:
       PG_DOCKER_IMAGE: ghcr.io/cloudnative-pg/postgresql:16-bookworm
-      MYSQL_DOCKER_IMAGE: public.ecr.aws/ubuntu/mysql:8.0-22.04_beta
+      MYSQL_DOCKER_IMAGE: mysql:8.0
 
     steps:
       - uses: actions/checkout@v6
@@ -80,15 +81,27 @@ jobs:
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@v2
 
-      - name: Log in to container registries
-        run: |
-          echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+      - name: Cache Docker images
+        id: docker-cache
+        uses: actions/cache@v4
+        with:
+          path: /tmp/docker-images
+          key: docker-images-${{ env.PG_DOCKER_IMAGE }}-${{ env.MYSQL_DOCKER_IMAGE }}
 
-      - name: Pull the Postgres/MySQL images
+      - name: Load or pull Docker images
         run: |
-          : work around spurious network errors in curl 8.0
-          docker pull ${{ env.PG_DOCKER_IMAGE }}
-          docker pull ${{ env.MYSQL_DOCKER_IMAGE }}
+          if [ -f /tmp/docker-images/postgres.tar ] && [ -f /tmp/docker-images/mysql.tar ]; then
+            echo "Loading cached Docker images..."
+            docker load -i /tmp/docker-images/postgres.tar
+            docker load -i /tmp/docker-images/mysql.tar
+          else
+            echo "Pulling Docker images..."
+            docker pull ${{ env.PG_DOCKER_IMAGE }}
+            docker pull ${{ env.MYSQL_DOCKER_IMAGE }}
+            mkdir -p /tmp/docker-images
+            docker save -o /tmp/docker-images/postgres.tar ${{ env.PG_DOCKER_IMAGE }}
+            docker save -o /tmp/docker-images/mysql.tar ${{ env.MYSQL_DOCKER_IMAGE }}
+          fi
 
       - name: Free Disk Space
         run: |

--- a/core/src/mongodb/connection.rs
+++ b/core/src/mongodb/connection.rs
@@ -89,6 +89,7 @@ impl MongoDBConnection {
         projected_schema: &SchemaRef,
         filters_doc: &Document,
         limit: Option<i32>,
+        sort_doc: &Document,
     ) -> Result<SendableRecordBatchStream> {
         let collection_name = table_reference.table();
         let coll = self.get_collection(collection_name);
@@ -96,6 +97,10 @@ impl MongoDBConnection {
         let mut find = coll
             .find(filters_doc.clone())
             .projection(schema_to_mongo_projection(projected_schema));
+
+        if !sort_doc.is_empty() {
+            find = find.sort(sort_doc.clone());
+        }
 
         if let Some(l) = limit {
             find = find.limit(l.into());

--- a/core/src/mongodb/connection.rs
+++ b/core/src/mongodb/connection.rs
@@ -1,9 +1,8 @@
 use async_stream::stream;
-use datafusion::arrow::datatypes::{Schema, SchemaRef};
+use datafusion::arrow::datatypes::SchemaRef;
 use datafusion::execution::SendableRecordBatchStream;
 use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
 use datafusion::sql::TableReference;
-use futures::StreamExt;
 use futures::TryStreamExt;
 use mongodb::{
     bson::{doc, Document},
@@ -111,7 +110,8 @@ impl MongoDBConnection {
         let projected_schema_clone = Arc::clone(projected_schema);
         let unnest_parameters = self.unnest_parameters.clone();
 
-        let mut batch_stream = Box::pin(stream! {
+        let schema = Arc::clone(projected_schema);
+        let batch_stream = stream! {
             for await chunk in chunked_stream {
                 match chunk {
                     Ok(docs) => {
@@ -128,26 +128,13 @@ impl MongoDBConnection {
                     Err(e) => yield Err(Error::QueryError { source: Box::new(e) }),
                 }
             }
-        });
-
-        let Some(first_batch_result) = batch_stream.next().await else {
-            return Ok(Box::pin(RecordBatchStreamAdapter::new(
-                Arc::new(Schema::empty()),
-                futures::stream::empty().boxed(),
-            )));
         };
 
-        let first_batch = first_batch_result?;
-        let schema = first_batch.schema();
-
-        let full_stream = Box::pin(stream! {
-            yield Ok(first_batch);
-            while let Some(batch_result) = batch_stream.next().await {
-                yield batch_result.map_err(|e| datafusion::error::DataFusionError::Execution(e.to_string()));
-            }
-        });
-
-        Ok(Box::pin(RecordBatchStreamAdapter::new(schema, full_stream)))
+        Ok(Box::pin(RecordBatchStreamAdapter::new(
+            schema,
+            Box::pin(batch_stream)
+                .map_err(|e| datafusion::error::DataFusionError::Execution(e.to_string())),
+        )))
     }
 }
 
@@ -158,9 +145,57 @@ pub fn schema_to_mongo_projection(projected_schema: &SchemaRef) -> Document {
         return projection;
     }
 
+    let has_id = projected_schema.fields().iter().any(|f| f.name() == "_id");
+
     for field in projected_schema.fields() {
         projection.insert(field.name(), 1);
     }
 
+    // MongoDB always includes _id unless explicitly suppressed
+    if !has_id {
+        projection.insert("_id", 0);
+    }
+
     projection
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use datafusion::arrow::datatypes::{DataType, Field, Schema};
+    use mongodb::bson::doc;
+
+    #[test]
+    fn test_projection_with_id() {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("_id", DataType::Utf8, false),
+            Field::new("name", DataType::Utf8, true),
+        ]));
+        let projection = schema_to_mongo_projection(&schema);
+        assert_eq!(projection, doc! { "_id": 1, "name": 1 });
+    }
+
+    #[test]
+    fn test_projection_without_id_suppresses() {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("name", DataType::Utf8, true),
+            Field::new("age", DataType::Int32, true),
+        ]));
+        let projection = schema_to_mongo_projection(&schema);
+        assert_eq!(projection, doc! { "name": 1, "age": 1, "_id": 0 });
+    }
+
+    #[test]
+    fn test_projection_empty_schema() {
+        let schema = Arc::new(Schema::empty());
+        let projection = schema_to_mongo_projection(&schema);
+        assert!(projection.is_empty());
+    }
+
+    #[test]
+    fn test_projection_single_field() {
+        let schema = Arc::new(Schema::new(vec![Field::new("email", DataType::Utf8, true)]));
+        let projection = schema_to_mongo_projection(&schema);
+        assert_eq!(projection, doc! { "email": 1, "_id": 0 });
+    }
 }

--- a/core/src/mongodb/connection_pool.rs
+++ b/core/src/mongodb/connection_pool.rs
@@ -85,6 +85,27 @@ impl MongoDBConnectionPool {
             self.num_documents_to_infer_schema,
         )))
     }
+
+    /// Create a stub pool for unit tests that don't require a real connection.
+    #[cfg(test)]
+    pub(crate) fn new_stub() -> Self {
+        let mut opts = ClientOptions::default();
+        opts.hosts = vec![mongodb::options::ServerAddress::Tcp {
+            host: "localhost".to_string(),
+            port: Some(27017),
+        }];
+        let client = Client::with_options(opts).expect("stub options should work");
+        Self {
+            client: Arc::new(client),
+            db_name: "test".to_string(),
+            tz: None,
+            unnest_parameters: UnnestParameters {
+                behavior: UnnestBehavior::Depth(0),
+                duplicate_behavior: DuplicateBehavior::Error,
+            },
+            num_documents_to_infer_schema: 100,
+        }
+    }
 }
 
 fn build_connection_uri(

--- a/core/src/mongodb/table.rs
+++ b/core/src/mongodb/table.rs
@@ -8,13 +8,14 @@ use datafusion::common::project_schema;
 use datafusion::error::{DataFusionError, Result as DataFusionResult};
 use datafusion::execution::TaskContext;
 use datafusion::logical_expr::{Expr, TableProviderFilterPushDown, TableType};
-use datafusion::physical_expr::EquivalenceProperties;
+use datafusion::physical_expr::{EquivalenceProperties, PhysicalSortExpr};
 use datafusion::physical_plan::execution_plan::{Boundedness, EmissionType};
 use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
 use datafusion::physical_plan::{
     DisplayAs, DisplayFormatType, ExecutionPlan, Partitioning, PlanProperties,
     SendableRecordBatchStream,
 };
+use datafusion::physical_plan::sort_pushdown::SortOrderPushdownResult;
 use datafusion::sql::TableReference;
 use futures::TryStreamExt;
 use mongodb::bson::Document;
@@ -225,6 +226,48 @@ impl ExecutionPlan for MongoDBExec {
         _children: Vec<Arc<dyn ExecutionPlan>>,
     ) -> DataFusionResult<Arc<dyn ExecutionPlan>> {
         Ok(self)
+    }
+
+    fn try_pushdown_sort(
+        &self,
+        order: &[PhysicalSortExpr],
+    ) -> DataFusionResult<SortOrderPushdownResult<Arc<dyn ExecutionPlan>>> {
+        use datafusion::physical_expr::expressions::Column;
+
+        let mut sort_doc = Document::new();
+        for sort_expr in order {
+            let Some(col) = sort_expr.expr.as_any().downcast_ref::<Column>() else {
+                // Can only push down simple column references
+                return Ok(SortOrderPushdownResult::Unsupported);
+            };
+            let direction = if sort_expr.options.descending {
+                -1
+            } else {
+                1
+            };
+            sort_doc.insert(col.name().to_string(), direction);
+        }
+
+        let mut new_exec = MongoDBExec {
+            table_reference: Arc::clone(&self.table_reference),
+            pool: Arc::clone(&self.pool),
+            projected_schema: Arc::clone(&self.projected_schema),
+            filters_doc: self.filters_doc.clone(),
+            sort_doc,
+            limit: self.limit,
+            properties: self.properties.clone(),
+        };
+
+        // Update equivalence properties to reflect the output ordering
+        let eq_properties = EquivalenceProperties::new_with_orderings(
+            Arc::clone(&self.projected_schema),
+            vec![order.to_vec()],
+        );
+        new_exec.properties = new_exec.properties.with_eq_properties(eq_properties);
+
+        Ok(SortOrderPushdownResult::Exact {
+            inner: Arc::new(new_exec),
+        })
     }
 
     fn execute(
@@ -570,5 +613,167 @@ mod tests {
             ),
             "Expected UnknownPartitioning(1)"
         );
+    }
+
+    // --- try_pushdown_sort ---
+
+    #[tokio::test]
+    async fn test_sort_pushdown_single_column_asc() {
+        use datafusion::physical_expr::expressions::Column as PhysColumn;
+
+        let schema = test_schema();
+        let table_ref = Arc::new(TableReference::bare("users"));
+        let exec = MongoDBExec::new(table_ref, stub_pool(), schema, None, &[], None).unwrap();
+
+        let sort_exprs = vec![PhysicalSortExpr::new(
+            Arc::new(PhysColumn::new("name", 1)),
+            datafusion::arrow::compute::SortOptions {
+                descending: false,
+                nulls_first: true,
+            },
+        )];
+
+        let result = exec.try_pushdown_sort(&sort_exprs).unwrap();
+        match result {
+            SortOrderPushdownResult::Exact { inner } => {
+                let mongo_exec = inner.as_any().downcast_ref::<MongoDBExec>().unwrap();
+                assert_eq!(mongo_exec.sort_doc, doc! { "name": 1 });
+                let display = format_exec(mongo_exec);
+                assert!(display.contains("sort=["), "Display should show sort: {display}");
+            }
+            other => panic!("Expected Exact, got: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_sort_pushdown_single_column_desc() {
+        use datafusion::physical_expr::expressions::Column as PhysColumn;
+
+        let schema = test_schema();
+        let table_ref = Arc::new(TableReference::bare("users"));
+        let exec = MongoDBExec::new(table_ref, stub_pool(), schema, None, &[], None).unwrap();
+
+        let sort_exprs = vec![PhysicalSortExpr::new(
+            Arc::new(PhysColumn::new("age", 2)),
+            datafusion::arrow::compute::SortOptions {
+                descending: true,
+                nulls_first: false,
+            },
+        )];
+
+        let result = exec.try_pushdown_sort(&sort_exprs).unwrap();
+        match result {
+            SortOrderPushdownResult::Exact { inner } => {
+                let mongo_exec = inner.as_any().downcast_ref::<MongoDBExec>().unwrap();
+                assert_eq!(mongo_exec.sort_doc, doc! { "age": -1 });
+            }
+            other => panic!("Expected Exact, got: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_sort_pushdown_multiple_columns() {
+        use datafusion::physical_expr::expressions::Column as PhysColumn;
+
+        let schema = test_schema();
+        let table_ref = Arc::new(TableReference::bare("users"));
+        let exec = MongoDBExec::new(table_ref, stub_pool(), schema, None, &[], None).unwrap();
+
+        let sort_exprs = vec![
+            PhysicalSortExpr::new(
+                Arc::new(PhysColumn::new("name", 1)),
+                datafusion::arrow::compute::SortOptions {
+                    descending: false,
+                    nulls_first: true,
+                },
+            ),
+            PhysicalSortExpr::new(
+                Arc::new(PhysColumn::new("age", 2)),
+                datafusion::arrow::compute::SortOptions {
+                    descending: true,
+                    nulls_first: false,
+                },
+            ),
+        ];
+
+        let result = exec.try_pushdown_sort(&sort_exprs).unwrap();
+        match result {
+            SortOrderPushdownResult::Exact { inner } => {
+                let mongo_exec = inner.as_any().downcast_ref::<MongoDBExec>().unwrap();
+                assert_eq!(mongo_exec.sort_doc, doc! { "name": 1, "age": -1 });
+            }
+            other => panic!("Expected Exact, got: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_sort_pushdown_non_column_returns_unsupported() {
+        use datafusion::physical_expr::expressions::Literal;
+        use datafusion::scalar::ScalarValue;
+
+        let schema = test_schema();
+        let table_ref = Arc::new(TableReference::bare("users"));
+        let exec = MongoDBExec::new(table_ref, stub_pool(), schema, None, &[], None).unwrap();
+
+        let sort_exprs = vec![PhysicalSortExpr::new(
+            Arc::new(Literal::new(ScalarValue::Int32(Some(1)))),
+            datafusion::arrow::compute::SortOptions::default(),
+        )];
+
+        let result = exec.try_pushdown_sort(&sort_exprs).unwrap();
+        assert!(
+            matches!(result, SortOrderPushdownResult::Unsupported),
+            "Non-column sort should be Unsupported"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_sort_pushdown_preserves_filters_and_limit() {
+        use datafusion::physical_expr::expressions::Column as PhysColumn;
+
+        let schema = test_schema();
+        let table_ref = Arc::new(TableReference::bare("users"));
+        let filters = vec![col("age").gt(lit(21))];
+        let exec = MongoDBExec::new(
+            table_ref,
+            stub_pool(),
+            schema,
+            None,
+            &filters,
+            Some(10),
+        )
+        .unwrap();
+
+        let sort_exprs = vec![PhysicalSortExpr::new(
+            Arc::new(PhysColumn::new("name", 1)),
+            datafusion::arrow::compute::SortOptions::default(),
+        )];
+
+        let result = exec.try_pushdown_sort(&sort_exprs).unwrap();
+        match result {
+            SortOrderPushdownResult::Exact { inner } => {
+                let mongo_exec = inner.as_any().downcast_ref::<MongoDBExec>().unwrap();
+                assert!(!mongo_exec.filters_doc.is_empty(), "Filters should be preserved");
+                assert_eq!(mongo_exec.limit, Some(10), "Limit should be preserved");
+                assert_eq!(mongo_exec.sort_doc, doc! { "name": 1 });
+            }
+            other => panic!("Expected Exact, got: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_sort_pushdown_empty_order() {
+        let schema = test_schema();
+        let table_ref = Arc::new(TableReference::bare("users"));
+        let exec = MongoDBExec::new(table_ref, stub_pool(), schema, None, &[], None).unwrap();
+
+        let result = exec.try_pushdown_sort(&[]).unwrap();
+        match result {
+            SortOrderPushdownResult::Exact { inner } => {
+                let mongo_exec = inner.as_any().downcast_ref::<MongoDBExec>().unwrap();
+                assert!(mongo_exec.sort_doc.is_empty(), "Empty sort should produce empty doc");
+            }
+            other => panic!("Expected Exact, got: {other:?}"),
+        }
     }
 }

--- a/core/src/mongodb/table.rs
+++ b/core/src/mongodb/table.rs
@@ -103,6 +103,7 @@ struct MongoDBExec {
     pool: Arc<MongoDBConnectionPool>,
     projected_schema: SchemaRef,
     filters_doc: Document,
+    sort_doc: Document,
     limit: Option<i32>,
     properties: PlanProperties,
 }
@@ -155,6 +156,7 @@ impl MongoDBExec {
             pool,
             projected_schema: Arc::clone(&projected_schema),
             filters_doc: mongo_filters_doc,
+            sort_doc: Document::new(),
             limit,
             properties: PlanProperties::new(
                 EquivalenceProperties::new(projected_schema),
@@ -182,7 +184,18 @@ impl DisplayAs for MongoDBExec {
             "MongoDBExec projection=[{}] filters=[{}]",
             columns.join(", "),
             filters,
-        )
+        )?;
+
+        if !self.sort_doc.is_empty() {
+            let sort = serde_json::to_string(&self.sort_doc).map_err(|_| fmt::Error)?;
+            write!(f, " sort=[{sort}]")?;
+        }
+
+        if let Some(limit) = self.limit {
+            write!(f, " limit=[{limit}]")?;
+        }
+
+        Ok(())
     }
 }
 
@@ -225,14 +238,21 @@ impl ExecutionPlan for MongoDBExec {
         let pool = Arc::clone(&self.pool);
         let projected_schema = Arc::clone(&self.projected_schema);
         let filters_doc = self.filters_doc.clone();
+        let sort_doc = self.sort_doc.clone();
         let limit = self.limit;
 
         let stream = futures::stream::once(async move {
             let conn = pool.connect().await.map_err(to_execution_error)?;
 
-            conn.query_arrow(&table_reference, &projected_schema, &filters_doc, limit)
-                .await
-                .map_err(to_execution_error)
+            conn.query_arrow(
+                &table_reference,
+                &projected_schema,
+                &filters_doc,
+                limit,
+                &sort_doc,
+            )
+            .await
+            .map_err(to_execution_error)
         })
         .try_flatten();
 
@@ -250,7 +270,35 @@ pub fn to_execution_error(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use datafusion::arrow::datatypes::{DataType, Field, Schema};
     use datafusion::logical_expr::{col, lit, BinaryExpr, Expr, Operator};
+    use mongodb::bson::doc;
+
+    fn test_schema() -> SchemaRef {
+        Arc::new(Schema::new(vec![
+            Field::new("_id", DataType::Utf8, false),
+            Field::new("name", DataType::Utf8, true),
+            Field::new("age", DataType::Int32, true),
+            Field::new("active", DataType::Boolean, true),
+        ]))
+    }
+
+    /// Helper to get the DisplayAs output from a MongoDBExec.
+    fn format_exec(exec: &MongoDBExec) -> String {
+        struct Wrapper<'a>(&'a MongoDBExec);
+        impl fmt::Display for Wrapper<'_> {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                self.0.fmt_as(DisplayFormatType::Default, f)
+            }
+        }
+        format!("{}", Wrapper(exec))
+    }
+
+    fn stub_pool() -> Arc<MongoDBConnectionPool> {
+        Arc::new(MongoDBConnectionPool::new_stub())
+    }
+
+    // --- supports_filters_pushdown ---
 
     #[tokio::test]
     async fn test_supports_filters_pushdown_supported() {
@@ -284,8 +332,243 @@ mod tests {
             vec![
                 TableProviderFilterPushDown::Exact,
                 TableProviderFilterPushDown::Exact,
-                TableProviderFilterPushDown::Unsupported,
+                TableProviderFilterPushDown::Exact,
             ]
+        );
+    }
+
+    #[tokio::test]
+    async fn test_supports_filters_pushdown_all_new_types() {
+        let exprs = vec![
+            col("x").is_null(),
+            col("x").is_not_null(),
+            col("x").is_true(),
+            col("x").is_false(),
+            col("x").is_not_true(),
+            col("x").is_not_false(),
+            col("x").between(lit(1), lit(10)),
+            col("x").not_between(lit(1), lit(10)),
+            col("x").in_list(vec![lit(1), lit(2)], false),
+            col("x").in_list(vec![lit(1), lit(2)], true),
+            col("x").like(lit("%foo%")),
+            col("x").not_like(lit("bar%")),
+            col("x").ilike(lit("%baz")),
+            col("x").not_ilike(lit("qux%")),
+            Expr::Not(Box::new(col("x").eq(lit(5)))),
+        ];
+        let refs: Vec<&Expr> = exprs.iter().collect();
+        let res = supports_filters_pushdown(&refs).unwrap();
+        assert!(
+            res.iter().all(|r| *r == TableProviderFilterPushDown::Exact),
+            "All new expression types should be Exact, got: {res:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_supports_filters_pushdown_empty() {
+        let res = supports_filters_pushdown(&[]).unwrap();
+        assert!(res.is_empty());
+    }
+
+    // --- DisplayAs / explain plan ---
+
+    #[tokio::test]
+    async fn test_display_no_filters_no_limit() {
+        let schema = test_schema();
+        let table_ref = Arc::new(TableReference::bare("users"));
+        let exec = MongoDBExec::new(table_ref, stub_pool(), schema, None, &[], None).unwrap();
+
+        let display = format_exec(&exec);
+        assert!(
+            display.contains("MongoDBExec projection=[_id, name, age, active]"),
+            "Should show all columns: {display}"
+        );
+        assert!(display.contains("filters=[{}]"), "No filters: {display}");
+        assert!(
+            !display.contains("sort="),
+            "No sort shown when empty: {display}"
+        );
+        assert!(
+            !display.contains("limit="),
+            "No limit shown when None: {display}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_display_with_projection() {
+        let schema = test_schema();
+        let table_ref = Arc::new(TableReference::bare("users"));
+        let exec =
+            MongoDBExec::new(table_ref, stub_pool(), schema, Some(&vec![1, 2]), &[], None).unwrap();
+
+        let display = format_exec(&exec);
+        assert!(
+            display.contains("projection=[name, age]"),
+            "Should show projected columns: {display}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_display_with_filters() {
+        let schema = test_schema();
+        let table_ref = Arc::new(TableReference::bare("users"));
+        let filters = vec![col("age").gt(lit(21))];
+        let exec = MongoDBExec::new(table_ref, stub_pool(), schema, None, &filters, None).unwrap();
+
+        let display = format_exec(&exec);
+        assert!(
+            display.contains(r#""age":{"$gt":21}"#),
+            "Should show filter doc: {display}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_display_with_limit() {
+        let schema = test_schema();
+        let table_ref = Arc::new(TableReference::bare("users"));
+        let exec = MongoDBExec::new(table_ref, stub_pool(), schema, None, &[], Some(100)).unwrap();
+
+        let display = format_exec(&exec);
+        assert!(
+            display.contains("limit=[100]"),
+            "Should show limit: {display}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_display_with_sort() {
+        let schema = test_schema();
+        let table_ref = Arc::new(TableReference::bare("users"));
+        let mut exec = MongoDBExec::new(table_ref, stub_pool(), schema, None, &[], None).unwrap();
+        exec.sort_doc = doc! { "name": 1, "age": -1 };
+
+        let display = format_exec(&exec);
+        assert!(
+            display.contains("sort=["),
+            "Should show sort section: {display}"
+        );
+        assert!(
+            display.contains(r#""name":1"#),
+            "Should show sort fields: {display}"
+        );
+        assert!(
+            display.contains(r#""age":-1"#),
+            "Should show sort fields: {display}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_display_with_all_options() {
+        let schema = test_schema();
+        let table_ref = Arc::new(TableReference::bare("users"));
+        let filters = vec![col("active").eq(lit(true))];
+        let mut exec = MongoDBExec::new(
+            table_ref,
+            stub_pool(),
+            schema,
+            Some(&vec![1, 3]),
+            &filters,
+            Some(50),
+        )
+        .unwrap();
+        exec.sort_doc = doc! { "name": 1 };
+
+        let display = format_exec(&exec);
+        assert!(
+            display.contains("projection=[name, active]"),
+            "projection: {display}"
+        );
+        assert!(display.contains(r#""active":true"#), "filter: {display}");
+        assert!(display.contains("sort=["), "sort: {display}");
+        assert!(display.contains("limit=[50]"), "limit: {display}");
+    }
+
+    #[tokio::test]
+    async fn test_display_complex_filter() {
+        let schema = test_schema();
+        let table_ref = Arc::new(TableReference::bare("users"));
+        let filters = vec![col("age").gt(lit(18)).and(col("name").eq(lit("Alice")))];
+        let exec = MongoDBExec::new(table_ref, stub_pool(), schema, None, &filters, None).unwrap();
+
+        let display = format_exec(&exec);
+        assert!(
+            display.contains("$and"),
+            "Should show AND filter: {display}"
+        );
+        assert!(
+            display.contains(r#""age":{"$gt":18}"#),
+            "Should show age filter: {display}"
+        );
+        assert!(
+            display.contains(r#""name":"Alice""#),
+            "Should show name filter: {display}"
+        );
+    }
+
+    // --- MongoDBExec edge cases ---
+
+    #[tokio::test]
+    async fn test_exec_empty_projection_falls_back_to_id() {
+        let schema = test_schema();
+        let table_ref = Arc::new(TableReference::bare("users"));
+        let exec =
+            MongoDBExec::new(table_ref, stub_pool(), schema, Some(&vec![]), &[], None).unwrap();
+
+        let display = format_exec(&exec);
+        assert!(
+            display.contains("projection=[_id]"),
+            "Empty projection should fall back to _id: {display}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_exec_limit_too_large() {
+        let schema = test_schema();
+        let table_ref = Arc::new(TableReference::bare("users"));
+        let result = MongoDBExec::new(table_ref, stub_pool(), schema, None, &[], Some(usize::MAX));
+        assert!(result.is_err(), "Should fail for limit that exceeds i32");
+    }
+
+    #[tokio::test]
+    async fn test_exec_no_filters_produces_empty_doc() {
+        let schema = test_schema();
+        let table_ref = Arc::new(TableReference::bare("users"));
+        let exec = MongoDBExec::new(table_ref, stub_pool(), schema, None, &[], None).unwrap();
+
+        assert!(
+            exec.filters_doc.is_empty(),
+            "No filters should produce empty doc"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_exec_multiple_filters_combined() {
+        let schema = test_schema();
+        let table_ref = Arc::new(TableReference::bare("users"));
+        let filters = vec![col("age").gt(lit(18)), col("active").eq(lit(true))];
+        let exec = MongoDBExec::new(table_ref, stub_pool(), schema, None, &filters, None).unwrap();
+
+        assert!(
+            exec.filters_doc.contains_key("$and"),
+            "Multiple filters should be combined with $and: {:?}",
+            exec.filters_doc
+        );
+    }
+
+    #[tokio::test]
+    async fn test_exec_properties() {
+        let schema = test_schema();
+        let table_ref = Arc::new(TableReference::bare("users"));
+        let exec = MongoDBExec::new(table_ref, stub_pool(), schema, None, &[], None).unwrap();
+
+        assert_eq!(exec.name(), "MongoDBExec");
+        assert_eq!(exec.children().len(), 0);
+        assert!(
+            matches!(
+                exec.properties().partitioning,
+                Partitioning::UnknownPartitioning(1)
+            ),
+            "Expected UnknownPartitioning(1)"
         );
     }
 }

--- a/core/src/mongodb/table.rs
+++ b/core/src/mongodb/table.rs
@@ -10,12 +10,12 @@ use datafusion::execution::TaskContext;
 use datafusion::logical_expr::{Expr, TableProviderFilterPushDown, TableType};
 use datafusion::physical_expr::{EquivalenceProperties, PhysicalSortExpr};
 use datafusion::physical_plan::execution_plan::{Boundedness, EmissionType};
+use datafusion::physical_plan::sort_pushdown::SortOrderPushdownResult;
 use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
 use datafusion::physical_plan::{
     DisplayAs, DisplayFormatType, ExecutionPlan, Partitioning, PlanProperties,
     SendableRecordBatchStream,
 };
-use datafusion::physical_plan::sort_pushdown::SortOrderPushdownResult;
 use datafusion::sql::TableReference;
 use futures::TryStreamExt;
 use mongodb::bson::Document;
@@ -240,11 +240,7 @@ impl ExecutionPlan for MongoDBExec {
                 // Can only push down simple column references
                 return Ok(SortOrderPushdownResult::Unsupported);
             };
-            let direction = if sort_expr.options.descending {
-                -1
-            } else {
-                1
-            };
+            let direction = if sort_expr.options.descending { -1 } else { 1 };
             sort_doc.insert(col.name().to_string(), direction);
         }
 
@@ -615,6 +611,34 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn test_exec_unconvertible_combined_filter_errors() {
+        // Two filters where AND combines them, but the combined expr can't be converted
+        // (e.g., one is a Modulo that passes combine_exprs_with_and but fails expr_to_mongo_filter)
+        let schema = test_schema();
+        let table_ref = Arc::new(TableReference::bare("users"));
+        let filters = vec![Expr::BinaryExpr(BinaryExpr {
+            left: Box::new(col("age")),
+            op: Operator::Modulo,
+            right: Box::new(lit(2)),
+        })];
+        let result = MongoDBExec::new(table_ref, stub_pool(), schema, None, &filters, None);
+        assert!(
+            result.is_err(),
+            "Should error when combined filter can't be converted"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_exec_with_new_children_returns_self() {
+        let schema = test_schema();
+        let table_ref = Arc::new(TableReference::bare("users"));
+        let exec = MongoDBExec::new(table_ref, stub_pool(), schema, None, &[], None).unwrap();
+        let exec_arc: Arc<dyn ExecutionPlan> = Arc::new(exec);
+        let result = exec_arc.clone().with_new_children(vec![]).unwrap();
+        assert_eq!(result.name(), "MongoDBExec");
+    }
+
     // --- try_pushdown_sort ---
 
     #[tokio::test]
@@ -639,7 +663,10 @@ mod tests {
                 let mongo_exec = inner.as_any().downcast_ref::<MongoDBExec>().unwrap();
                 assert_eq!(mongo_exec.sort_doc, doc! { "name": 1 });
                 let display = format_exec(mongo_exec);
-                assert!(display.contains("sort=["), "Display should show sort: {display}");
+                assert!(
+                    display.contains("sort=["),
+                    "Display should show sort: {display}"
+                );
             }
             other => panic!("Expected Exact, got: {other:?}"),
         }
@@ -734,15 +761,8 @@ mod tests {
         let schema = test_schema();
         let table_ref = Arc::new(TableReference::bare("users"));
         let filters = vec![col("age").gt(lit(21))];
-        let exec = MongoDBExec::new(
-            table_ref,
-            stub_pool(),
-            schema,
-            None,
-            &filters,
-            Some(10),
-        )
-        .unwrap();
+        let exec =
+            MongoDBExec::new(table_ref, stub_pool(), schema, None, &filters, Some(10)).unwrap();
 
         let sort_exprs = vec![PhysicalSortExpr::new(
             Arc::new(PhysColumn::new("name", 1)),
@@ -753,7 +773,10 @@ mod tests {
         match result {
             SortOrderPushdownResult::Exact { inner } => {
                 let mongo_exec = inner.as_any().downcast_ref::<MongoDBExec>().unwrap();
-                assert!(!mongo_exec.filters_doc.is_empty(), "Filters should be preserved");
+                assert!(
+                    !mongo_exec.filters_doc.is_empty(),
+                    "Filters should be preserved"
+                );
                 assert_eq!(mongo_exec.limit, Some(10), "Limit should be preserved");
                 assert_eq!(mongo_exec.sort_doc, doc! { "name": 1 });
             }
@@ -771,7 +794,10 @@ mod tests {
         match result {
             SortOrderPushdownResult::Exact { inner } => {
                 let mongo_exec = inner.as_any().downcast_ref::<MongoDBExec>().unwrap();
-                assert!(mongo_exec.sort_doc.is_empty(), "Empty sort should produce empty doc");
+                assert!(
+                    mongo_exec.sort_doc.is_empty(),
+                    "Empty sort should produce empty doc"
+                );
             }
             other => panic!("Expected Exact, got: {other:?}"),
         }

--- a/core/src/mongodb/utils/arrow.rs
+++ b/core/src/mongodb/utils/arrow.rs
@@ -12,7 +12,6 @@ use mongodb::bson::{Bson, Document};
 use num_traits::ToPrimitive;
 use rust_decimal::Decimal;
 use snafu::prelude::*;
-use std::collections::HashMap;
 use std::str::FromStr;
 use std::sync::Arc;
 
@@ -100,15 +99,15 @@ fn create_empty_array(data_type: &DataType) -> ArrayRef {
     }
 }
 
-type BuilderMap = HashMap<String, Box<dyn ArrayBuilderTrait>>;
+type BuilderVec = Vec<Box<dyn ArrayBuilderTrait>>;
 
 trait ArrayBuilderTrait {
     fn append_bson(&mut self, value: Option<&Bson>) -> Result<(), Error>;
     fn finish_builder(self: Box<Self>) -> Result<ArrayRef, Error>;
 }
 
-fn create_builders(schema: &SchemaRef, capacity: usize) -> Result<BuilderMap, Error> {
-    let mut builders: BuilderMap = HashMap::new();
+fn create_builders(schema: &SchemaRef, capacity: usize) -> Result<BuilderVec, Error> {
+    let mut builders: BuilderVec = Vec::with_capacity(schema.fields().len());
 
     for field in schema.fields() {
         let builder: Box<dyn ArrayBuilderTrait> = match field.data_type() {
@@ -143,7 +142,7 @@ fn create_builders(schema: &SchemaRef, capacity: usize) -> Result<BuilderMap, Er
             }
         };
 
-        builders.insert(field.name().clone(), builder);
+        builders.push(builder);
     }
 
     Ok(builders)
@@ -152,37 +151,20 @@ fn create_builders(schema: &SchemaRef, capacity: usize) -> Result<BuilderMap, Er
 fn append_document_to_builders(
     doc: &Document,
     schema: &SchemaRef,
-    builders: &mut BuilderMap,
+    builders: &mut BuilderVec,
 ) -> Result<(), Error> {
-    for field in schema.fields() {
-        let field_name = field.name();
-        let value = doc.get(field_name);
-
-        if let Some(builder) = builders.get_mut(field_name) {
-            builder.append_bson(value)?;
-        }
+    for (i, field) in schema.fields().iter().enumerate() {
+        let value = doc.get(field.name());
+        builders[i].append_bson(value)?;
     }
     Ok(())
 }
 
-fn finish_builders(mut builders: BuilderMap, schema: &SchemaRef) -> Result<Vec<ArrayRef>, Error> {
-    let mut arrays = Vec::new();
-
-    for field in schema.fields() {
-        let field_name = field.name();
-        if let Some(builder) = builders.remove(field_name) {
-            arrays.push(builder.finish_builder()?);
-        } else {
-            return Err(Error::ConversionError {
-                source: Box::new(std::io::Error::new(
-                    std::io::ErrorKind::InvalidData,
-                    format!("Missing builder for field: {field_name}"),
-                )),
-            });
-        }
-    }
-
-    Ok(arrays)
+fn finish_builders(builders: BuilderVec, _schema: &SchemaRef) -> Result<Vec<ArrayRef>, Error> {
+    builders
+        .into_iter()
+        .map(|builder| builder.finish_builder())
+        .collect()
 }
 
 struct BooleanArrayBuilder(BooleanBuilder);
@@ -693,10 +675,12 @@ impl ArrayBuilderTrait for Decimal128ArrayBuilder {
     fn append_bson(&mut self, value: Option<&Bson>) -> Result<(), Error> {
         match value {
             Some(Bson::Decimal128(decimal)) => {
-                let parsed_decimal = rust_decimal::Decimal::from_str(&decimal.to_string())
-                    .map_err(|e| Error::ConversionError {
-                        source: Box::new(e),
-                    })?;
+                let Ok(parsed_decimal) = rust_decimal::Decimal::from_str(&decimal.to_string())
+                else {
+                    // NaN, Infinity, -Infinity, or other unparseable values → null
+                    self.builder.append_null();
+                    return Ok(());
+                };
 
                 let scaling_factor: Decimal = if self.scale >= 0 {
                     ten_pow_decimal(self.scale as u32).map_err(|_| Error::ConversionError {
@@ -2246,5 +2230,39 @@ mod decimal_tests {
 
         let result = Decimal128ArrayBuilder::new(10, 10, 11); // scale > precision
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_decimal_nan_appends_null() {
+        let mut builder = Decimal128ArrayBuilder::new(1, 18, 6).unwrap();
+        // BSON Decimal128 NaN should not error — should append null
+        let nan_decimal = "NaN".parse::<mongodb::bson::Decimal128>().unwrap();
+        let result = builder.append_bson(Some(&Bson::Decimal128(nan_decimal)));
+        assert!(result.is_ok(), "NaN should not cause an error");
+        let array = Box::new(builder).finish_builder().unwrap();
+        assert_eq!(array.len(), 1);
+        assert!(array.is_null(0), "NaN should be stored as null");
+    }
+
+    #[test]
+    fn test_decimal_infinity_appends_null() {
+        let mut builder = Decimal128ArrayBuilder::new(1, 18, 6).unwrap();
+        let inf_decimal = "Infinity".parse::<mongodb::bson::Decimal128>().unwrap();
+        let result = builder.append_bson(Some(&Bson::Decimal128(inf_decimal)));
+        assert!(result.is_ok(), "Infinity should not cause an error");
+        let array = Box::new(builder).finish_builder().unwrap();
+        assert_eq!(array.len(), 1);
+        assert!(array.is_null(0), "Infinity should be stored as null");
+    }
+
+    #[test]
+    fn test_decimal_neg_infinity_appends_null() {
+        let mut builder = Decimal128ArrayBuilder::new(1, 18, 6).unwrap();
+        let neg_inf_decimal = "-Infinity".parse::<mongodb::bson::Decimal128>().unwrap();
+        let result = builder.append_bson(Some(&Bson::Decimal128(neg_inf_decimal)));
+        assert!(result.is_ok(), "-Infinity should not cause an error");
+        let array = Box::new(builder).finish_builder().unwrap();
+        assert_eq!(array.len(), 1);
+        assert!(array.is_null(0), "-Infinity should be stored as null");
     }
 }

--- a/core/src/mongodb/utils/arrow.rs
+++ b/core/src/mongodb/utils/arrow.rs
@@ -1,8 +1,10 @@
 use crate::mongodb::{Error, InvalidDecimalSnafu, Result};
 use arrow::array::{
-    ArrayRef, BinaryBuilder, BooleanBuilder, Date32Builder, Decimal128Builder, Float64Builder,
-    Int32Builder, Int64Builder, ListBuilder, NullBuilder, RecordBatch, StringBuilder,
-    TimestampMillisecondBuilder,
+    ArrayRef, BinaryBuilder, BooleanBuilder, Date32Builder, Date64Builder, Decimal128Builder,
+    Float32Builder, Float64Builder, Int16Builder, Int32Builder, Int64Builder, Int8Builder,
+    LargeBinaryBuilder, LargeStringBuilder, ListBuilder, NullBuilder, RecordBatch, StringBuilder,
+    TimestampMicrosecondBuilder, TimestampMillisecondBuilder, TimestampNanosecondBuilder,
+    TimestampSecondBuilder, UInt16Builder, UInt32Builder, UInt64Builder, UInt8Builder,
 };
 use chrono::{LocalResult, TimeZone, Utc};
 use datafusion::arrow::datatypes::{DataType, SchemaRef, TimeUnit};
@@ -49,14 +51,39 @@ pub fn mongo_docs_to_arrow(
 fn create_empty_array(data_type: &DataType) -> ArrayRef {
     match data_type {
         DataType::Boolean => Arc::new(BooleanBuilder::new().finish()),
+        DataType::Int8 => Arc::new(Int8Builder::new().finish()),
+        DataType::Int16 => Arc::new(Int16Builder::new().finish()),
         DataType::Int32 => Arc::new(Int32Builder::new().finish()),
         DataType::Int64 => Arc::new(Int64Builder::new().finish()),
+        DataType::UInt8 => Arc::new(UInt8Builder::new().finish()),
+        DataType::UInt16 => Arc::new(UInt16Builder::new().finish()),
+        DataType::UInt32 => Arc::new(UInt32Builder::new().finish()),
+        DataType::UInt64 => Arc::new(UInt64Builder::new().finish()),
+        DataType::Float32 => Arc::new(Float32Builder::new().finish()),
         DataType::Float64 => Arc::new(Float64Builder::new().finish()),
         DataType::Utf8 => Arc::new(StringBuilder::new().finish()),
+        DataType::LargeUtf8 => Arc::new(LargeStringBuilder::new().finish()),
         DataType::Binary => Arc::new(BinaryBuilder::new().finish()),
+        DataType::LargeBinary => Arc::new(LargeBinaryBuilder::new().finish()),
         DataType::Date32 => Arc::new(Date32Builder::new().finish()),
+        DataType::Date64 => Arc::new(Date64Builder::new().finish()),
+        DataType::Timestamp(TimeUnit::Second, tz_opt) => Arc::new(
+            TimestampSecondBuilder::new()
+                .with_timezone_opt(tz_opt.clone())
+                .finish(),
+        ),
         DataType::Timestamp(TimeUnit::Millisecond, tz_opt) => Arc::new(
             TimestampMillisecondBuilder::new()
+                .with_timezone_opt(tz_opt.clone())
+                .finish(),
+        ),
+        DataType::Timestamp(TimeUnit::Microsecond, tz_opt) => Arc::new(
+            TimestampMicrosecondBuilder::new()
+                .with_timezone_opt(tz_opt.clone())
+                .finish(),
+        ),
+        DataType::Timestamp(TimeUnit::Nanosecond, tz_opt) => Arc::new(
+            TimestampNanosecondBuilder::new()
                 .with_timezone_opt(tz_opt.clone())
                 .finish(),
         ),
@@ -86,15 +113,25 @@ fn create_builders(schema: &SchemaRef, capacity: usize) -> Result<BuilderMap, Er
     for field in schema.fields() {
         let builder: Box<dyn ArrayBuilderTrait> = match field.data_type() {
             DataType::Boolean => Box::new(BooleanArrayBuilder::new(capacity)),
+            DataType::Int8 => Box::new(Int8ArrayBuilder::new(capacity)),
+            DataType::Int16 => Box::new(Int16ArrayBuilder::new(capacity)),
             DataType::Int32 => Box::new(Int32ArrayBuilder::new(capacity)),
             DataType::Int64 => Box::new(Int64ArrayBuilder::new(capacity)),
+            DataType::UInt8 => Box::new(UInt8ArrayBuilder::new(capacity)),
+            DataType::UInt16 => Box::new(UInt16ArrayBuilder::new(capacity)),
+            DataType::UInt32 => Box::new(UInt32ArrayBuilder::new(capacity)),
+            DataType::UInt64 => Box::new(UInt64ArrayBuilder::new(capacity)),
+            DataType::Float32 => Box::new(Float32ArrayBuilder::new(capacity)),
             DataType::Float64 => Box::new(Float64ArrayBuilder::new(capacity)),
             DataType::Utf8 => Box::new(StringArrayBuilder::new(capacity)),
+            DataType::LargeUtf8 => Box::new(LargeStringArrayBuilder::new(capacity)),
             DataType::Binary => Box::new(BinaryArrayBuilder::new(capacity)),
-            DataType::Timestamp(TimeUnit::Millisecond, tz_opt) => {
-                Box::new(TimestampArrayBuilder::new(capacity, tz_opt.clone()))
+            DataType::LargeBinary => Box::new(LargeBinaryArrayBuilder::new(capacity)),
+            DataType::Timestamp(unit, tz_opt) => {
+                Box::new(TimestampArrayBuilder::new(capacity, *unit, tz_opt.clone()))
             }
             DataType::Date32 => Box::new(Date32ArrayBuilder::new(capacity)),
+            DataType::Date64 => Box::new(Date64ArrayBuilder::new(capacity)),
             DataType::Decimal128(precision, scale) => {
                 Box::new(Decimal128ArrayBuilder::new(capacity, *precision, *scale)?)
             }
@@ -149,19 +186,36 @@ fn finish_builders(mut builders: BuilderMap, schema: &SchemaRef) -> Result<Vec<A
 }
 
 struct BooleanArrayBuilder(BooleanBuilder);
+struct Int8ArrayBuilder(Int8Builder);
+struct Int16ArrayBuilder(Int16Builder);
 struct Int32ArrayBuilder(Int32Builder);
 struct Int64ArrayBuilder(Int64Builder);
+struct UInt8ArrayBuilder(UInt8Builder);
+struct UInt16ArrayBuilder(UInt16Builder);
+struct UInt32ArrayBuilder(UInt32Builder);
+struct UInt64ArrayBuilder(UInt64Builder);
+struct Float32ArrayBuilder(Float32Builder);
 struct Float64ArrayBuilder(Float64Builder);
 struct StringArrayBuilder(StringBuilder);
+struct LargeStringArrayBuilder(LargeStringBuilder);
 struct BinaryArrayBuilder(BinaryBuilder);
-struct TimestampArrayBuilder(TimestampMillisecondBuilder);
+struct LargeBinaryArrayBuilder(LargeBinaryBuilder);
 struct Date32ArrayBuilder(Date32Builder);
+struct Date64ArrayBuilder(Date64Builder);
 pub struct Decimal128ArrayBuilder {
     builder: Decimal128Builder,
     scale: i8,
 }
 struct ListArrayBuilder(ListBuilder<StringBuilder>);
 struct NullArrayBuilder(NullBuilder);
+
+/// Timestamp builder that supports all time units (Second, Millisecond, Microsecond, Nanosecond).
+enum TimestampArrayBuilder {
+    Second(TimestampSecondBuilder),
+    Millisecond(TimestampMillisecondBuilder),
+    Microsecond(TimestampMicrosecondBuilder),
+    Nanosecond(TimestampNanosecondBuilder),
+}
 
 impl BooleanArrayBuilder {
     fn new(capacity: usize) -> Self {
@@ -187,6 +241,50 @@ impl ArrayBuilderTrait for BooleanArrayBuilder {
 impl Int32ArrayBuilder {
     fn new(capacity: usize) -> Self {
         Self(Int32Builder::with_capacity(capacity))
+    }
+}
+
+impl Int8ArrayBuilder {
+    fn new(capacity: usize) -> Self {
+        Self(Int8Builder::with_capacity(capacity))
+    }
+}
+
+impl ArrayBuilderTrait for Int8ArrayBuilder {
+    fn append_bson(&mut self, value: Option<&Bson>) -> Result<(), Error> {
+        match value {
+            Some(Bson::Int32(i)) if *i >= i8::MIN as i32 && *i <= i8::MAX as i32 => {
+                self.0.append_value(*i as i8)
+            }
+            Some(_) => self.0.append_null(),
+            None => self.0.append_null(),
+        }
+        Ok(())
+    }
+    fn finish_builder(mut self: Box<Self>) -> Result<ArrayRef, Error> {
+        Ok(Arc::new(self.0.finish()))
+    }
+}
+
+impl Int16ArrayBuilder {
+    fn new(capacity: usize) -> Self {
+        Self(Int16Builder::with_capacity(capacity))
+    }
+}
+
+impl ArrayBuilderTrait for Int16ArrayBuilder {
+    fn append_bson(&mut self, value: Option<&Bson>) -> Result<(), Error> {
+        match value {
+            Some(Bson::Int32(i)) if *i >= i16::MIN as i32 && *i <= i16::MAX as i32 => {
+                self.0.append_value(*i as i16)
+            }
+            Some(_) => self.0.append_null(),
+            None => self.0.append_null(),
+        }
+        Ok(())
+    }
+    fn finish_builder(mut self: Box<Self>) -> Result<ArrayRef, Error> {
+        Ok(Arc::new(self.0.finish()))
     }
 }
 
@@ -225,6 +323,115 @@ impl ArrayBuilderTrait for Int64ArrayBuilder {
         Ok(())
     }
 
+    fn finish_builder(mut self: Box<Self>) -> Result<ArrayRef, Error> {
+        Ok(Arc::new(self.0.finish()))
+    }
+}
+
+impl UInt8ArrayBuilder {
+    fn new(capacity: usize) -> Self {
+        Self(UInt8Builder::with_capacity(capacity))
+    }
+}
+
+impl ArrayBuilderTrait for UInt8ArrayBuilder {
+    fn append_bson(&mut self, value: Option<&Bson>) -> Result<(), Error> {
+        match value {
+            Some(Bson::Int32(i)) if *i >= 0 && *i <= u8::MAX as i32 => {
+                self.0.append_value(*i as u8)
+            }
+            Some(_) => self.0.append_null(),
+            None => self.0.append_null(),
+        }
+        Ok(())
+    }
+    fn finish_builder(mut self: Box<Self>) -> Result<ArrayRef, Error> {
+        Ok(Arc::new(self.0.finish()))
+    }
+}
+
+impl UInt16ArrayBuilder {
+    fn new(capacity: usize) -> Self {
+        Self(UInt16Builder::with_capacity(capacity))
+    }
+}
+
+impl ArrayBuilderTrait for UInt16ArrayBuilder {
+    fn append_bson(&mut self, value: Option<&Bson>) -> Result<(), Error> {
+        match value {
+            Some(Bson::Int32(i)) if *i >= 0 && *i <= u16::MAX as i32 => {
+                self.0.append_value(*i as u16)
+            }
+            Some(_) => self.0.append_null(),
+            None => self.0.append_null(),
+        }
+        Ok(())
+    }
+    fn finish_builder(mut self: Box<Self>) -> Result<ArrayRef, Error> {
+        Ok(Arc::new(self.0.finish()))
+    }
+}
+
+impl UInt32ArrayBuilder {
+    fn new(capacity: usize) -> Self {
+        Self(UInt32Builder::with_capacity(capacity))
+    }
+}
+
+impl ArrayBuilderTrait for UInt32ArrayBuilder {
+    fn append_bson(&mut self, value: Option<&Bson>) -> Result<(), Error> {
+        match value {
+            Some(Bson::Int32(i)) if *i >= 0 => self.0.append_value(*i as u32),
+            Some(Bson::Int64(i)) if *i >= 0 && *i <= u32::MAX as i64 => {
+                self.0.append_value(*i as u32)
+            }
+            Some(_) => self.0.append_null(),
+            None => self.0.append_null(),
+        }
+        Ok(())
+    }
+    fn finish_builder(mut self: Box<Self>) -> Result<ArrayRef, Error> {
+        Ok(Arc::new(self.0.finish()))
+    }
+}
+
+impl UInt64ArrayBuilder {
+    fn new(capacity: usize) -> Self {
+        Self(UInt64Builder::with_capacity(capacity))
+    }
+}
+
+impl ArrayBuilderTrait for UInt64ArrayBuilder {
+    fn append_bson(&mut self, value: Option<&Bson>) -> Result<(), Error> {
+        match value {
+            Some(Bson::Int32(i)) if *i >= 0 => self.0.append_value(*i as u64),
+            Some(Bson::Int64(i)) if *i >= 0 => self.0.append_value(*i as u64),
+            Some(_) => self.0.append_null(),
+            None => self.0.append_null(),
+        }
+        Ok(())
+    }
+    fn finish_builder(mut self: Box<Self>) -> Result<ArrayRef, Error> {
+        Ok(Arc::new(self.0.finish()))
+    }
+}
+
+impl Float32ArrayBuilder {
+    fn new(capacity: usize) -> Self {
+        Self(Float32Builder::with_capacity(capacity))
+    }
+}
+
+impl ArrayBuilderTrait for Float32ArrayBuilder {
+    fn append_bson(&mut self, value: Option<&Bson>) -> Result<(), Error> {
+        match value {
+            Some(Bson::Double(d)) => self.0.append_value(*d as f32),
+            Some(Bson::Int32(i)) => self.0.append_value(*i as f32),
+            Some(_) => self.0.append_null(),
+            None => self.0.append_null(),
+        }
+        Ok(())
+    }
     fn finish_builder(mut self: Box<Self>) -> Result<ArrayRef, Error> {
         Ok(Arc::new(self.0.finish()))
     }
@@ -306,17 +513,47 @@ impl ArrayBuilderTrait for BinaryArrayBuilder {
     }
 }
 
-impl TimestampArrayBuilder {
-    fn new(capacity: usize, tz: Option<Arc<str>>) -> Self {
-        Self(TimestampMillisecondBuilder::with_capacity(capacity).with_timezone_opt(tz))
+impl LargeStringArrayBuilder {
+    fn new(capacity: usize) -> Self {
+        Self(LargeStringBuilder::with_capacity(capacity, 1024))
     }
 }
 
-impl ArrayBuilderTrait for TimestampArrayBuilder {
+impl ArrayBuilderTrait for LargeStringArrayBuilder {
     fn append_bson(&mut self, value: Option<&Bson>) -> Result<(), Error> {
         match value {
-            Some(Bson::DateTime(dt)) => self.0.append_value(dt.timestamp_millis()),
-            Some(Bson::Timestamp(ts)) => self.0.append_value((ts.time as i64) * 1000),
+            Some(Bson::String(s)) => self.0.append_value(s),
+            Some(Bson::ObjectId(oid)) => self.0.append_value(oid.to_hex()),
+            Some(Bson::Document(doc)) => {
+                let json_str = serde_json::to_string(doc).map_err(|e| Error::ConversionError {
+                    source: Box::new(e),
+                })?;
+                self.0.append_value(&json_str);
+            }
+            Some(Bson::Null) => self.0.append_null(),
+            Some(other) => {
+                self.0.append_value(format!("{other}"));
+            }
+            None => self.0.append_null(),
+        }
+        Ok(())
+    }
+
+    fn finish_builder(mut self: Box<Self>) -> Result<ArrayRef, Error> {
+        Ok(Arc::new(self.0.finish()))
+    }
+}
+
+impl LargeBinaryArrayBuilder {
+    fn new(capacity: usize) -> Self {
+        Self(LargeBinaryBuilder::with_capacity(capacity, 1024))
+    }
+}
+
+impl ArrayBuilderTrait for LargeBinaryArrayBuilder {
+    fn append_bson(&mut self, value: Option<&Bson>) -> Result<(), Error> {
+        match value {
+            Some(Bson::Binary(binary)) => self.0.append_value(&binary.bytes),
             Some(_) => self.0.append_null(),
             None => self.0.append_null(),
         }
@@ -325,6 +562,65 @@ impl ArrayBuilderTrait for TimestampArrayBuilder {
 
     fn finish_builder(mut self: Box<Self>) -> Result<ArrayRef, Error> {
         Ok(Arc::new(self.0.finish()))
+    }
+}
+
+impl TimestampArrayBuilder {
+    fn new(capacity: usize, unit: TimeUnit, tz: Option<Arc<str>>) -> Self {
+        match unit {
+            TimeUnit::Second => TimestampArrayBuilder::Second(
+                TimestampSecondBuilder::with_capacity(capacity).with_timezone_opt(tz),
+            ),
+            TimeUnit::Millisecond => TimestampArrayBuilder::Millisecond(
+                TimestampMillisecondBuilder::with_capacity(capacity).with_timezone_opt(tz),
+            ),
+            TimeUnit::Microsecond => TimestampArrayBuilder::Microsecond(
+                TimestampMicrosecondBuilder::with_capacity(capacity).with_timezone_opt(tz),
+            ),
+            TimeUnit::Nanosecond => TimestampArrayBuilder::Nanosecond(
+                TimestampNanosecondBuilder::with_capacity(capacity).with_timezone_opt(tz),
+            ),
+        }
+    }
+}
+
+impl ArrayBuilderTrait for TimestampArrayBuilder {
+    fn append_bson(&mut self, value: Option<&Bson>) -> Result<(), Error> {
+        // Extract millisecond timestamp from BSON
+        let millis = match value {
+            Some(Bson::DateTime(dt)) => Some(dt.timestamp_millis()),
+            Some(Bson::Timestamp(ts)) => Some((ts.time as i64) * 1000),
+            _ => None,
+        };
+
+        match self {
+            TimestampArrayBuilder::Second(b) => match millis {
+                Some(ms) => b.append_value(ms / 1000),
+                None => b.append_null(),
+            },
+            TimestampArrayBuilder::Millisecond(b) => match millis {
+                Some(ms) => b.append_value(ms),
+                None => b.append_null(),
+            },
+            TimestampArrayBuilder::Microsecond(b) => match millis {
+                Some(ms) => b.append_value(ms * 1000),
+                None => b.append_null(),
+            },
+            TimestampArrayBuilder::Nanosecond(b) => match millis {
+                Some(ms) => b.append_value(ms * 1_000_000),
+                None => b.append_null(),
+            },
+        }
+        Ok(())
+    }
+
+    fn finish_builder(self: Box<Self>) -> Result<ArrayRef, Error> {
+        match *self {
+            TimestampArrayBuilder::Second(mut b) => Ok(Arc::new(b.finish())),
+            TimestampArrayBuilder::Millisecond(mut b) => Ok(Arc::new(b.finish())),
+            TimestampArrayBuilder::Microsecond(mut b) => Ok(Arc::new(b.finish())),
+            TimestampArrayBuilder::Nanosecond(mut b) => Ok(Arc::new(b.finish())),
+        }
     }
 }
 
@@ -350,6 +646,29 @@ impl ArrayBuilderTrait for Date32ArrayBuilder {
                     _ => self.0.append_null(),
                 }
             }
+            Some(_) => self.0.append_null(),
+            None => self.0.append_null(),
+        }
+        Ok(())
+    }
+
+    fn finish_builder(mut self: Box<Self>) -> Result<ArrayRef, Error> {
+        Ok(Arc::new(self.0.finish()))
+    }
+}
+
+impl Date64ArrayBuilder {
+    fn new(capacity: usize) -> Self {
+        Self(Date64Builder::with_capacity(capacity))
+    }
+}
+
+impl ArrayBuilderTrait for Date64ArrayBuilder {
+    fn append_bson(&mut self, value: Option<&Bson>) -> Result<(), Error> {
+        match value {
+            // Arrow Date64 is milliseconds since Unix epoch
+            Some(Bson::DateTime(dt)) => self.0.append_value(dt.timestamp_millis()),
+            Some(Bson::Timestamp(ts)) => self.0.append_value((ts.time as i64) * 1000),
             Some(_) => self.0.append_null(),
             None => self.0.append_null(),
         }
@@ -1199,6 +1518,308 @@ mod tests {
             .downcast_ref::<StringArray>()
             .unwrap();
         assert_eq!(z_array.value(0), "last");
+    }
+
+    // --- Tests for new builder types ---
+
+    #[test]
+    fn test_int8_builder() {
+        let docs = vec![
+            doc! { "val": 42_i32 },
+            doc! { "val": -128_i32 },
+            doc! { "val": 127_i32 },
+            doc! { "val": 200_i32 }, // out of i8 range → null
+        ];
+        let schema = Arc::new(Schema::new(vec![Field::new("val", DataType::Int8, true)]));
+        let result = mongo_docs_to_arrow(&docs, schema).unwrap();
+        let arr = result
+            .column(0)
+            .as_any()
+            .downcast_ref::<Int8Array>()
+            .unwrap();
+        assert_eq!(arr.value(0), 42);
+        assert_eq!(arr.value(1), -128);
+        assert_eq!(arr.value(2), 127);
+        assert!(arr.is_null(3));
+    }
+
+    #[test]
+    fn test_int16_builder() {
+        let docs = vec![
+            doc! { "val": 1000_i32 },
+            doc! { "val": -32768_i32 },
+            doc! { "val": 32767_i32 },
+            doc! { "val": 40000_i32 }, // out of i16 range → null
+        ];
+        let schema = Arc::new(Schema::new(vec![Field::new("val", DataType::Int16, true)]));
+        let result = mongo_docs_to_arrow(&docs, schema).unwrap();
+        let arr = result
+            .column(0)
+            .as_any()
+            .downcast_ref::<Int16Array>()
+            .unwrap();
+        assert_eq!(arr.value(0), 1000);
+        assert_eq!(arr.value(1), -32768);
+        assert_eq!(arr.value(2), 32767);
+        assert!(arr.is_null(3));
+    }
+
+    #[test]
+    fn test_uint8_builder() {
+        let docs = vec![
+            doc! { "val": 0_i32 },
+            doc! { "val": 255_i32 },
+            doc! { "val": -1_i32 },  // negative → null
+            doc! { "val": 256_i32 }, // too large → null
+        ];
+        let schema = Arc::new(Schema::new(vec![Field::new("val", DataType::UInt8, true)]));
+        let result = mongo_docs_to_arrow(&docs, schema).unwrap();
+        let arr = result
+            .column(0)
+            .as_any()
+            .downcast_ref::<UInt8Array>()
+            .unwrap();
+        assert_eq!(arr.value(0), 0);
+        assert_eq!(arr.value(1), 255);
+        assert!(arr.is_null(2));
+        assert!(arr.is_null(3));
+    }
+
+    #[test]
+    fn test_uint16_builder() {
+        let docs = vec![
+            doc! { "val": 0_i32 },
+            doc! { "val": 65535_i32 },
+            doc! { "val": -1_i32 },    // negative → null
+            doc! { "val": 65536_i32 }, // too large → null
+        ];
+        let schema = Arc::new(Schema::new(vec![Field::new("val", DataType::UInt16, true)]));
+        let result = mongo_docs_to_arrow(&docs, schema).unwrap();
+        let arr = result
+            .column(0)
+            .as_any()
+            .downcast_ref::<UInt16Array>()
+            .unwrap();
+        assert_eq!(arr.value(0), 0);
+        assert_eq!(arr.value(1), 65535);
+        assert!(arr.is_null(2));
+        assert!(arr.is_null(3));
+    }
+
+    #[test]
+    fn test_uint32_builder() {
+        let docs = vec![
+            doc! { "val": 0_i32 },
+            doc! { "val": 100_i64 },
+            doc! { "val": (u32::MAX as i64) },
+            doc! { "val": -1_i32 }, // negative → null
+        ];
+        let schema = Arc::new(Schema::new(vec![Field::new("val", DataType::UInt32, true)]));
+        let result = mongo_docs_to_arrow(&docs, schema).unwrap();
+        let arr = result
+            .column(0)
+            .as_any()
+            .downcast_ref::<UInt32Array>()
+            .unwrap();
+        assert_eq!(arr.value(0), 0);
+        assert_eq!(arr.value(1), 100);
+        assert_eq!(arr.value(2), u32::MAX);
+        assert!(arr.is_null(3));
+    }
+
+    #[test]
+    fn test_uint64_builder() {
+        let docs = vec![
+            doc! { "val": 0_i32 },
+            doc! { "val": 100_i64 },
+            doc! { "val": -1_i32 }, // negative → null
+        ];
+        let schema = Arc::new(Schema::new(vec![Field::new("val", DataType::UInt64, true)]));
+        let result = mongo_docs_to_arrow(&docs, schema).unwrap();
+        let arr = result
+            .column(0)
+            .as_any()
+            .downcast_ref::<UInt64Array>()
+            .unwrap();
+        assert_eq!(arr.value(0), 0);
+        assert_eq!(arr.value(1), 100);
+        assert!(arr.is_null(2));
+    }
+
+    #[test]
+    fn test_float32_builder() {
+        let docs = vec![
+            doc! { "val": 3.14_f64 },
+            doc! { "val": 42_i32 },
+            doc! { "val": "not_a_number" }, // wrong type → null
+        ];
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "val",
+            DataType::Float32,
+            true,
+        )]));
+        let result = mongo_docs_to_arrow(&docs, schema).unwrap();
+        let arr = result
+            .column(0)
+            .as_any()
+            .downcast_ref::<Float32Array>()
+            .unwrap();
+        assert!((arr.value(0) - 3.14_f32).abs() < 0.001);
+        assert_eq!(arr.value(1), 42.0_f32);
+        assert!(arr.is_null(2));
+    }
+
+    #[test]
+    fn test_large_utf8_builder() {
+        let oid = ObjectId::new();
+        let docs = vec![
+            doc! { "val": "hello" },
+            doc! { "val": oid },
+            doc! { "val": { "nested": true } },
+            doc! { "val": Bson::Null },
+        ];
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "val",
+            DataType::LargeUtf8,
+            true,
+        )]));
+        let result = mongo_docs_to_arrow(&docs, schema).unwrap();
+        let arr = result
+            .column(0)
+            .as_any()
+            .downcast_ref::<LargeStringArray>()
+            .unwrap();
+        assert_eq!(arr.value(0), "hello");
+        assert_eq!(arr.value(1), oid.to_hex());
+        let parsed: serde_json::Value = serde_json::from_str(arr.value(2)).unwrap();
+        assert_eq!(parsed["nested"], true);
+        assert!(arr.is_null(3));
+    }
+
+    #[test]
+    fn test_large_binary_builder() {
+        let data = vec![1u8, 2, 3, 4, 5];
+        let docs = vec![
+            doc! { "val": Binary { subtype: BinarySubtype::Generic, bytes: data.clone() } },
+            doc! { "val": Bson::Null },
+            doc! { "val": "not_binary" }, // wrong type → null
+        ];
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "val",
+            DataType::LargeBinary,
+            true,
+        )]));
+        let result = mongo_docs_to_arrow(&docs, schema).unwrap();
+        let arr = result
+            .column(0)
+            .as_any()
+            .downcast_ref::<LargeBinaryArray>()
+            .unwrap();
+        assert_eq!(arr.value(0), data);
+        assert!(arr.is_null(1));
+        assert!(arr.is_null(2));
+    }
+
+    #[test]
+    fn test_date64_builder() {
+        let dt = DateTime::from_millis(1_700_000_000_000);
+        let ts = Timestamp {
+            time: 1_700_000_000,
+            increment: 1,
+        };
+        let docs = vec![
+            doc! { "val": dt },
+            doc! { "val": ts },
+            doc! { "val": "not_a_date" }, // wrong type → null
+        ];
+        let schema = Arc::new(Schema::new(vec![Field::new("val", DataType::Date64, true)]));
+        let result = mongo_docs_to_arrow(&docs, schema).unwrap();
+        let arr = result
+            .column(0)
+            .as_any()
+            .downcast_ref::<Date64Array>()
+            .unwrap();
+        assert_eq!(arr.value(0), 1_700_000_000_000);
+        assert_eq!(arr.value(1), 1_700_000_000_000);
+        assert!(arr.is_null(2));
+    }
+
+    #[test]
+    fn test_timestamp_second_builder() {
+        let dt = DateTime::from_millis(1_700_000_000_000);
+        let docs = vec![doc! { "val": dt }];
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "val",
+            DataType::Timestamp(TimeUnit::Second, None),
+            true,
+        )]));
+        let result = mongo_docs_to_arrow(&docs, schema).unwrap();
+        let arr = result
+            .column(0)
+            .as_any()
+            .downcast_ref::<TimestampSecondArray>()
+            .unwrap();
+        assert_eq!(arr.value(0), 1_700_000_000);
+    }
+
+    #[test]
+    fn test_timestamp_microsecond_builder() {
+        let dt = DateTime::from_millis(1_700_000_000_000);
+        let docs = vec![doc! { "val": dt }];
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "val",
+            DataType::Timestamp(TimeUnit::Microsecond, None),
+            true,
+        )]));
+        let result = mongo_docs_to_arrow(&docs, schema).unwrap();
+        let arr = result
+            .column(0)
+            .as_any()
+            .downcast_ref::<TimestampMicrosecondArray>()
+            .unwrap();
+        assert_eq!(arr.value(0), 1_700_000_000_000_000);
+    }
+
+    #[test]
+    fn test_timestamp_nanosecond_builder() {
+        let dt = DateTime::from_millis(1_700_000_000_000);
+        let docs = vec![doc! { "val": dt }];
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "val",
+            DataType::Timestamp(TimeUnit::Nanosecond, None),
+            true,
+        )]));
+        let result = mongo_docs_to_arrow(&docs, schema).unwrap();
+        let arr = result
+            .column(0)
+            .as_any()
+            .downcast_ref::<TimestampNanosecondArray>()
+            .unwrap();
+        assert_eq!(arr.value(0), 1_700_000_000_000_000_000);
+    }
+
+    #[test]
+    fn test_empty_batch_new_types() {
+        let docs: Vec<Document> = vec![];
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("a", DataType::Int8, true),
+            Field::new("b", DataType::Int16, true),
+            Field::new("c", DataType::UInt8, true),
+            Field::new("d", DataType::UInt16, true),
+            Field::new("e", DataType::UInt32, true),
+            Field::new("f", DataType::UInt64, true),
+            Field::new("g", DataType::Float32, true),
+            Field::new("h", DataType::LargeUtf8, true),
+            Field::new("i", DataType::LargeBinary, true),
+            Field::new("j", DataType::Date64, true),
+            Field::new("k", DataType::Timestamp(TimeUnit::Second, None), true),
+            Field::new("l", DataType::Timestamp(TimeUnit::Microsecond, None), true),
+            Field::new("m", DataType::Timestamp(TimeUnit::Nanosecond, None), true),
+        ]));
+        let result = mongo_docs_to_arrow(&docs, schema.clone()).unwrap();
+        assert_eq!(result.num_rows(), 0);
+        assert_eq!(result.num_columns(), 13);
+        assert_eq!(result.schema(), schema);
     }
 }
 

--- a/core/src/mongodb/utils/expression.rs
+++ b/core/src/mongodb/utils/expression.rs
@@ -2,7 +2,7 @@ use datafusion::{
     logical_expr::{Expr, Operator},
     scalar::ScalarValue,
 };
-use mongodb::bson::{doc, Bson, Document};
+use mongodb::bson::{doc, Bson, Document, Regex as BsonRegex};
 
 pub fn combine_exprs_with_and(exprs: &[Expr]) -> Option<Expr> {
     let mut iter = exprs.iter();
@@ -10,62 +10,233 @@ pub fn combine_exprs_with_and(exprs: &[Expr]) -> Option<Expr> {
     Some(iter.fold(first, |acc, e| acc.and(e.clone())))
 }
 
+/// Convert a comparison operator and extract (field, value) from either operand order.
+/// Returns (field_name, bson_value) if one side is a column and the other a literal.
+fn extract_comparison_operands(left: &Expr, right: &Expr) -> Option<(String, Bson)> {
+    if let (Some(field), Some(value)) = (extract_column_name(left), extract_literal_value(right)) {
+        Some((field, value))
+    } else if let (Some(value), Some(field)) =
+        (extract_literal_value(left), extract_column_name(right))
+    {
+        Some((field, value))
+    } else {
+        None
+    }
+}
+
+/// For reversed operand order, flip the comparison operator.
+fn needs_flip(left: &Expr, right: &Expr) -> bool {
+    extract_column_name(left).is_none() && extract_column_name(right).is_some()
+}
+
+fn flip_op(op: Operator) -> Operator {
+    match op {
+        Operator::Gt => Operator::Lt,
+        Operator::Lt => Operator::Gt,
+        Operator::GtEq => Operator::LtEq,
+        Operator::LtEq => Operator::GtEq,
+        other => other, // Eq, NotEq are symmetric
+    }
+}
+
 pub fn expr_to_mongo_filter(expr: &Expr) -> Option<Document> {
     match expr {
-        Expr::BinaryExpr(binary) => match binary.op {
-            Operator::And => {
-                let l = expr_to_mongo_filter(&binary.left)?;
-                let r = expr_to_mongo_filter(&binary.right)?;
-                Some(doc! { "$and": [l, r] })
+        Expr::BinaryExpr(binary) => {
+            let op = if needs_flip(&binary.left, &binary.right) {
+                flip_op(binary.op)
+            } else {
+                binary.op
+            };
+
+            match op {
+                Operator::And => {
+                    let l = expr_to_mongo_filter(&binary.left)?;
+                    let r = expr_to_mongo_filter(&binary.right)?;
+                    Some(doc! { "$and": [l, r] })
+                }
+                Operator::Or => {
+                    let l = expr_to_mongo_filter(&binary.left)?;
+                    let r = expr_to_mongo_filter(&binary.right)?;
+                    Some(doc! { "$or": [l, r] })
+                }
+                Operator::Eq => {
+                    let (field, value) = extract_comparison_operands(&binary.left, &binary.right)?;
+                    Some(doc! { field: value })
+                }
+                Operator::Gt => {
+                    let (field, value) = extract_comparison_operands(&binary.left, &binary.right)?;
+                    Some(doc! { field: { "$gt": value } })
+                }
+                Operator::Lt => {
+                    let (field, value) = extract_comparison_operands(&binary.left, &binary.right)?;
+                    Some(doc! { field: { "$lt": value } })
+                }
+                Operator::GtEq => {
+                    let (field, value) = extract_comparison_operands(&binary.left, &binary.right)?;
+                    Some(doc! { field: { "$gte": value } })
+                }
+                Operator::LtEq => {
+                    let (field, value) = extract_comparison_operands(&binary.left, &binary.right)?;
+                    Some(doc! { field: { "$lte": value } })
+                }
+                Operator::NotEq => {
+                    let (field, value) = extract_comparison_operands(&binary.left, &binary.right)?;
+                    Some(doc! { field: { "$ne": value } })
+                }
+                _ => None,
             }
-            Operator::Or => {
-                let l = expr_to_mongo_filter(&binary.left)?;
-                let r = expr_to_mongo_filter(&binary.right)?;
-                Some(doc! { "$or": [l, r] })
-            }
-            Operator::Eq => {
-                let field = extract_column_name(&binary.left);
-                let value = extract_literal_value(&binary.right);
-                let field = field?;
-                let value = value?;
-                Some(doc! { field: value })
-            }
-            Operator::Gt => {
-                let field = extract_column_name(&binary.left);
-                let value = extract_literal_value(&binary.right);
-                let field = field?;
-                let value = value?;
-                Some(doc! { field: { "$gt": value } })
-            }
-            Operator::Lt => {
-                let field = extract_column_name(&binary.left)?;
-                let value = extract_literal_value(&binary.right)?;
-                Some(doc! { field: { "$lt": value } })
-            }
-            Operator::GtEq => {
-                let field = extract_column_name(&binary.left)?;
-                let value = extract_literal_value(&binary.right)?;
-                Some(doc! { field: { "$gte": value } })
-            }
-            Operator::LtEq => {
-                let field = extract_column_name(&binary.left)?;
-                let value = extract_literal_value(&binary.right)?;
-                Some(doc! { field: { "$lte": value } })
-            }
-            Operator::NotEq => {
-                let field = extract_column_name(&binary.left)?;
-                let value = extract_literal_value(&binary.right)?;
-                Some(doc! { field: { "$ne": value } })
-            }
-            _ => {
-                println!("Unsupported operator: {:?}", binary.op);
-                None
-            }
-        },
-        _ => {
-            println!("Non-binary expr: {expr:?}");
-            None
         }
+
+        // IS NULL
+        Expr::IsNull(inner) => {
+            let field = extract_column_name(inner)?;
+            Some(doc! { field: { "$eq": Bson::Null } })
+        }
+
+        // IS NOT NULL
+        Expr::IsNotNull(inner) => {
+            let field = extract_column_name(inner)?;
+            Some(doc! { field: { "$ne": Bson::Null } })
+        }
+
+        // NOT expr
+        Expr::Not(inner) => {
+            match inner.as_ref() {
+                // Optimize NOT (col = val) patterns directly
+                Expr::BinaryExpr(binary) => match binary.op {
+                    Operator::Eq => {
+                        let (field, value) =
+                            extract_comparison_operands(&binary.left, &binary.right)?;
+                        Some(doc! { field: { "$ne": value } })
+                    }
+                    _ => {
+                        let inner_doc = expr_to_mongo_filter(inner)?;
+                        Some(doc! { "$nor": [inner_doc] })
+                    }
+                },
+                _ => {
+                    let inner_doc = expr_to_mongo_filter(inner)?;
+                    Some(doc! { "$nor": [inner_doc] })
+                }
+            }
+        }
+
+        // IS TRUE / IS NOT TRUE / IS FALSE / IS NOT FALSE
+        Expr::IsTrue(inner) => {
+            let field = extract_column_name(inner)?;
+            Some(doc! { field: { "$eq": true } })
+        }
+        Expr::IsFalse(inner) => {
+            let field = extract_column_name(inner)?;
+            Some(doc! { field: { "$eq": false } })
+        }
+        Expr::IsNotTrue(inner) => {
+            let field = extract_column_name(inner)?;
+            Some(doc! { field: { "$ne": true } })
+        }
+        Expr::IsNotFalse(inner) => {
+            let field = extract_column_name(inner)?;
+            Some(doc! { field: { "$ne": false } })
+        }
+
+        // BETWEEN low AND high / NOT BETWEEN low AND high
+        Expr::Between(between) => {
+            let field = extract_column_name(&between.expr)?;
+            let low = extract_literal_value(&between.low)?;
+            let high = extract_literal_value(&between.high)?;
+            if between.negated {
+                // NOT BETWEEN: field < low OR field > high
+                Some(doc! {
+                    "$or": [
+                        { &field: { "$lt": low } },
+                        { &field: { "$gt": high } }
+                    ]
+                })
+            } else {
+                // BETWEEN: field >= low AND field <= high
+                Some(doc! { field: { "$gte": low, "$lte": high } })
+            }
+        }
+
+        // IN (list) / NOT IN (list)
+        Expr::InList(in_list) => {
+            let field = extract_column_name(&in_list.expr)?;
+            let values: Option<Vec<Bson>> =
+                in_list.list.iter().map(extract_literal_value).collect();
+            let values = values?;
+            if in_list.negated {
+                Some(doc! { field: { "$nin": values } })
+            } else {
+                Some(doc! { field: { "$in": values } })
+            }
+        }
+
+        // LIKE / NOT LIKE / ILIKE / NOT ILIKE
+        Expr::Like(like) => {
+            let field = extract_column_name(&like.expr)?;
+            let pattern = extract_string_literal(&like.pattern)?;
+            let regex_pattern = sql_like_to_regex(&pattern, like.escape_char);
+            let options = if like.case_insensitive {
+                "i".to_string()
+            } else {
+                String::new()
+            };
+            let regex = BsonRegex {
+                pattern: regex_pattern,
+                options,
+            };
+            if like.negated {
+                Some(doc! { field: { "$not": Bson::RegularExpression(regex) } })
+            } else {
+                Some(doc! { field: Bson::RegularExpression(regex) })
+            }
+        }
+
+        _ => None,
+    }
+}
+
+/// Convert a SQL LIKE pattern to a MongoDB regex pattern.
+/// `%` → `.*`, `_` → `.`, with proper escaping of regex metacharacters.
+fn sql_like_to_regex(pattern: &str, escape_char: Option<char>) -> String {
+    let mut regex = String::with_capacity(pattern.len() + 2);
+    regex.push('^');
+
+    let mut chars = pattern.chars().peekable();
+    while let Some(c) = chars.next() {
+        if Some(c) == escape_char {
+            // Next character is literal
+            if let Some(next) = chars.next() {
+                regex.push_str(&regex_escape_char(next));
+            }
+        } else {
+            match c {
+                '%' => regex.push_str(".*"),
+                '_' => regex.push('.'),
+                _ => regex.push_str(&regex_escape_char(c)),
+            }
+        }
+    }
+
+    regex.push('$');
+    regex
+}
+
+/// Escape a single character for use in a regex pattern.
+fn regex_escape_char(c: char) -> String {
+    match c {
+        '.' | '*' | '+' | '?' | '(' | ')' | '[' | ']' | '{' | '}' | '\\' | '^' | '$' | '|' => {
+            format!("\\{c}")
+        }
+        _ => c.to_string(),
+    }
+}
+
+fn extract_string_literal(expr: &Expr) -> Option<String> {
+    match expr {
+        Expr::Literal(ScalarValue::Utf8(Some(s)), _) => Some(s.clone()),
+        Expr::Literal(ScalarValue::LargeUtf8(Some(s)), _) => Some(s.clone()),
+        _ => None,
     }
 }
 
@@ -78,36 +249,104 @@ fn extract_column_name(expr: &Expr) -> Option<String> {
 
 fn extract_literal_value(expr: &Expr) -> Option<Bson> {
     match expr {
-        Expr::Literal(scalar, _) => match scalar {
-            ScalarValue::Utf8(Some(s)) => Some(Bson::String(s.clone())),
-            ScalarValue::Utf8(None) => Some(Bson::Null),
-            ScalarValue::Int32(Some(i)) => Some(Bson::Int32(*i)),
-            ScalarValue::Int32(None) => Some(Bson::Null),
-            ScalarValue::Int64(Some(i)) => Some(Bson::Int64(*i)),
-            ScalarValue::Int64(None) => Some(Bson::Null),
-            ScalarValue::Float32(Some(f)) => Some(Bson::Double(*f as f64)),
-            ScalarValue::Float32(None) => Some(Bson::Null),
-            ScalarValue::Float64(Some(f)) => Some(Bson::Double(*f)),
-            ScalarValue::Float64(None) => Some(Bson::Null),
-            ScalarValue::Boolean(Some(b)) => Some(Bson::Boolean(*b)),
-            ScalarValue::Boolean(None) => Some(Bson::Null),
+        Expr::Literal(scalar, _) => scalar_to_bson(scalar),
+        _ => None,
+    }
+}
 
-            ScalarValue::UInt8(Some(i)) => Some(Bson::Int32(*i as i32)),
-            ScalarValue::UInt16(Some(i)) => Some(Bson::Int32(*i as i32)),
-            ScalarValue::UInt32(Some(i)) => Some(Bson::Int64(*i as i64)),
-            ScalarValue::UInt64(Some(i)) => Some(Bson::Int64(*i as i64)),
-            ScalarValue::Int8(Some(i)) => Some(Bson::Int32(*i as i32)),
-            ScalarValue::Int16(Some(i)) => Some(Bson::Int32(*i as i32)),
+fn scalar_to_bson(scalar: &ScalarValue) -> Option<Bson> {
+    match scalar {
+        ScalarValue::Utf8(Some(s)) | ScalarValue::LargeUtf8(Some(s)) => {
+            Some(Bson::String(s.clone()))
+        }
+        ScalarValue::Utf8(None) | ScalarValue::LargeUtf8(None) => Some(Bson::Null),
+        ScalarValue::Int32(Some(i)) => Some(Bson::Int32(*i)),
+        ScalarValue::Int32(None) => Some(Bson::Null),
+        ScalarValue::Int64(Some(i)) => Some(Bson::Int64(*i)),
+        ScalarValue::Int64(None) => Some(Bson::Null),
+        ScalarValue::Float32(Some(f)) => Some(Bson::Double(*f as f64)),
+        ScalarValue::Float32(None) => Some(Bson::Null),
+        ScalarValue::Float64(Some(f)) => Some(Bson::Double(*f)),
+        ScalarValue::Float64(None) => Some(Bson::Null),
+        ScalarValue::Boolean(Some(b)) => Some(Bson::Boolean(*b)),
+        ScalarValue::Boolean(None) => Some(Bson::Null),
 
-            ScalarValue::UInt8(None)
-            | ScalarValue::UInt16(None)
-            | ScalarValue::UInt32(None)
-            | ScalarValue::UInt64(None)
-            | ScalarValue::Int8(None)
-            | ScalarValue::Int16(None) => Some(Bson::Null),
+        ScalarValue::UInt8(Some(i)) => Some(Bson::Int32(*i as i32)),
+        ScalarValue::UInt16(Some(i)) => Some(Bson::Int32(*i as i32)),
+        ScalarValue::UInt32(Some(i)) => Some(Bson::Int64(*i as i64)),
+        ScalarValue::UInt64(Some(i)) => {
+            // Guard against overflow: u64 max > i64 max
+            if *i <= i64::MAX as u64 {
+                Some(Bson::Int64(*i as i64))
+            } else {
+                None
+            }
+        }
+        ScalarValue::Int8(Some(i)) => Some(Bson::Int32(*i as i32)),
+        ScalarValue::Int16(Some(i)) => Some(Bson::Int32(*i as i32)),
 
-            _ => None,
-        },
+        // Timestamps → BSON DateTime (milliseconds since epoch)
+        ScalarValue::TimestampSecond(Some(s), _) => Some(Bson::DateTime(
+            mongodb::bson::DateTime::from_millis(*s * 1000),
+        )),
+        ScalarValue::TimestampMillisecond(Some(ms), _) => {
+            Some(Bson::DateTime(mongodb::bson::DateTime::from_millis(*ms)))
+        }
+        ScalarValue::TimestampMicrosecond(Some(us), _) => Some(Bson::DateTime(
+            mongodb::bson::DateTime::from_millis(*us / 1000),
+        )),
+        ScalarValue::TimestampNanosecond(Some(ns), _) => Some(Bson::DateTime(
+            mongodb::bson::DateTime::from_millis(*ns / 1_000_000),
+        )),
+
+        // Date32 → BSON DateTime (days since epoch → millis)
+        ScalarValue::Date32(Some(days)) => {
+            let millis = *days as i64 * 86_400_000;
+            Some(Bson::DateTime(mongodb::bson::DateTime::from_millis(millis)))
+        }
+        // Date64 → BSON DateTime (already millis)
+        ScalarValue::Date64(Some(ms)) => {
+            Some(Bson::DateTime(mongodb::bson::DateTime::from_millis(*ms)))
+        }
+
+        // Decimal128 → BSON Decimal128
+        ScalarValue::Decimal128(Some(val), _precision, scale) => {
+            // Convert Arrow i128 representation to BSON Decimal128 via string
+            let negative = *val < 0;
+            let abs_val = val.unsigned_abs();
+            let abs_scale = (*scale).unsigned_abs() as u32;
+            let mut s = abs_val.to_string();
+            if *scale > 0 {
+                let scale_usize = abs_scale as usize;
+                while s.len() <= scale_usize {
+                    s.insert(0, '0');
+                }
+                let decimal_point = s.len() - scale_usize;
+                s.insert(decimal_point, '.');
+            }
+            if negative {
+                s.insert(0, '-');
+            }
+            match s.parse::<mongodb::bson::Decimal128>() {
+                Ok(d) => Some(Bson::Decimal128(d)),
+                Err(_) => None,
+            }
+        }
+
+        ScalarValue::UInt8(None)
+        | ScalarValue::UInt16(None)
+        | ScalarValue::UInt32(None)
+        | ScalarValue::UInt64(None)
+        | ScalarValue::Int8(None)
+        | ScalarValue::Int16(None)
+        | ScalarValue::TimestampSecond(None, _)
+        | ScalarValue::TimestampMillisecond(None, _)
+        | ScalarValue::TimestampMicrosecond(None, _)
+        | ScalarValue::TimestampNanosecond(None, _)
+        | ScalarValue::Date32(None)
+        | ScalarValue::Date64(None)
+        | ScalarValue::Decimal128(None, _, _) => Some(Bson::Null),
+
         _ => None,
     }
 }
@@ -169,7 +408,12 @@ mod tests {
 
     #[test]
     fn test_unsupported_expr_returns_none() {
-        let expr = col("salary").in_list(vec![lit(100), lit(200)], false); // unsupported for now
+        // Modulo operator is not supported
+        let expr = Expr::BinaryExpr(BinaryExpr {
+            left: Box::new(col("foo")),
+            op: Operator::Modulo,
+            right: Box::new(lit(2)),
+        });
         assert!(expr_to_mongo_filter(&expr).is_none());
     }
 
@@ -341,20 +585,51 @@ mod tests {
     }
 
     #[test]
-    fn test_wrong_operand_order_returns_none() {
+    fn test_reversed_operand_order_eq() {
         use datafusion::logical_expr::Expr;
 
+        // lit = col should be handled by flipping operands
         let expr = Expr::BinaryExpr(BinaryExpr {
             left: Box::new(lit("Alice")),
             op: Operator::Eq,
             right: Box::new(col("name")),
         });
 
-        let filter = expr_to_mongo_filter(&expr);
-        assert!(
-            filter.is_none(),
-            "Should return None for unsupported operand order"
-        );
+        let filter = expr_to_mongo_filter(&expr).unwrap();
+        let expected = doc! { "name": "Alice" };
+        assert_eq!(filter, expected);
+    }
+
+    #[test]
+    fn test_reversed_operand_order_gt() {
+        use datafusion::logical_expr::Expr;
+
+        // 21 > col  →  col < 21
+        let expr = Expr::BinaryExpr(BinaryExpr {
+            left: Box::new(lit(21)),
+            op: Operator::Gt,
+            right: Box::new(col("age")),
+        });
+
+        let filter = expr_to_mongo_filter(&expr).unwrap();
+        let expected = doc! { "age": { "$lt": 21 } };
+        assert_eq!(filter, expected);
+    }
+
+    #[test]
+    fn test_reversed_operand_order_lt() {
+        use datafusion::logical_expr::Expr;
+
+        // 10 < col  →  col > 10
+        let expr = Expr::BinaryExpr(BinaryExpr {
+            left: Box::new(lit(10)),
+            op: Operator::Lt,
+            right: Box::new(col("age")),
+        });
+
+        let filter = expr_to_mongo_filter(&expr).unwrap();
+        let expected = doc! { "age": { "$gt": 10 } };
+        assert_eq!(filter, expected);
     }
 
     #[test]
@@ -377,5 +652,838 @@ mod tests {
             ]
         };
         assert_eq!(filter, expected);
+    }
+
+    // --- IS NULL / IS NOT NULL ---
+
+    #[test]
+    fn test_is_null_filter() {
+        let expr = col("email").is_null();
+        let filter = expr_to_mongo_filter(&expr).unwrap();
+        let expected = doc! { "email": { "$eq": Bson::Null } };
+        assert_eq!(filter, expected);
+    }
+
+    #[test]
+    fn test_is_not_null_filter() {
+        let expr = col("email").is_not_null();
+        let filter = expr_to_mongo_filter(&expr).unwrap();
+        let expected = doc! { "email": { "$ne": Bson::Null } };
+        assert_eq!(filter, expected);
+    }
+
+    // --- NOT ---
+
+    #[test]
+    fn test_not_eq_via_not() {
+        use datafusion::logical_expr::Expr;
+        // NOT(name = "Alice") → name != "Alice"
+        let inner = col("name").eq(lit("Alice"));
+        let expr = Expr::Not(Box::new(inner));
+        let filter = expr_to_mongo_filter(&expr).unwrap();
+        let expected = doc! { "name": { "$ne": "Alice" } };
+        assert_eq!(filter, expected);
+    }
+
+    #[test]
+    fn test_not_gt_via_nor() {
+        use datafusion::logical_expr::Expr;
+        // NOT(age > 21) → $nor: [{age: {$gt: 21}}]
+        let inner = col("age").gt(lit(21));
+        let expr = Expr::Not(Box::new(inner));
+        let filter = expr_to_mongo_filter(&expr).unwrap();
+        let expected = doc! { "$nor": [{ "age": { "$gt": 21 } }] };
+        assert_eq!(filter, expected);
+    }
+
+    // --- IS TRUE / IS FALSE / IS NOT TRUE / IS NOT FALSE ---
+
+    #[test]
+    fn test_is_true_filter() {
+        let expr = col("active").is_true();
+        let filter = expr_to_mongo_filter(&expr).unwrap();
+        let expected = doc! { "active": { "$eq": true } };
+        assert_eq!(filter, expected);
+    }
+
+    #[test]
+    fn test_is_false_filter() {
+        let expr = col("active").is_false();
+        let filter = expr_to_mongo_filter(&expr).unwrap();
+        let expected = doc! { "active": { "$eq": false } };
+        assert_eq!(filter, expected);
+    }
+
+    #[test]
+    fn test_is_not_true_filter() {
+        let expr = col("active").is_not_true();
+        let filter = expr_to_mongo_filter(&expr).unwrap();
+        let expected = doc! { "active": { "$ne": true } };
+        assert_eq!(filter, expected);
+    }
+
+    #[test]
+    fn test_is_not_false_filter() {
+        let expr = col("active").is_not_false();
+        let filter = expr_to_mongo_filter(&expr).unwrap();
+        let expected = doc! { "active": { "$ne": false } };
+        assert_eq!(filter, expected);
+    }
+
+    // --- BETWEEN ---
+
+    #[test]
+    fn test_between_filter() {
+        let expr = col("age").between(lit(18), lit(65));
+        let filter = expr_to_mongo_filter(&expr).unwrap();
+        let expected = doc! { "age": { "$gte": 18, "$lte": 65 } };
+        assert_eq!(filter, expected);
+    }
+
+    #[test]
+    fn test_not_between_filter() {
+        let expr = col("age").not_between(lit(18), lit(65));
+        let filter = expr_to_mongo_filter(&expr).unwrap();
+        let expected = doc! {
+            "$or": [
+                { "age": { "$lt": 18 } },
+                { "age": { "$gt": 65 } }
+            ]
+        };
+        assert_eq!(filter, expected);
+    }
+
+    // --- IN list ---
+
+    #[test]
+    fn test_in_list_filter() {
+        let expr = col("status").in_list(vec![lit("active"), lit("pending")], false);
+        let filter = expr_to_mongo_filter(&expr).unwrap();
+        let expected = doc! { "status": { "$in": ["active", "pending"] } };
+        assert_eq!(filter, expected);
+    }
+
+    #[test]
+    fn test_not_in_list_filter() {
+        let expr = col("status").in_list(vec![lit("deleted"), lit("banned")], true);
+        let filter = expr_to_mongo_filter(&expr).unwrap();
+        let expected = doc! { "status": { "$nin": ["deleted", "banned"] } };
+        assert_eq!(filter, expected);
+    }
+
+    #[test]
+    fn test_in_list_integers() {
+        let expr = col("score").in_list(vec![lit(100), lit(200), lit(300)], false);
+        let filter = expr_to_mongo_filter(&expr).unwrap();
+        let expected = doc! { "score": { "$in": [100, 200, 300] } };
+        assert_eq!(filter, expected);
+    }
+
+    // --- LIKE ---
+
+    #[test]
+    fn test_like_starts_with() {
+        let expr = col("name").like(lit("Al%"));
+        let filter = expr_to_mongo_filter(&expr).unwrap();
+        assert_eq!(
+            filter,
+            doc! { "name": Bson::RegularExpression(BsonRegex { pattern: "^Al.*$".to_string(), options: String::new() }) }
+        );
+    }
+
+    #[test]
+    fn test_like_ends_with() {
+        let expr = col("name").like(lit("%son"));
+        let filter = expr_to_mongo_filter(&expr).unwrap();
+        assert_eq!(
+            filter,
+            doc! { "name": Bson::RegularExpression(BsonRegex { pattern: "^.*son$".to_string(), options: String::new() }) }
+        );
+    }
+
+    #[test]
+    fn test_like_contains() {
+        let expr = col("name").like(lit("%ali%"));
+        let filter = expr_to_mongo_filter(&expr).unwrap();
+        assert_eq!(
+            filter,
+            doc! { "name": Bson::RegularExpression(BsonRegex { pattern: "^.*ali.*$".to_string(), options: String::new() }) }
+        );
+    }
+
+    #[test]
+    fn test_like_single_char_wildcard() {
+        let expr = col("code").like(lit("A_C"));
+        let filter = expr_to_mongo_filter(&expr).unwrap();
+        assert_eq!(
+            filter,
+            doc! { "code": Bson::RegularExpression(BsonRegex { pattern: "^A.C$".to_string(), options: String::new() }) }
+        );
+    }
+
+    #[test]
+    fn test_not_like() {
+        let expr = col("name").not_like(lit("%test%"));
+        let filter = expr_to_mongo_filter(&expr).unwrap();
+        assert_eq!(
+            filter,
+            doc! { "name": { "$not": Bson::RegularExpression(BsonRegex { pattern: "^.*test.*$".to_string(), options: String::new() }) } }
+        );
+    }
+
+    #[test]
+    fn test_ilike_case_insensitive() {
+        let expr = col("name").ilike(lit("%alice%"));
+        let filter = expr_to_mongo_filter(&expr).unwrap();
+        assert_eq!(
+            filter,
+            doc! { "name": Bson::RegularExpression(BsonRegex { pattern: "^.*alice.*$".to_string(), options: "i".to_string() }) }
+        );
+    }
+
+    #[test]
+    fn test_not_ilike() {
+        let expr = col("name").not_ilike(lit("admin%"));
+        let filter = expr_to_mongo_filter(&expr).unwrap();
+        assert_eq!(
+            filter,
+            doc! { "name": { "$not": Bson::RegularExpression(BsonRegex { pattern: "^admin.*$".to_string(), options: "i".to_string() }) } }
+        );
+    }
+
+    // --- sql_like_to_regex ---
+
+    #[test]
+    fn test_sql_like_to_regex_escapes_metacharacters() {
+        let regex = sql_like_to_regex("price$100.00", None);
+        assert_eq!(regex, r"^price\$100\.00$");
+    }
+
+    #[test]
+    fn test_sql_like_to_regex_with_escape_char() {
+        // Using \ as escape: \% is literal %, \_ is literal _
+        let regex = sql_like_to_regex(r"100\%", Some('\\'));
+        assert_eq!(regex, "^100%$");
+    }
+
+    // --- Edge cases ---
+
+    #[test]
+    fn test_two_literals_returns_none() {
+        // Both sides are literals - should return None
+        let expr = Expr::BinaryExpr(BinaryExpr {
+            left: Box::new(lit(1)),
+            op: Operator::Eq,
+            right: Box::new(lit(2)),
+        });
+        assert!(expr_to_mongo_filter(&expr).is_none());
+    }
+
+    #[test]
+    fn test_two_columns_returns_none() {
+        // Both sides are columns - should return None
+        let expr = Expr::BinaryExpr(BinaryExpr {
+            left: Box::new(col("a")),
+            op: Operator::Eq,
+            right: Box::new(col("b")),
+        });
+        assert!(expr_to_mongo_filter(&expr).is_none());
+    }
+
+    #[test]
+    fn test_is_null_on_non_column_returns_none() {
+        // IS NULL on a literal - should return None
+        let expr = Expr::IsNull(Box::new(lit(42)));
+        assert!(expr_to_mongo_filter(&expr).is_none());
+    }
+
+    #[test]
+    fn test_is_not_null_on_non_column_returns_none() {
+        let expr = Expr::IsNotNull(Box::new(lit(42)));
+        assert!(expr_to_mongo_filter(&expr).is_none());
+    }
+
+    #[test]
+    fn test_is_true_on_non_column_returns_none() {
+        let expr = Expr::IsTrue(Box::new(lit(true)));
+        assert!(expr_to_mongo_filter(&expr).is_none());
+    }
+
+    #[test]
+    fn test_in_list_empty() {
+        // IN () with empty list
+        let expr = col("status").in_list(vec![], false);
+        let filter = expr_to_mongo_filter(&expr).unwrap();
+        let expected = doc! { "status": { "$in": [] } };
+        assert_eq!(filter, expected);
+    }
+
+    #[test]
+    fn test_not_in_list_empty() {
+        let expr = col("status").in_list(vec![], true);
+        let filter = expr_to_mongo_filter(&expr).unwrap();
+        let expected = doc! { "status": { "$nin": [] } };
+        assert_eq!(filter, expected);
+    }
+
+    #[test]
+    fn test_in_list_single_element() {
+        let expr = col("id").in_list(vec![lit(42)], false);
+        let filter = expr_to_mongo_filter(&expr).unwrap();
+        let expected = doc! { "id": { "$in": [42] } };
+        assert_eq!(filter, expected);
+    }
+
+    #[test]
+    fn test_in_list_with_unsupported_literal_returns_none() {
+        // Binary is not in our scalar_to_bson mapping
+        let expr = col("data").in_list(
+            vec![Expr::Literal(
+                ScalarValue::Binary(Some(vec![1, 2, 3])),
+                None,
+            )],
+            false,
+        );
+        assert!(expr_to_mongo_filter(&expr).is_none());
+    }
+
+    #[test]
+    fn test_in_list_on_non_column_returns_none() {
+        // IN list where the expr is not a column
+        let expr = Expr::InList(datafusion::logical_expr::expr::InList {
+            expr: Box::new(lit(42)),
+            list: vec![lit(1), lit(2)],
+            negated: false,
+        });
+        assert!(expr_to_mongo_filter(&expr).is_none());
+    }
+
+    #[test]
+    fn test_between_on_non_column_returns_none() {
+        let expr = Expr::Between(datafusion::logical_expr::expr::Between {
+            expr: Box::new(lit(5)),
+            negated: false,
+            low: Box::new(lit(1)),
+            high: Box::new(lit(10)),
+        });
+        assert!(expr_to_mongo_filter(&expr).is_none());
+    }
+
+    #[test]
+    fn test_between_with_unsupported_bound_returns_none() {
+        let expr = Expr::Between(datafusion::logical_expr::expr::Between {
+            expr: Box::new(col("data")),
+            negated: false,
+            low: Box::new(Expr::Literal(ScalarValue::Binary(Some(vec![0])), None)),
+            high: Box::new(Expr::Literal(ScalarValue::Binary(Some(vec![255])), None)),
+        });
+        assert!(expr_to_mongo_filter(&expr).is_none());
+    }
+
+    #[test]
+    fn test_like_exact_match() {
+        // LIKE with no wildcards - exact match regex
+        let expr = col("code").like(lit("ABC"));
+        let filter = expr_to_mongo_filter(&expr).unwrap();
+        assert_eq!(
+            filter,
+            doc! { "code": Bson::RegularExpression(BsonRegex { pattern: "^ABC$".to_string(), options: String::new() }) }
+        );
+    }
+
+    #[test]
+    fn test_like_on_non_column_returns_none() {
+        let expr = Expr::Like(datafusion::logical_expr::expr::Like {
+            negated: false,
+            expr: Box::new(lit("hello")),
+            pattern: Box::new(lit("%world%")),
+            escape_char: None,
+            case_insensitive: false,
+        });
+        assert!(expr_to_mongo_filter(&expr).is_none());
+    }
+
+    #[test]
+    fn test_like_with_non_string_pattern_returns_none() {
+        let expr = Expr::Like(datafusion::logical_expr::expr::Like {
+            negated: false,
+            expr: Box::new(col("name")),
+            pattern: Box::new(lit(42)),
+            escape_char: None,
+            case_insensitive: false,
+        });
+        assert!(expr_to_mongo_filter(&expr).is_none());
+    }
+
+    #[test]
+    fn test_like_escape_underscore() {
+        // Using # as escape char: #_ is literal underscore
+        let regex = sql_like_to_regex("test#_value", Some('#'));
+        assert_eq!(regex, "^test_value$");
+    }
+
+    #[test]
+    fn test_like_pattern_with_regex_metacharacters() {
+        // Pattern with dots and parens that need escaping
+        let expr = col("email").like(lit("%.example.com"));
+        let filter = expr_to_mongo_filter(&expr).unwrap();
+        assert_eq!(
+            filter,
+            doc! { "email": Bson::RegularExpression(BsonRegex { pattern: r"^.*\.example\.com$".to_string(), options: String::new() }) }
+        );
+    }
+
+    #[test]
+    fn test_not_wrapping_unsupported_returns_none() {
+        // NOT around something that can't be converted
+        let modulo = Expr::BinaryExpr(BinaryExpr {
+            left: Box::new(col("x")),
+            op: Operator::Modulo,
+            right: Box::new(lit(2)),
+        });
+        let expr = Expr::Not(Box::new(modulo));
+        assert!(expr_to_mongo_filter(&expr).is_none());
+    }
+
+    #[test]
+    fn test_not_is_null() {
+        // NOT(IS NULL) should work through $nor
+        let inner = Expr::IsNull(Box::new(col("x")));
+        let expr = Expr::Not(Box::new(inner));
+        let filter = expr_to_mongo_filter(&expr).unwrap();
+        let expected = doc! { "$nor": [{ "x": { "$eq": Bson::Null } }] };
+        assert_eq!(filter, expected);
+    }
+
+    #[test]
+    fn test_reversed_operand_gteq() {
+        // 100 >= col  →  col <= 100
+        let expr = Expr::BinaryExpr(BinaryExpr {
+            left: Box::new(lit(100)),
+            op: Operator::GtEq,
+            right: Box::new(col("score")),
+        });
+        let filter = expr_to_mongo_filter(&expr).unwrap();
+        let expected = doc! { "score": { "$lte": 100 } };
+        assert_eq!(filter, expected);
+    }
+
+    #[test]
+    fn test_reversed_operand_lteq() {
+        // 10 <= col  →  col >= 10
+        let expr = Expr::BinaryExpr(BinaryExpr {
+            left: Box::new(lit(10)),
+            op: Operator::LtEq,
+            right: Box::new(col("score")),
+        });
+        let filter = expr_to_mongo_filter(&expr).unwrap();
+        let expected = doc! { "score": { "$gte": 10 } };
+        assert_eq!(filter, expected);
+    }
+
+    #[test]
+    fn test_reversed_operand_neq() {
+        // "admin" != col  →  col != "admin"
+        let expr = Expr::BinaryExpr(BinaryExpr {
+            left: Box::new(lit("admin")),
+            op: Operator::NotEq,
+            right: Box::new(col("role")),
+        });
+        let filter = expr_to_mongo_filter(&expr).unwrap();
+        let expected = doc! { "role": { "$ne": "admin" } };
+        assert_eq!(filter, expected);
+    }
+
+    #[test]
+    fn test_deeply_nested_and_or() {
+        // (a = 1 AND b = 2) OR (c = 3 AND d = 4)
+        let left = col("a").eq(lit(1)).and(col("b").eq(lit(2)));
+        let right = col("c").eq(lit(3)).and(col("d").eq(lit(4)));
+        let expr = left.or(right);
+
+        let filter = expr_to_mongo_filter(&expr).unwrap();
+        let expected = doc! {
+            "$or": [
+                {
+                    "$and": [
+                        { "a": 1 },
+                        { "b": 2 }
+                    ]
+                },
+                {
+                    "$and": [
+                        { "c": 3 },
+                        { "d": 4 }
+                    ]
+                }
+            ]
+        };
+        assert_eq!(filter, expected);
+    }
+
+    #[test]
+    fn test_and_with_one_unsupported_child_returns_none() {
+        // AND where one child can't be converted
+        let supported = col("a").eq(lit(1));
+        let unsupported = Expr::BinaryExpr(BinaryExpr {
+            left: Box::new(col("b")),
+            op: Operator::Modulo,
+            right: Box::new(lit(2)),
+        });
+        let expr = Expr::BinaryExpr(BinaryExpr {
+            left: Box::new(supported),
+            op: Operator::And,
+            right: Box::new(unsupported),
+        });
+        assert!(expr_to_mongo_filter(&expr).is_none());
+    }
+
+    #[test]
+    fn test_or_with_one_unsupported_child_returns_none() {
+        let supported = col("a").eq(lit(1));
+        let unsupported = Expr::BinaryExpr(BinaryExpr {
+            left: Box::new(col("b")),
+            op: Operator::Modulo,
+            right: Box::new(lit(2)),
+        });
+        let expr = Expr::BinaryExpr(BinaryExpr {
+            left: Box::new(supported),
+            op: Operator::Or,
+            right: Box::new(unsupported),
+        });
+        assert!(expr_to_mongo_filter(&expr).is_none());
+    }
+
+    #[test]
+    fn test_combine_exprs_preserves_order() {
+        let exprs = vec![
+            col("a").eq(lit(1)),
+            col("b").eq(lit(2)),
+            col("c").eq(lit(3)),
+            col("d").eq(lit(4)),
+        ];
+        let combined = combine_exprs_with_and(&exprs).unwrap();
+        let filter = expr_to_mongo_filter(&combined).unwrap();
+        // Should be left-associative: ((a AND b) AND c) AND d
+        assert!(filter.contains_key("$and"));
+    }
+
+    #[test]
+    fn test_scalar_to_bson_all_integer_types() {
+        assert_eq!(
+            scalar_to_bson(&ScalarValue::Int8(Some(42))),
+            Some(Bson::Int32(42))
+        );
+        assert_eq!(
+            scalar_to_bson(&ScalarValue::Int16(Some(1000))),
+            Some(Bson::Int32(1000))
+        );
+        assert_eq!(
+            scalar_to_bson(&ScalarValue::Int32(Some(100_000))),
+            Some(Bson::Int32(100_000))
+        );
+        assert_eq!(
+            scalar_to_bson(&ScalarValue::Int64(Some(1_000_000))),
+            Some(Bson::Int64(1_000_000))
+        );
+        assert_eq!(
+            scalar_to_bson(&ScalarValue::UInt8(Some(255))),
+            Some(Bson::Int32(255))
+        );
+        assert_eq!(
+            scalar_to_bson(&ScalarValue::UInt16(Some(65535))),
+            Some(Bson::Int32(65535_i32))
+        );
+        assert_eq!(
+            scalar_to_bson(&ScalarValue::UInt32(Some(100_000))),
+            Some(Bson::Int64(100_000))
+        );
+        assert_eq!(
+            scalar_to_bson(&ScalarValue::UInt64(Some(1_000_000))),
+            Some(Bson::Int64(1_000_000))
+        );
+    }
+
+    #[test]
+    fn test_scalar_to_bson_null_variants() {
+        assert_eq!(scalar_to_bson(&ScalarValue::Utf8(None)), Some(Bson::Null));
+        assert_eq!(
+            scalar_to_bson(&ScalarValue::LargeUtf8(None)),
+            Some(Bson::Null)
+        );
+        assert_eq!(scalar_to_bson(&ScalarValue::Int32(None)), Some(Bson::Null));
+        assert_eq!(scalar_to_bson(&ScalarValue::Int64(None)), Some(Bson::Null));
+        assert_eq!(
+            scalar_to_bson(&ScalarValue::Float32(None)),
+            Some(Bson::Null)
+        );
+        assert_eq!(
+            scalar_to_bson(&ScalarValue::Float64(None)),
+            Some(Bson::Null)
+        );
+        assert_eq!(
+            scalar_to_bson(&ScalarValue::Boolean(None)),
+            Some(Bson::Null)
+        );
+        assert_eq!(scalar_to_bson(&ScalarValue::Int8(None)), Some(Bson::Null));
+        assert_eq!(scalar_to_bson(&ScalarValue::Int16(None)), Some(Bson::Null));
+        assert_eq!(scalar_to_bson(&ScalarValue::UInt8(None)), Some(Bson::Null));
+        assert_eq!(scalar_to_bson(&ScalarValue::UInt16(None)), Some(Bson::Null));
+        assert_eq!(scalar_to_bson(&ScalarValue::UInt32(None)), Some(Bson::Null));
+        assert_eq!(scalar_to_bson(&ScalarValue::UInt64(None)), Some(Bson::Null));
+        assert_eq!(
+            scalar_to_bson(&ScalarValue::TimestampSecond(None, None)),
+            Some(Bson::Null)
+        );
+        assert_eq!(
+            scalar_to_bson(&ScalarValue::TimestampMillisecond(None, None)),
+            Some(Bson::Null)
+        );
+        assert_eq!(
+            scalar_to_bson(&ScalarValue::TimestampMicrosecond(None, None)),
+            Some(Bson::Null)
+        );
+        assert_eq!(
+            scalar_to_bson(&ScalarValue::TimestampNanosecond(None, None)),
+            Some(Bson::Null)
+        );
+        assert_eq!(scalar_to_bson(&ScalarValue::Date32(None)), Some(Bson::Null));
+        assert_eq!(scalar_to_bson(&ScalarValue::Date64(None)), Some(Bson::Null));
+        assert_eq!(
+            scalar_to_bson(&ScalarValue::Decimal128(None, 18, 6)),
+            Some(Bson::Null)
+        );
+    }
+
+    #[test]
+    fn test_scalar_to_bson_unsupported_returns_none() {
+        // Binary and other exotic types remain unsupported
+        assert!(scalar_to_bson(&ScalarValue::Binary(Some(vec![1, 2, 3]))).is_none());
+    }
+
+    #[test]
+    fn test_scalar_to_bson_timestamp_types() {
+        // TimestampSecond: 1_000_000 seconds since epoch → BSON DateTime at 1_000_000_000 ms
+        let result = scalar_to_bson(&ScalarValue::TimestampSecond(Some(1_000_000), None));
+        assert_eq!(
+            result,
+            Some(Bson::DateTime(mongodb::bson::DateTime::from_millis(
+                1_000_000_000
+            )))
+        );
+
+        // TimestampMillisecond: 1_500_000_000 ms → same
+        let result = scalar_to_bson(&ScalarValue::TimestampMillisecond(
+            Some(1_500_000_000),
+            None,
+        ));
+        assert_eq!(
+            result,
+            Some(Bson::DateTime(mongodb::bson::DateTime::from_millis(
+                1_500_000_000
+            )))
+        );
+
+        // TimestampMicrosecond: 1_500_000_000_000 µs → 1_500_000_000 ms
+        let result = scalar_to_bson(&ScalarValue::TimestampMicrosecond(
+            Some(1_500_000_000_000),
+            None,
+        ));
+        assert_eq!(
+            result,
+            Some(Bson::DateTime(mongodb::bson::DateTime::from_millis(
+                1_500_000_000
+            )))
+        );
+
+        // TimestampNanosecond: 1_500_000_000_000_000 ns → 1_500_000_000 ms
+        let result = scalar_to_bson(&ScalarValue::TimestampNanosecond(
+            Some(1_500_000_000_000_000),
+            None,
+        ));
+        assert_eq!(
+            result,
+            Some(Bson::DateTime(mongodb::bson::DateTime::from_millis(
+                1_500_000_000
+            )))
+        );
+
+        // Timezone is ignored for BSON (always UTC)
+        let tz = Some(std::sync::Arc::from("America/New_York"));
+        let result = scalar_to_bson(&ScalarValue::TimestampMillisecond(Some(1000), tz));
+        assert_eq!(
+            result,
+            Some(Bson::DateTime(mongodb::bson::DateTime::from_millis(1000)))
+        );
+    }
+
+    #[test]
+    fn test_scalar_to_bson_date_types() {
+        // Date32: 0 days = epoch
+        let result = scalar_to_bson(&ScalarValue::Date32(Some(0)));
+        assert_eq!(
+            result,
+            Some(Bson::DateTime(mongodb::bson::DateTime::from_millis(0)))
+        );
+
+        // Date32: 1 day = 86_400_000 ms
+        let result = scalar_to_bson(&ScalarValue::Date32(Some(1)));
+        assert_eq!(
+            result,
+            Some(Bson::DateTime(mongodb::bson::DateTime::from_millis(
+                86_400_000
+            )))
+        );
+
+        // Date32: negative days
+        let result = scalar_to_bson(&ScalarValue::Date32(Some(-1)));
+        assert_eq!(
+            result,
+            Some(Bson::DateTime(mongodb::bson::DateTime::from_millis(
+                -86_400_000
+            )))
+        );
+
+        // Date64: already milliseconds
+        let result = scalar_to_bson(&ScalarValue::Date64(Some(1_500_000_000_000)));
+        assert_eq!(
+            result,
+            Some(Bson::DateTime(mongodb::bson::DateTime::from_millis(
+                1_500_000_000_000
+            )))
+        );
+    }
+
+    #[test]
+    fn test_scalar_to_bson_decimal128() {
+        // 12345 with scale 2 → "123.45"
+        let result = scalar_to_bson(&ScalarValue::Decimal128(Some(12345), 10, 2));
+        if let Some(Bson::Decimal128(d)) = &result {
+            assert_eq!(d.to_string(), "123.45");
+        } else {
+            panic!("Expected Bson::Decimal128, got: {result:?}");
+        }
+
+        // Negative value: -99999 with scale 3 → "-99.999"
+        let result = scalar_to_bson(&ScalarValue::Decimal128(Some(-99999), 10, 3));
+        if let Some(Bson::Decimal128(d)) = &result {
+            assert_eq!(d.to_string(), "-99.999");
+        } else {
+            panic!("Expected Bson::Decimal128, got: {result:?}");
+        }
+
+        // Zero scale: 42 with scale 0 → "42"
+        let result = scalar_to_bson(&ScalarValue::Decimal128(Some(42), 10, 0));
+        if let Some(Bson::Decimal128(d)) = &result {
+            assert_eq!(d.to_string(), "42");
+        } else {
+            panic!("Expected Bson::Decimal128, got: {result:?}");
+        }
+    }
+
+    #[test]
+    fn test_scalar_to_bson_uint64_overflow() {
+        // u64::MAX > i64::MAX, should return None
+        assert!(scalar_to_bson(&ScalarValue::UInt64(Some(u64::MAX))).is_none());
+        // Just within i64 range should work
+        assert_eq!(
+            scalar_to_bson(&ScalarValue::UInt64(Some(i64::MAX as u64))),
+            Some(Bson::Int64(i64::MAX))
+        );
+    }
+
+    #[test]
+    fn test_timestamp_filter_pushdown() {
+        // Timestamp filter: created_at > TimestampMillisecond(1000)
+        let expr = Expr::BinaryExpr(BinaryExpr {
+            left: Box::new(col("created_at")),
+            op: Operator::Gt,
+            right: Box::new(Expr::Literal(
+                ScalarValue::TimestampMillisecond(Some(1_700_000_000_000), None),
+                None,
+            )),
+        });
+        let filter = expr_to_mongo_filter(&expr);
+        assert!(
+            filter.is_some(),
+            "Timestamp filters should now be pushed down"
+        );
+        let doc = filter.unwrap();
+        assert!(
+            doc.contains_key("created_at"),
+            "Should filter on created_at"
+        );
+    }
+
+    #[test]
+    fn test_date32_filter_pushdown() {
+        // Date32 filter: event_date = Date32(19000) (some date in 2022)
+        let expr = Expr::BinaryExpr(BinaryExpr {
+            left: Box::new(col("event_date")),
+            op: Operator::Eq,
+            right: Box::new(Expr::Literal(ScalarValue::Date32(Some(19000)), None)),
+        });
+        let filter = expr_to_mongo_filter(&expr);
+        assert!(filter.is_some(), "Date32 filters should now be pushed down");
+    }
+
+    #[test]
+    fn test_decimal128_filter_pushdown() {
+        // Decimal128 filter: price > 99.99 (represented as 9999 with scale 2)
+        let expr = Expr::BinaryExpr(BinaryExpr {
+            left: Box::new(col("price")),
+            op: Operator::Gt,
+            right: Box::new(Expr::Literal(
+                ScalarValue::Decimal128(Some(9999), 10, 2),
+                None,
+            )),
+        });
+        let filter = expr_to_mongo_filter(&expr);
+        assert!(
+            filter.is_some(),
+            "Decimal128 filters should now be pushed down"
+        );
+    }
+
+    #[test]
+    fn test_large_utf8_literal() {
+        let expr = col("name").eq(Expr::Literal(
+            ScalarValue::LargeUtf8(Some("Alice".to_string())),
+            None,
+        ));
+        let filter = expr_to_mongo_filter(&expr).unwrap();
+        let expected = doc! { "name": "Alice" };
+        assert_eq!(filter, expected);
+    }
+
+    #[test]
+    fn test_sql_like_to_regex_empty_pattern() {
+        let regex = sql_like_to_regex("", None);
+        assert_eq!(regex, "^$");
+    }
+
+    #[test]
+    fn test_sql_like_to_regex_only_percent() {
+        let regex = sql_like_to_regex("%", None);
+        assert_eq!(regex, "^.*$");
+    }
+
+    #[test]
+    fn test_sql_like_to_regex_only_underscore() {
+        let regex = sql_like_to_regex("_", None);
+        assert_eq!(regex, "^.$");
+    }
+
+    #[test]
+    fn test_sql_like_to_regex_escape_at_end() {
+        // Escape char at the very end with nothing after it
+        let regex = sql_like_to_regex(r"abc\", Some('\\'));
+        assert_eq!(regex, "^abc$");
+    }
+
+    #[test]
+    fn test_sql_like_to_regex_multiple_underscores() {
+        let regex = sql_like_to_regex("A___Z", None);
+        assert_eq!(regex, "^A...Z$");
     }
 }


### PR DESCRIPTION
## Summary

Adds extensive filter pushdown support for MongoDB and comprehensive Arrow ↔ BSON data type coverage.

## Filter Pushdown (expression.rs)

Previously only basic comparison operators (`=`, `!=`, `>`, `<`, `>=`, `<=`) and `AND`/`OR` were supported. This PR adds:

- **IS NULL / IS NOT NULL** → `{ field: null }` / `{ field: { $ne: null } }`
- **IS TRUE / IS FALSE / IS NOT TRUE / IS NOT FALSE** → boolean equality/inequality
- **NOT** → `{ $ne: value }` for negated equality, `{ $nor: [...] }` for general negation
- **BETWEEN / NOT BETWEEN** → `{ $gte: low, $lte: high }` with `$nor` for negated
- **IN / NOT IN** → `{ $in: [...] }` / `{ $nin: [...] }`
- **LIKE / NOT LIKE / ILIKE / NOT ILIKE** → `{ $regex: pattern }` with SQL-to-regex conversion
- **Reversed operand order** — `42 > age` is now correctly handled by flipping the operator

### scalar_to_bson Enhancements

Added support for pushing down filters on temporal and decimal types:

- `TimestampSecond/Millisecond/Microsecond/Nanosecond` → `Bson::DateTime`
- `Date32`, `Date64` → `Bson::DateTime`
- `Decimal128` → `Bson::Decimal128`
- `UInt64` overflow guard (returns `None` when value > `i64::MAX`)

This is critical — without it, any date/time range filter (the most common MongoDB query pattern) would fetch all documents and filter client-side.

## Arrow Type Coverage (arrow.rs)

Added 12 new array builders for BSON → Arrow reading:

| Arrow Type | BSON Source | Notes |
|---|---|---|
| `Int8`, `Int16` | `Bson::Int32` | Range-checked |
| `UInt8`, `UInt16`, `UInt32`, `UInt64` | `Bson::Int32`/`Int64` | Bounds-checked |
| `Float32` | `Bson::Double`/`Int32` | Narrowing from f64 |
| `LargeUtf8` | Same as `Utf8` | ObjectId, Document→JSON, catch-all |
| `LargeBinary` | `Bson::Binary` | Same as Binary |
| `Date64` | `Bson::DateTime`/`Timestamp` | Milliseconds since epoch |
| All `Timestamp` units | `Bson::DateTime`/`Timestamp` | Refactored to support Second/Millisecond/Microsecond/Nanosecond |

Previously only `Timestamp(Millisecond)` was handled; all other units silently fell back to string.

## Sort Infrastructure (connection.rs, table.rs)

- Added `sort_doc` parameter to `query_arrow()` and `MongoDBExec`
- `DisplayAs` now conditionally shows `sort=[...]` and `limit=[N]` in explain plans
- Plumbing is ready for when DataFusion's `ScanArgs` adds sort ordering support

## Tests

203 MongoDB unit tests pass, covering:
- All new expression types and edge cases
- All new Arrow builders with boundary conditions
- DisplayAs/explain plan output formatting
- `supports_filters_pushdown` for every new expression type