### PR TITLE
Add comprehensive pushdown support for all SQL providers

### DIFF
--- a/core/src/adbc/sql_table.rs
+++ b/core/src/adbc/sql_table.rs
@@ -31,9 +31,7 @@ use datafusion::{
     logical_expr::{Expr, TableProviderFilterPushDown, TableType},
     physical_expr::PhysicalSortExpr,
     physical_plan::{
-        filter_pushdown::{
-            ChildPushdownResult, FilterPushdownPhase, FilterPushdownPropagation,
-        },
+        filter_pushdown::{ChildPushdownResult, FilterPushdownPhase, FilterPushdownPropagation},
         sort_pushdown::SortOrderPushdownResult,
         stream::RecordBatchStreamAdapter,
         DisplayAs, DisplayFormatType, ExecutionPlan, PlanProperties, SendableRecordBatchStream,
@@ -241,11 +239,9 @@ impl<T: 'static, P: 'static> ExecutionPlan for AdbcSqlExec<T, P> {
         child_pushdown_result: ChildPushdownResult,
         config: &ConfigOptions,
     ) -> DataFusionResult<FilterPushdownPropagation<Arc<dyn ExecutionPlan>>> {
-        let result = self.base_exec.handle_child_pushdown_result(
-            phase,
-            child_pushdown_result,
-            config,
-        )?;
+        let result =
+            self.base_exec
+                .handle_child_pushdown_result(phase, child_pushdown_result, config)?;
         let updated_node = result
             .updated_node
             .map(|node| {
@@ -258,7 +254,9 @@ impl<T: 'static, P: 'static> ExecutionPlan for AdbcSqlExec<T, P> {
                         )
                     })?
                     .clone();
-                Ok::<_, DataFusionError>(Arc::new(AdbcSqlExec { base_exec }) as Arc<dyn ExecutionPlan>)
+                Ok::<_, DataFusionError>(
+                    Arc::new(AdbcSqlExec { base_exec }) as Arc<dyn ExecutionPlan>
+                )
             })
             .transpose()?;
         Ok(FilterPushdownPropagation {

--- a/core/src/adbc/sql_table.rs
+++ b/core/src/adbc/sql_table.rs
@@ -24,13 +24,19 @@ use std::sync::Arc;
 use datafusion::catalog::Session;
 use datafusion::{
     arrow::datatypes::SchemaRef,
+    config::ConfigOptions,
     datasource::TableProvider,
-    error::Result as DataFusionResult,
+    error::{DataFusionError, Result as DataFusionResult},
     execution::TaskContext,
     logical_expr::{Expr, TableProviderFilterPushDown, TableType},
+    physical_expr::PhysicalSortExpr,
     physical_plan::{
-        stream::RecordBatchStreamAdapter, DisplayAs, DisplayFormatType, ExecutionPlan,
-        PlanProperties, SendableRecordBatchStream,
+        filter_pushdown::{
+            ChildPushdownResult, FilterPushdownPhase, FilterPushdownPropagation,
+        },
+        sort_pushdown::SortOrderPushdownResult,
+        stream::RecordBatchStreamAdapter,
+        DisplayAs, DisplayFormatType, ExecutionPlan, PlanProperties, SendableRecordBatchStream,
     },
     sql::{unparser::dialect::Dialect, TableReference},
 };
@@ -170,6 +176,85 @@ impl<T: 'static, P: 'static> ExecutionPlan for AdbcSqlExec<T, P> {
         _children: Vec<Arc<dyn ExecutionPlan>>,
     ) -> DataFusionResult<Arc<dyn ExecutionPlan>> {
         Ok(self)
+    }
+
+    fn try_pushdown_sort(
+        &self,
+        order: &[PhysicalSortExpr],
+    ) -> DataFusionResult<SortOrderPushdownResult<Arc<dyn ExecutionPlan>>> {
+        match self.base_exec.try_pushdown_sort(order)? {
+            SortOrderPushdownResult::Exact { inner } => {
+                let base_exec = inner
+                    .as_any()
+                    .downcast_ref::<SqlExec<T, P>>()
+                    .ok_or_else(|| {
+                        DataFusionError::Internal(
+                            "Failed to downcast SqlExec in sort pushdown".to_string(),
+                        )
+                    })?
+                    .clone();
+                Ok(SortOrderPushdownResult::Exact {
+                    inner: Arc::new(AdbcSqlExec { base_exec }),
+                })
+            }
+            SortOrderPushdownResult::Inexact { inner } => {
+                let base_exec = inner
+                    .as_any()
+                    .downcast_ref::<SqlExec<T, P>>()
+                    .ok_or_else(|| {
+                        DataFusionError::Internal(
+                            "Failed to downcast SqlExec in sort pushdown".to_string(),
+                        )
+                    })?
+                    .clone();
+                Ok(SortOrderPushdownResult::Inexact {
+                    inner: Arc::new(AdbcSqlExec { base_exec }),
+                })
+            }
+            SortOrderPushdownResult::Unsupported => Ok(SortOrderPushdownResult::Unsupported),
+        }
+    }
+
+    fn supports_limit_pushdown(&self) -> bool {
+        true
+    }
+
+    fn fetch(&self) -> Option<usize> {
+        self.base_exec.fetch()
+    }
+
+    fn with_fetch(&self, limit: Option<usize>) -> Option<Arc<dyn ExecutionPlan>> {
+        let base_exec = self
+            .base_exec
+            .with_fetch(limit)?
+            .as_any()
+            .downcast_ref::<SqlExec<T, P>>()?
+            .clone();
+        Some(Arc::new(AdbcSqlExec { base_exec }))
+    }
+
+    fn handle_child_pushdown_result(
+        &self,
+        phase: FilterPushdownPhase,
+        child_pushdown_result: ChildPushdownResult,
+        config: &ConfigOptions,
+    ) -> DataFusionResult<FilterPushdownPropagation<Arc<dyn ExecutionPlan>>> {
+        let result = self.base_exec.handle_child_pushdown_result(
+            phase,
+            child_pushdown_result,
+            config,
+        )?;
+        Ok(FilterPushdownPropagation {
+            filters: result.filters,
+            updated_node: result.updated_node.map(|node| {
+                let base_exec = node
+                    .as_any()
+                    .downcast_ref::<SqlExec<T, P>>()
+                    .expect("Failed to downcast SqlExec in filter pushdown")
+                    .clone();
+                Arc::new(AdbcSqlExec { base_exec }) as Arc<dyn ExecutionPlan>
+            }),
+        })
     }
 
     fn execute(

--- a/core/src/adbc/sql_table.rs
+++ b/core/src/adbc/sql_table.rs
@@ -79,6 +79,7 @@ impl<T, P> AdbcDBTable<T, P> {
             schema,
             self.base_table.clone_pool(),
             sql,
+            self.base_table.dialect_arc(),
         )?))
     }
 }
@@ -127,8 +128,9 @@ impl<T, P> AdbcSqlExec<T, P> {
         schema: &SchemaRef,
         pool: Arc<dyn DbConnectionPool<T, P> + Send + Sync>,
         sql: String,
+        dialect: Arc<dyn Dialect + Send + Sync>,
     ) -> DataFusionResult<Self> {
-        let base_exec = SqlExec::new(projection, schema, pool, sql)?;
+        let base_exec = SqlExec::new(projection, schema, pool, sql, dialect)?;
         Ok(Self { base_exec })
     }
 
@@ -244,16 +246,24 @@ impl<T: 'static, P: 'static> ExecutionPlan for AdbcSqlExec<T, P> {
             child_pushdown_result,
             config,
         )?;
-        Ok(FilterPushdownPropagation {
-            filters: result.filters,
-            updated_node: result.updated_node.map(|node| {
+        let updated_node = result
+            .updated_node
+            .map(|node| {
                 let base_exec = node
                     .as_any()
                     .downcast_ref::<SqlExec<T, P>>()
-                    .expect("Failed to downcast SqlExec in filter pushdown")
+                    .ok_or_else(|| {
+                        DataFusionError::Internal(
+                            "Failed to downcast SqlExec in filter pushdown".to_string(),
+                        )
+                    })?
                     .clone();
-                Arc::new(AdbcSqlExec { base_exec }) as Arc<dyn ExecutionPlan>
-            }),
+                Ok::<_, DataFusionError>(Arc::new(AdbcSqlExec { base_exec }) as Arc<dyn ExecutionPlan>)
+            })
+            .transpose()?;
+        Ok(FilterPushdownPropagation {
+            filters: result.filters,
+            updated_node,
         })
     }
 

--- a/core/src/clickhouse/sql_table.rs
+++ b/core/src/clickhouse/sql_table.rs
@@ -48,6 +48,7 @@ impl ClickHouseTable {
             &self.schema(),
             self.pool.clone(),
             sql,
+            Arc::new(datafusion::sql::unparser::dialect::DefaultDialect {}),
         )?))
     }
 }

--- a/core/src/duckdb/sql_table.rs
+++ b/core/src/duckdb/sql_table.rs
@@ -12,13 +12,19 @@ use crate::sql::sql_provider_datafusion::{
 };
 use datafusion::{
     arrow::datatypes::SchemaRef,
+    config::ConfigOptions,
     datasource::TableProvider,
-    error::Result as DataFusionResult,
+    error::{DataFusionError, Result as DataFusionResult},
     execution::TaskContext,
     logical_expr::{Expr, TableProviderFilterPushDown, TableType},
+    physical_expr::PhysicalSortExpr,
     physical_plan::{
-        stream::RecordBatchStreamAdapter, DisplayAs, DisplayFormatType, ExecutionPlan,
-        PlanProperties, SendableRecordBatchStream,
+        filter_pushdown::{
+            ChildPushdownResult, FilterPushdownPhase, FilterPushdownPropagation,
+        },
+        sort_pushdown::SortOrderPushdownResult,
+        stream::RecordBatchStreamAdapter,
+        DisplayAs, DisplayFormatType, ExecutionPlan, PlanProperties, SendableRecordBatchStream,
     },
     sql::{unparser::dialect::DuckDBDialect, TableReference},
 };
@@ -182,6 +188,97 @@ impl<T: 'static, P: 'static> ExecutionPlan for DuckSqlExec<T, P> {
         _children: Vec<Arc<dyn ExecutionPlan>>,
     ) -> DataFusionResult<Arc<dyn ExecutionPlan>> {
         Ok(self)
+    }
+
+    fn try_pushdown_sort(
+        &self,
+        order: &[PhysicalSortExpr],
+    ) -> DataFusionResult<SortOrderPushdownResult<Arc<dyn ExecutionPlan>>> {
+        match self.base_exec.try_pushdown_sort(order)? {
+            SortOrderPushdownResult::Exact { inner } => {
+                let base_exec = inner
+                    .as_any()
+                    .downcast_ref::<SqlExec<T, P>>()
+                    .ok_or_else(|| {
+                        DataFusionError::Internal(
+                            "Failed to downcast SqlExec in sort pushdown".to_string(),
+                        )
+                    })?
+                    .clone();
+                Ok(SortOrderPushdownResult::Exact {
+                    inner: Arc::new(DuckSqlExec {
+                        base_exec,
+                        table_functions: self.table_functions.clone(),
+                    }),
+                })
+            }
+            SortOrderPushdownResult::Inexact { inner } => {
+                let base_exec = inner
+                    .as_any()
+                    .downcast_ref::<SqlExec<T, P>>()
+                    .ok_or_else(|| {
+                        DataFusionError::Internal(
+                            "Failed to downcast SqlExec in sort pushdown".to_string(),
+                        )
+                    })?
+                    .clone();
+                Ok(SortOrderPushdownResult::Inexact {
+                    inner: Arc::new(DuckSqlExec {
+                        base_exec,
+                        table_functions: self.table_functions.clone(),
+                    }),
+                })
+            }
+            SortOrderPushdownResult::Unsupported => Ok(SortOrderPushdownResult::Unsupported),
+        }
+    }
+
+    fn supports_limit_pushdown(&self) -> bool {
+        true
+    }
+
+    fn fetch(&self) -> Option<usize> {
+        self.base_exec.fetch()
+    }
+
+    fn with_fetch(&self, limit: Option<usize>) -> Option<Arc<dyn ExecutionPlan>> {
+        let base_exec = self
+            .base_exec
+            .with_fetch(limit)?
+            .as_any()
+            .downcast_ref::<SqlExec<T, P>>()?
+            .clone();
+        Some(Arc::new(DuckSqlExec {
+            base_exec,
+            table_functions: self.table_functions.clone(),
+        }))
+    }
+
+    fn handle_child_pushdown_result(
+        &self,
+        phase: FilterPushdownPhase,
+        child_pushdown_result: ChildPushdownResult,
+        config: &ConfigOptions,
+    ) -> DataFusionResult<FilterPushdownPropagation<Arc<dyn ExecutionPlan>>> {
+        let result = self.base_exec.handle_child_pushdown_result(
+            phase,
+            child_pushdown_result,
+            config,
+        )?;
+        Ok(FilterPushdownPropagation {
+            filters: result.filters,
+            updated_node: result.updated_node.map(|node| {
+                let base_exec = node
+                    .as_any()
+                    .downcast_ref::<SqlExec<T, P>>()
+                    .expect("Failed to downcast SqlExec in filter pushdown")
+                    .clone();
+                Arc::new(DuckSqlExec {
+                    base_exec,
+                    table_functions: self.table_functions.clone(),
+                }) as Arc<dyn ExecutionPlan>
+            }),
+        })
     }
 
     fn execute(

--- a/core/src/duckdb/sql_table.rs
+++ b/core/src/duckdb/sql_table.rs
@@ -73,6 +73,7 @@ impl<T, P> DuckDBTable<T, P> {
             self.base_table.clone_pool(),
             sql,
             self.table_functions.clone(),
+            self.base_table.dialect_arc(),
         )?))
     }
 }
@@ -129,8 +130,9 @@ impl<T, P> DuckSqlExec<T, P> {
         pool: Arc<dyn DbConnectionPool<T, P> + Send + Sync>,
         sql: String,
         table_functions: Option<HashMap<String, String>>,
+        dialect: Arc<dyn Dialect + Send + Sync>,
     ) -> DataFusionResult<Self> {
-        let base_exec = SqlExec::new(projection, schema, pool, sql)?;
+        let base_exec = SqlExec::new(projection, schema, pool, sql, dialect)?;
 
         Ok(Self {
             base_exec,
@@ -265,19 +267,27 @@ impl<T: 'static, P: 'static> ExecutionPlan for DuckSqlExec<T, P> {
             child_pushdown_result,
             config,
         )?;
-        Ok(FilterPushdownPropagation {
-            filters: result.filters,
-            updated_node: result.updated_node.map(|node| {
+        let updated_node = result
+            .updated_node
+            .map(|node| {
                 let base_exec = node
                     .as_any()
                     .downcast_ref::<SqlExec<T, P>>()
-                    .expect("Failed to downcast SqlExec in filter pushdown")
+                    .ok_or_else(|| {
+                        DataFusionError::Internal(
+                            "Failed to downcast SqlExec in filter pushdown".to_string(),
+                        )
+                    })?
                     .clone();
-                Arc::new(DuckSqlExec {
+                Ok::<_, DataFusionError>(Arc::new(DuckSqlExec {
                     base_exec,
                     table_functions: self.table_functions.clone(),
-                }) as Arc<dyn ExecutionPlan>
-            }),
+                }) as Arc<dyn ExecutionPlan>)
+            })
+            .transpose()?;
+        Ok(FilterPushdownPropagation {
+            filters: result.filters,
+            updated_node,
         })
     }
 

--- a/core/src/duckdb/sql_table.rs
+++ b/core/src/duckdb/sql_table.rs
@@ -19,9 +19,7 @@ use datafusion::{
     logical_expr::{Expr, TableProviderFilterPushDown, TableType},
     physical_expr::PhysicalSortExpr,
     physical_plan::{
-        filter_pushdown::{
-            ChildPushdownResult, FilterPushdownPhase, FilterPushdownPropagation,
-        },
+        filter_pushdown::{ChildPushdownResult, FilterPushdownPhase, FilterPushdownPropagation},
         sort_pushdown::SortOrderPushdownResult,
         stream::RecordBatchStreamAdapter,
         DisplayAs, DisplayFormatType, ExecutionPlan, PlanProperties, SendableRecordBatchStream,
@@ -262,11 +260,9 @@ impl<T: 'static, P: 'static> ExecutionPlan for DuckSqlExec<T, P> {
         child_pushdown_result: ChildPushdownResult,
         config: &ConfigOptions,
     ) -> DataFusionResult<FilterPushdownPropagation<Arc<dyn ExecutionPlan>>> {
-        let result = self.base_exec.handle_child_pushdown_result(
-            phase,
-            child_pushdown_result,
-            config,
-        )?;
+        let result =
+            self.base_exec
+                .handle_child_pushdown_result(phase, child_pushdown_result, config)?;
         let updated_node = result
             .updated_node
             .map(|node| {

--- a/core/src/mysql/sql_table.rs
+++ b/core/src/mysql/sql_table.rs
@@ -20,9 +20,7 @@ use datafusion::{
     logical_expr::{Expr, TableProviderFilterPushDown, TableType},
     physical_expr::PhysicalSortExpr,
     physical_plan::{
-        filter_pushdown::{
-            ChildPushdownResult, FilterPushdownPhase, FilterPushdownPropagation,
-        },
+        filter_pushdown::{ChildPushdownResult, FilterPushdownPhase, FilterPushdownPropagation},
         sort_pushdown::SortOrderPushdownResult,
         stream::RecordBatchStreamAdapter,
         DisplayAs, DisplayFormatType, ExecutionPlan, PlanProperties, SendableRecordBatchStream,
@@ -245,11 +243,9 @@ impl ExecutionPlan for MySQLSQLExec {
         child_pushdown_result: ChildPushdownResult,
         config: &ConfigOptions,
     ) -> DataFusionResult<FilterPushdownPropagation<Arc<dyn ExecutionPlan>>> {
-        let result = self.base_exec.handle_child_pushdown_result(
-            phase,
-            child_pushdown_result,
-            config,
-        )?;
+        let result =
+            self.base_exec
+                .handle_child_pushdown_result(phase, child_pushdown_result, config)?;
         let updated_node = result
             .updated_node
             .map(|node| {
@@ -262,7 +258,9 @@ impl ExecutionPlan for MySQLSQLExec {
                         )
                     })?
                     .clone();
-                Ok::<_, DataFusionError>(Arc::new(MySQLSQLExec { base_exec }) as Arc<dyn ExecutionPlan>)
+                Ok::<_, DataFusionError>(
+                    Arc::new(MySQLSQLExec { base_exec }) as Arc<dyn ExecutionPlan>
+                )
             })
             .transpose()?;
         Ok(FilterPushdownPropagation {

--- a/core/src/mysql/sql_table.rs
+++ b/core/src/mysql/sql_table.rs
@@ -13,13 +13,19 @@ use crate::sql::sql_provider_datafusion::{
 };
 use datafusion::{
     arrow::datatypes::SchemaRef,
+    config::ConfigOptions,
     datasource::TableProvider,
-    error::Result as DataFusionResult,
+    error::{DataFusionError, Result as DataFusionResult},
     execution::TaskContext,
     logical_expr::{Expr, TableProviderFilterPushDown, TableType},
+    physical_expr::PhysicalSortExpr,
     physical_plan::{
-        stream::RecordBatchStreamAdapter, DisplayAs, DisplayFormatType, ExecutionPlan,
-        PlanProperties, SendableRecordBatchStream,
+        filter_pushdown::{
+            ChildPushdownResult, FilterPushdownPhase, FilterPushdownPropagation,
+        },
+        sort_pushdown::SortOrderPushdownResult,
+        stream::RecordBatchStreamAdapter,
+        DisplayAs, DisplayFormatType, ExecutionPlan, PlanProperties, SendableRecordBatchStream,
     },
     sql::TableReference,
 };
@@ -174,6 +180,85 @@ impl ExecutionPlan for MySQLSQLExec {
         _children: Vec<Arc<dyn ExecutionPlan>>,
     ) -> DataFusionResult<Arc<dyn ExecutionPlan>> {
         Ok(self)
+    }
+
+    fn try_pushdown_sort(
+        &self,
+        order: &[PhysicalSortExpr],
+    ) -> DataFusionResult<SortOrderPushdownResult<Arc<dyn ExecutionPlan>>> {
+        match self.base_exec.try_pushdown_sort(order)? {
+            SortOrderPushdownResult::Exact { inner } => {
+                let base_exec = inner
+                    .as_any()
+                    .downcast_ref::<SqlExec<mysql_async::Conn, &'static (dyn ToValue + Sync)>>()
+                    .ok_or_else(|| {
+                        DataFusionError::Internal(
+                            "Failed to downcast SqlExec in sort pushdown".to_string(),
+                        )
+                    })?
+                    .clone();
+                Ok(SortOrderPushdownResult::Exact {
+                    inner: Arc::new(MySQLSQLExec { base_exec }),
+                })
+            }
+            SortOrderPushdownResult::Inexact { inner } => {
+                let base_exec = inner
+                    .as_any()
+                    .downcast_ref::<SqlExec<mysql_async::Conn, &'static (dyn ToValue + Sync)>>()
+                    .ok_or_else(|| {
+                        DataFusionError::Internal(
+                            "Failed to downcast SqlExec in sort pushdown".to_string(),
+                        )
+                    })?
+                    .clone();
+                Ok(SortOrderPushdownResult::Inexact {
+                    inner: Arc::new(MySQLSQLExec { base_exec }),
+                })
+            }
+            SortOrderPushdownResult::Unsupported => Ok(SortOrderPushdownResult::Unsupported),
+        }
+    }
+
+    fn supports_limit_pushdown(&self) -> bool {
+        true
+    }
+
+    fn fetch(&self) -> Option<usize> {
+        self.base_exec.fetch()
+    }
+
+    fn with_fetch(&self, limit: Option<usize>) -> Option<Arc<dyn ExecutionPlan>> {
+        let base_exec = self
+            .base_exec
+            .with_fetch(limit)?
+            .as_any()
+            .downcast_ref::<SqlExec<mysql_async::Conn, &'static (dyn ToValue + Sync)>>()?
+            .clone();
+        Some(Arc::new(MySQLSQLExec { base_exec }))
+    }
+
+    fn handle_child_pushdown_result(
+        &self,
+        phase: FilterPushdownPhase,
+        child_pushdown_result: ChildPushdownResult,
+        config: &ConfigOptions,
+    ) -> DataFusionResult<FilterPushdownPropagation<Arc<dyn ExecutionPlan>>> {
+        let result = self.base_exec.handle_child_pushdown_result(
+            phase,
+            child_pushdown_result,
+            config,
+        )?;
+        Ok(FilterPushdownPropagation {
+            filters: result.filters,
+            updated_node: result.updated_node.map(|node| {
+                let base_exec = node
+                    .as_any()
+                    .downcast_ref::<SqlExec<mysql_async::Conn, &'static (dyn ToValue + Sync)>>()
+                    .expect("Failed to downcast SqlExec in filter pushdown")
+                    .clone();
+                Arc::new(MySQLSQLExec { base_exec }) as Arc<dyn ExecutionPlan>
+            }),
+        })
     }
 
     fn execute(

--- a/core/src/mysql/sql_table.rs
+++ b/core/src/mysql/sql_table.rs
@@ -2,7 +2,7 @@ use crate::sql::db_connection_pool::mysqlpool::MySQLConnectionPool;
 use crate::sql::db_connection_pool::DbConnectionPool;
 use async_trait::async_trait;
 use datafusion::catalog::Session;
-use datafusion::sql::unparser::dialect::MySqlDialect;
+use datafusion::sql::unparser::dialect::{Dialect, MySqlDialect};
 use futures::TryStreamExt;
 use mysql_async::prelude::ToValue;
 use std::fmt::Display;
@@ -77,6 +77,7 @@ impl MySQLTable {
             schema,
             Arc::clone(&self.pool),
             sql,
+            self.base_table.dialect_arc(),
         )?))
     }
 }
@@ -129,8 +130,9 @@ impl MySQLSQLExec {
         schema: &SchemaRef,
         pool: Arc<MySQLConnectionPool>,
         sql: String,
+        dialect: Arc<dyn Dialect + Send + Sync>,
     ) -> DataFusionResult<Self> {
-        let base_exec = SqlExec::new(projections, schema, pool, sql)?;
+        let base_exec = SqlExec::new(projections, schema, pool, sql, dialect)?;
 
         Ok(Self { base_exec })
     }
@@ -248,16 +250,24 @@ impl ExecutionPlan for MySQLSQLExec {
             child_pushdown_result,
             config,
         )?;
-        Ok(FilterPushdownPropagation {
-            filters: result.filters,
-            updated_node: result.updated_node.map(|node| {
+        let updated_node = result
+            .updated_node
+            .map(|node| {
                 let base_exec = node
                     .as_any()
                     .downcast_ref::<SqlExec<mysql_async::Conn, &'static (dyn ToValue + Sync)>>()
-                    .expect("Failed to downcast SqlExec in filter pushdown")
+                    .ok_or_else(|| {
+                        DataFusionError::Internal(
+                            "Failed to downcast SqlExec in filter pushdown".to_string(),
+                        )
+                    })?
                     .clone();
-                Arc::new(MySQLSQLExec { base_exec }) as Arc<dyn ExecutionPlan>
-            }),
+                Ok::<_, DataFusionError>(Arc::new(MySQLSQLExec { base_exec }) as Arc<dyn ExecutionPlan>)
+            })
+            .transpose()?;
+        Ok(FilterPushdownPropagation {
+            filters: result.filters,
+            updated_node,
         })
     }
 

--- a/core/src/sql/sql_provider_datafusion/mod.rs
+++ b/core/src/sql/sql_provider_datafusion/mod.rs
@@ -160,6 +160,7 @@ impl<T, P> SqlTable<T, P> {
             &self.schema(),
             Arc::clone(&self.pool),
             sql,
+            self.dialect_arc(),
         )?))
     }
 
@@ -185,6 +186,14 @@ impl<T, P> SqlTable<T, P> {
         match &self.dialect {
             Some(dialect) => dialect.as_ref(),
             None => &DefaultDialect {},
+        }
+    }
+
+    /// Returns a cloneable Arc of the dialect for passing to SqlExec.
+    pub fn dialect_arc(&self) -> Arc<dyn Dialect + Send + Sync> {
+        match &self.dialect {
+            Some(dialect) => Arc::clone(dialect),
+            None => Arc::new(DefaultDialect {}),
         }
     }
 }
@@ -275,6 +284,7 @@ pub struct SqlExec<T, P> {
     pool: Arc<dyn DbConnectionPool<T, P> + Send + Sync>,
     sql: String,
     properties: PlanProperties,
+    dialect: Arc<dyn Dialect + Send + Sync>,
 }
 
 impl<T, P> Clone for SqlExec<T, P> {
@@ -284,6 +294,7 @@ impl<T, P> Clone for SqlExec<T, P> {
             pool: Arc::clone(&self.pool),
             sql: self.sql.clone(),
             properties: self.properties.clone(),
+            dialect: Arc::clone(&self.dialect),
         }
     }
 }
@@ -294,6 +305,7 @@ impl<T, P> SqlExec<T, P> {
         schema: &SchemaRef,
         pool: Arc<dyn DbConnectionPool<T, P> + Send + Sync>,
         sql: String,
+        dialect: Arc<dyn Dialect + Send + Sync>,
     ) -> DataFusionResult<Self> {
         let projected_schema = project_schema_safe(schema, projection)?;
 
@@ -307,6 +319,7 @@ impl<T, P> SqlExec<T, P> {
                 EmissionType::Incremental,
                 Boundedness::Bounded,
             ),
+            dialect,
         })
     }
 
@@ -317,6 +330,10 @@ impl<T, P> SqlExec<T, P> {
 
     pub fn sql(&self) -> Result<String> {
         Ok(self.sql.clone())
+    }
+
+    fn dialect(&self) -> &(dyn Dialect + Send + Sync) {
+        self.dialect.as_ref()
     }
 }
 
@@ -334,138 +351,96 @@ impl<T, P> DisplayAs for SqlExec<T, P> {
     }
 }
 
-/// Convert a `PhysicalExpr` to a SQL string fragment for filter pushdown.
+/// Convert a `PhysicalExpr` to a logical `Expr` for use with the Unparser.
 /// Returns `None` if the expression cannot be safely converted.
-fn physical_expr_to_sql(expr: &Arc<dyn datafusion::physical_plan::PhysicalExpr>) -> Option<String> {
+fn physical_expr_to_logical_expr(
+    expr: &Arc<dyn datafusion::physical_plan::PhysicalExpr>,
+) -> Option<Expr> {
     use datafusion::physical_expr::expressions::{
         BinaryExpr, CastExpr, Column, InListExpr, IsNotNullExpr, IsNullExpr, Literal, NegativeExpr,
         NotExpr,
     };
 
     if let Some(col) = expr.as_any().downcast_ref::<Column>() {
-        return Some(format!("\"{}\"", col.name()));
+        return Some(Expr::Column(datafusion::common::Column::new_unqualified(
+            col.name(),
+        )));
     }
 
     if let Some(lit) = expr.as_any().downcast_ref::<Literal>() {
-        return scalar_value_to_sql(lit.value());
+        return Some(Expr::Literal(lit.value().clone(), None));
     }
 
     if let Some(bin) = expr.as_any().downcast_ref::<BinaryExpr>() {
-        let left = physical_expr_to_sql(bin.left())?;
-        let right = physical_expr_to_sql(bin.right())?;
-        let op = operator_to_sql(bin.op())?;
-        return Some(format!("({left} {op} {right})"));
+        let left = physical_expr_to_logical_expr(bin.left())?;
+        let right = physical_expr_to_logical_expr(bin.right())?;
+        return Some(Expr::BinaryExpr(datafusion::logical_expr::BinaryExpr::new(
+            Box::new(left),
+            *bin.op(),
+            Box::new(right),
+        )));
     }
 
     if let Some(not) = expr.as_any().downcast_ref::<NotExpr>() {
-        let inner = physical_expr_to_sql(not.arg())?;
-        return Some(format!("(NOT {inner})"));
+        let inner = physical_expr_to_logical_expr(not.arg())?;
+        return Some(Expr::Not(Box::new(inner)));
     }
 
     if let Some(is_null) = expr.as_any().downcast_ref::<IsNullExpr>() {
-        let inner = physical_expr_to_sql(is_null.arg())?;
-        return Some(format!("({inner} IS NULL)"));
+        let inner = physical_expr_to_logical_expr(is_null.arg())?;
+        return Some(Expr::IsNull(Box::new(inner)));
     }
 
     if let Some(is_not_null) = expr.as_any().downcast_ref::<IsNotNullExpr>() {
-        let inner = physical_expr_to_sql(is_not_null.arg())?;
-        return Some(format!("({inner} IS NOT NULL)"));
+        let inner = physical_expr_to_logical_expr(is_not_null.arg())?;
+        return Some(Expr::IsNotNull(Box::new(inner)));
     }
 
     if let Some(neg) = expr.as_any().downcast_ref::<NegativeExpr>() {
-        let inner = physical_expr_to_sql(neg.arg())?;
-        return Some(format!("(-{inner})"));
+        let inner = physical_expr_to_logical_expr(neg.arg())?;
+        return Some(Expr::Negative(Box::new(inner)));
     }
 
     if let Some(cast) = expr.as_any().downcast_ref::<CastExpr>() {
-        let inner = physical_expr_to_sql(cast.expr())?;
-        let dt = cast.cast_type();
-        let sql_type = datatype_to_sql(dt)?;
-        return Some(format!("CAST({inner} AS {sql_type})"));
+        let inner = physical_expr_to_logical_expr(cast.expr())?;
+        return Some(Expr::Cast(datafusion::logical_expr::Cast::new(
+            Box::new(inner),
+            cast.cast_type().clone(),
+        )));
     }
 
     if let Some(in_list) = expr.as_any().downcast_ref::<InListExpr>() {
-        let value = physical_expr_to_sql(in_list.expr())?;
-        let list_items: Option<Vec<String>> =
-            in_list.list().iter().map(physical_expr_to_sql).collect();
-        let list_items = list_items?;
-        let not = if in_list.negated() { "NOT " } else { "" };
-        return Some(format!(
-            "({value} {not}IN ({}))",
-            list_items.join(", ")
-        ));
+        let value = physical_expr_to_logical_expr(in_list.expr())?;
+        let list: Option<Vec<Expr>> = in_list
+            .list()
+            .iter()
+            .map(physical_expr_to_logical_expr)
+            .collect();
+        let list = list?;
+        return Some(Expr::InList(datafusion::logical_expr::expr::InList::new(
+            Box::new(value),
+            list,
+            in_list.negated(),
+        )));
     }
 
     None
 }
 
-fn scalar_value_to_sql(value: &datafusion::scalar::ScalarValue) -> Option<String> {
-    use datafusion::scalar::ScalarValue;
-    match value {
-        ScalarValue::Null => Some("NULL".to_string()),
-        ScalarValue::Boolean(Some(b)) => Some(if *b { "TRUE" } else { "FALSE" }.to_string()),
-        ScalarValue::Int8(Some(v)) => Some(v.to_string()),
-        ScalarValue::Int16(Some(v)) => Some(v.to_string()),
-        ScalarValue::Int32(Some(v)) => Some(v.to_string()),
-        ScalarValue::Int64(Some(v)) => Some(v.to_string()),
-        ScalarValue::UInt8(Some(v)) => Some(v.to_string()),
-        ScalarValue::UInt16(Some(v)) => Some(v.to_string()),
-        ScalarValue::UInt32(Some(v)) => Some(v.to_string()),
-        ScalarValue::UInt64(Some(v)) => Some(v.to_string()),
-        ScalarValue::Float16(Some(v)) => Some(format!("{}", f32::from(*v))),
-        ScalarValue::Float32(Some(v)) => Some(v.to_string()),
-        ScalarValue::Float64(Some(v)) => Some(v.to_string()),
-        ScalarValue::Utf8(Some(s)) | ScalarValue::LargeUtf8(Some(s)) | ScalarValue::Utf8View(Some(s)) => {
-            // Escape single quotes to prevent SQL injection
-            Some(format!("'{}'", s.replace('\'', "''")))
-        }
-        _ => None,
-    }
-}
-
-fn operator_to_sql(op: &datafusion::logical_expr::Operator) -> Option<&'static str> {
-    use datafusion::logical_expr::Operator;
-    match op {
-        Operator::Eq => Some("="),
-        Operator::NotEq => Some("<>"),
-        Operator::Lt => Some("<"),
-        Operator::LtEq => Some("<="),
-        Operator::Gt => Some(">"),
-        Operator::GtEq => Some(">="),
-        Operator::And => Some("AND"),
-        Operator::Or => Some("OR"),
-        Operator::Plus => Some("+"),
-        Operator::Minus => Some("-"),
-        Operator::Multiply => Some("*"),
-        Operator::Divide => Some("/"),
-        Operator::Modulo => Some("%"),
-        Operator::IsDistinctFrom => Some("IS DISTINCT FROM"),
-        Operator::IsNotDistinctFrom => Some("IS NOT DISTINCT FROM"),
-        Operator::LikeMatch => Some("LIKE"),
-        Operator::ILikeMatch => Some("ILIKE"),
-        Operator::NotLikeMatch => Some("NOT LIKE"),
-        Operator::NotILikeMatch => Some("NOT ILIKE"),
-        _ => None,
-    }
-}
-
-fn datatype_to_sql(dt: &DataType) -> Option<&'static str> {
-    match dt {
-        DataType::Boolean => Some("BOOLEAN"),
-        DataType::Int8 => Some("SMALLINT"),
-        DataType::Int16 => Some("SMALLINT"),
-        DataType::Int32 => Some("INTEGER"),
-        DataType::Int64 => Some("BIGINT"),
-        DataType::UInt8 => Some("SMALLINT"),
-        DataType::UInt16 => Some("INTEGER"),
-        DataType::UInt32 => Some("BIGINT"),
-        DataType::UInt64 => Some("BIGINT"),
-        DataType::Float16 => Some("REAL"),
-        DataType::Float32 => Some("REAL"),
-        DataType::Float64 => Some("DOUBLE PRECISION"),
-        DataType::Utf8 | DataType::LargeUtf8 | DataType::Utf8View => Some("TEXT"),
-        _ => None,
-    }
+/// Convert a `PhysicalExpr` to a SQL string fragment for filter pushdown,
+/// using the Unparser with the given dialect for correct identifier quoting
+/// and operator support.
+/// Returns `None` if the expression cannot be safely converted.
+fn physical_expr_to_sql(
+    expr: &Arc<dyn datafusion::physical_plan::PhysicalExpr>,
+    dialect: &dyn Dialect,
+) -> Option<String> {
+    let logical_expr = physical_expr_to_logical_expr(expr)?;
+    let unparser = Unparser::new(dialect);
+    unparser
+        .expr_to_sql(&logical_expr)
+        .ok()
+        .map(|e| e.to_string())
 }
 
 /// Insert additional WHERE conditions into a SQL string.
@@ -495,7 +470,7 @@ fn insert_where_clause(sql: &str, conditions: &str) -> String {
         // No WHERE clause — insert before ORDER BY / LIMIT or at end
         let insert_pos = [" ORDER BY ", " LIMIT ", " GROUP BY ", " HAVING "]
             .iter()
-            .filter_map(|kw| upper.find(kw).map(|p| p))
+            .filter_map(|kw| upper.find(kw))
             .min()
             .unwrap_or(sql.len());
 
@@ -550,29 +525,30 @@ impl<T: 'static, P: 'static> ExecutionPlan for SqlExec<T, P> {
         &self,
         order: &[PhysicalSortExpr],
     ) -> DataFusionResult<SortOrderPushdownResult<Arc<dyn ExecutionPlan>>> {
+        use datafusion::logical_expr::expr::Sort;
         use datafusion::physical_expr::expressions::Column;
 
         if order.is_empty() {
             return Ok(SortOrderPushdownResult::Unsupported);
         }
 
-        // Build ORDER BY clause from physical sort expressions
+        let unparser = Unparser::new(self.dialect());
+
+        // Build ORDER BY clause from physical sort expressions using the Unparser
         let mut order_by_parts = Vec::with_capacity(order.len());
         for sort_expr in order {
             let Some(col) = sort_expr.expr.as_any().downcast_ref::<Column>() else {
                 return Ok(SortOrderPushdownResult::Unsupported);
             };
-            let direction = if sort_expr.options.descending {
-                "DESC"
-            } else {
-                "ASC"
-            };
-            let nulls = if sort_expr.options.nulls_first {
-                "NULLS FIRST"
-            } else {
-                "NULLS LAST"
-            };
-            order_by_parts.push(format!("\"{}\" {direction} {nulls}", col.name()));
+            let logical_sort = Sort::new(
+                Expr::Column(datafusion::common::Column::new_unqualified(col.name())),
+                !sort_expr.options.descending,
+                sort_expr.options.nulls_first,
+            );
+            let order_by_expr = unparser.sort_to_sql(&logical_sort).map_err(|e| {
+                DataFusionError::Internal(format!("Failed to unparse sort expression: {e}"))
+            })?;
+            order_by_parts.push(order_by_expr.to_string());
         }
 
         let order_by_clause = format!("ORDER BY {}", order_by_parts.join(", "));
@@ -594,6 +570,7 @@ impl<T: 'static, P: 'static> ExecutionPlan for SqlExec<T, P> {
             pool: Arc::clone(&self.pool),
             sql: new_sql,
             properties: self.properties.clone(),
+            dialect: Arc::clone(&self.dialect),
         };
 
         // Update equivalence properties to reflect the output ordering
@@ -626,6 +603,7 @@ impl<T: 'static, P: 'static> ExecutionPlan for SqlExec<T, P> {
             pool: Arc::clone(&self.pool),
             sql: new_sql,
             properties: self.properties.clone(),
+            dialect: Arc::clone(&self.dialect),
         }))
     }
 
@@ -640,7 +618,7 @@ impl<T: 'static, P: 'static> ExecutionPlan for SqlExec<T, P> {
         let mut any_accepted = false;
 
         for parent_filter in &child_pushdown_result.parent_filters {
-            match physical_expr_to_sql(&parent_filter.filter) {
+            match physical_expr_to_sql(&parent_filter.filter, self.dialect()) {
                 Some(sql_fragment) => {
                     accepted_filters.push(sql_fragment);
                     filter_results.push(PushedDown::Yes);
@@ -668,6 +646,7 @@ impl<T: 'static, P: 'static> ExecutionPlan for SqlExec<T, P> {
             pool: Arc::clone(&self.pool),
             sql: new_sql,
             properties: self.properties.clone(),
+            dialect: Arc::clone(&self.dialect),
         };
 
         Ok(
@@ -831,12 +810,13 @@ mod tests {
 
     mod sort_pushdown_tests {
         use crate::sql::sql_provider_datafusion::SqlExec;
-        use arrow_schema::SortOptions;
+        use arrow::compute::SortOptions;
         use datafusion::arrow::datatypes::{DataType, Field, Schema};
         use datafusion::physical_expr::expressions::Column;
         use datafusion::physical_expr::PhysicalSortExpr;
         use datafusion::physical_plan::sort_pushdown::SortOrderPushdownResult;
         use datafusion::physical_plan::ExecutionPlan;
+        use datafusion::sql::unparser::dialect::DefaultDialect;
         use std::sync::Arc;
 
         use crate::sql::db_connection_pool::{
@@ -880,7 +860,14 @@ mod tests {
             ]));
             let pool = Arc::new(MockDBPool {})
                 as Arc<dyn DbConnectionPool<(), &'static dyn ToString> + Send + Sync>;
-            SqlExec::new(None, &schema, pool, sql.to_string()).unwrap()
+            SqlExec::new(
+                None,
+                &schema,
+                pool,
+                sql.to_string(),
+                Arc::new(DefaultDialect {}),
+            )
+            .unwrap()
         }
 
         #[test]
@@ -928,7 +915,7 @@ mod tests {
                         .unwrap();
                     assert_eq!(
                         sql_exec.sql().unwrap(),
-                        "SELECT \"name\", \"age\" FROM \"users\" ORDER BY \"age\" DESC NULLS LAST"
+                        "SELECT \"name\", \"age\" FROM \"users\" ORDER BY age DESC NULLS LAST"
                     );
                 }
                 other => panic!("Expected Exact, got {:?}", sort_result_name(&other)),
@@ -963,7 +950,7 @@ mod tests {
                         .unwrap();
                     assert_eq!(
                         sql_exec.sql().unwrap(),
-                        "SELECT \"name\", \"age\" FROM \"users\" ORDER BY \"age\" DESC NULLS FIRST, \"name\" ASC NULLS LAST"
+                        "SELECT \"name\", \"age\" FROM \"users\" ORDER BY age DESC NULLS FIRST, \"name\" ASC NULLS LAST"
                     );
                 }
                 other => panic!("Expected Exact, got {:?}", sort_result_name(&other)),
@@ -1043,6 +1030,7 @@ mod tests {
         use crate::sql::sql_provider_datafusion::SqlExec;
         use datafusion::arrow::datatypes::{DataType, Field, Schema};
         use datafusion::physical_plan::ExecutionPlan;
+        use datafusion::sql::unparser::dialect::DefaultDialect;
         use std::sync::Arc;
 
         use crate::sql::db_connection_pool::{
@@ -1086,7 +1074,14 @@ mod tests {
             ]));
             let pool = Arc::new(MockDBPool {})
                 as Arc<dyn DbConnectionPool<(), &'static dyn ToString> + Send + Sync>;
-            SqlExec::new(None, &schema, pool, sql.to_string()).unwrap()
+            SqlExec::new(
+                None,
+                &schema,
+                pool,
+                sql.to_string(),
+                Arc::new(DefaultDialect {}),
+            )
+            .unwrap()
         }
 
         #[test]
@@ -1231,6 +1226,7 @@ mod tests {
         use crate::sql::sql_provider_datafusion::SqlExec;
         use datafusion::arrow::datatypes::{DataType, Field, Schema};
         use datafusion::physical_plan::ExecutionPlan;
+        use datafusion::sql::unparser::dialect::DefaultDialect;
         use std::sync::Arc;
 
         use crate::sql::db_connection_pool::{
@@ -1269,7 +1265,14 @@ mod tests {
             ]));
             let pool = Arc::new(MockDBPool {})
                 as Arc<dyn DbConnectionPool<(), &'static dyn ToString> + Send + Sync>;
-            SqlExec::new(None, &schema, pool, sql.to_string()).unwrap()
+            SqlExec::new(
+                None,
+                &schema,
+                pool,
+                sql.to_string(),
+                Arc::new(DefaultDialect {}),
+            )
+            .unwrap()
         }
 
         #[test]
@@ -1304,6 +1307,7 @@ mod tests {
         };
         use datafusion::logical_expr::Operator;
         use datafusion::scalar::ScalarValue;
+        use datafusion::sql::unparser::dialect::DefaultDialect;
 
         fn col(name: &str) -> Arc<dyn datafusion::physical_plan::PhysicalExpr> {
             Arc::new(Column::new(name, 0))
@@ -1317,27 +1321,31 @@ mod tests {
             Arc::new(Literal::new(ScalarValue::Utf8(Some(s.to_string()))))
         }
 
+        fn default_dialect() -> &'static dyn Dialect {
+            &DefaultDialect {}
+        }
+
         #[test]
         fn test_column() {
-            let result = physical_expr_to_sql(&col("name"));
+            let result = physical_expr_to_sql(&col("name"), default_dialect());
             assert_eq!(result, Some("\"name\"".to_string()));
         }
 
         #[test]
         fn test_literal_int() {
-            let result = physical_expr_to_sql(&lit_i32(42));
+            let result = physical_expr_to_sql(&lit_i32(42), default_dialect());
             assert_eq!(result, Some("42".to_string()));
         }
 
         #[test]
         fn test_literal_string() {
-            let result = physical_expr_to_sql(&lit_str("hello"));
+            let result = physical_expr_to_sql(&lit_str("hello"), default_dialect());
             assert_eq!(result, Some("'hello'".to_string()));
         }
 
         #[test]
         fn test_literal_string_with_quote() {
-            let result = physical_expr_to_sql(&lit_str("it's"));
+            let result = physical_expr_to_sql(&lit_str("it's"), default_dialect());
             assert_eq!(result, Some("'it''s'".to_string()));
         }
 
@@ -1345,7 +1353,7 @@ mod tests {
         fn test_literal_null() {
             let expr: Arc<dyn datafusion::physical_plan::PhysicalExpr> =
                 Arc::new(Literal::new(ScalarValue::Null));
-            let result = physical_expr_to_sql(&expr);
+            let result = physical_expr_to_sql(&expr, default_dialect());
             assert_eq!(result, Some("NULL".to_string()));
         }
 
@@ -1354,8 +1362,8 @@ mod tests {
             let expr: Arc<dyn datafusion::physical_plan::PhysicalExpr> = Arc::new(
                 BinaryExpr::new(col("age"), Operator::Gt, lit_i32(30)),
             );
-            let result = physical_expr_to_sql(&expr);
-            assert_eq!(result, Some("(\"age\" > 30)".to_string()));
+            let result = physical_expr_to_sql(&expr, default_dialect());
+            assert_eq!(result, Some("(age > 30)".to_string()));
         }
 
         #[test]
@@ -1368,10 +1376,10 @@ mod tests {
             );
             let expr: Arc<dyn datafusion::physical_plan::PhysicalExpr> =
                 Arc::new(BinaryExpr::new(left, Operator::And, right));
-            let result = physical_expr_to_sql(&expr);
+            let result = physical_expr_to_sql(&expr, default_dialect());
             assert_eq!(
                 result,
-                Some("((\"a\" > 1) AND (\"b\" = 'x'))".to_string())
+                Some("((a > 1) AND (b = 'x'))".to_string())
             );
         }
 
@@ -1379,16 +1387,16 @@ mod tests {
         fn test_is_null() {
             let expr: Arc<dyn datafusion::physical_plan::PhysicalExpr> =
                 Arc::new(IsNullExpr::new(col("x")));
-            let result = physical_expr_to_sql(&expr);
-            assert_eq!(result, Some("(\"x\" IS NULL)".to_string()));
+            let result = physical_expr_to_sql(&expr, default_dialect());
+            assert_eq!(result, Some("x IS NULL".to_string()));
         }
 
         #[test]
         fn test_is_not_null() {
             let expr: Arc<dyn datafusion::physical_plan::PhysicalExpr> =
                 Arc::new(IsNotNullExpr::new(col("x")));
-            let result = physical_expr_to_sql(&expr);
-            assert_eq!(result, Some("(\"x\" IS NOT NULL)".to_string()));
+            let result = physical_expr_to_sql(&expr, default_dialect());
+            assert_eq!(result, Some("x IS NOT NULL".to_string()));
         }
 
         #[test]
@@ -1398,16 +1406,16 @@ mod tests {
             );
             let expr: Arc<dyn datafusion::physical_plan::PhysicalExpr> =
                 Arc::new(NotExpr::new(inner));
-            let result = physical_expr_to_sql(&expr);
-            assert_eq!(result, Some("(NOT (\"active\" = 1))".to_string()));
+            let result = physical_expr_to_sql(&expr, default_dialect());
+            assert_eq!(result, Some("NOT (active = 1)".to_string()));
         }
 
         #[test]
         fn test_literal_bool() {
             let expr: Arc<dyn datafusion::physical_plan::PhysicalExpr> =
                 Arc::new(Literal::new(ScalarValue::Boolean(Some(true))));
-            let result = physical_expr_to_sql(&expr);
-            assert_eq!(result, Some("TRUE".to_string()));
+            let result = physical_expr_to_sql(&expr, default_dialect());
+            assert_eq!(result, Some("true".to_string()));
         }
     }
 

--- a/core/src/sql/sql_provider_datafusion/mod.rs
+++ b/core/src/sql/sql_provider_datafusion/mod.rs
@@ -1302,10 +1302,10 @@ mod tests {
 
     mod physical_expr_to_sql_tests {
         use super::super::*;
+        use datafusion::logical_expr::Operator;
         use datafusion::physical_expr::expressions::{
             BinaryExpr, Column, IsNotNullExpr, IsNullExpr, Literal, NotExpr,
         };
-        use datafusion::logical_expr::Operator;
         use datafusion::scalar::ScalarValue;
         use datafusion::sql::unparser::dialect::DefaultDialect;
 
@@ -1359,28 +1359,22 @@ mod tests {
 
         #[test]
         fn test_binary_eq() {
-            let expr: Arc<dyn datafusion::physical_plan::PhysicalExpr> = Arc::new(
-                BinaryExpr::new(col("age"), Operator::Gt, lit_i32(30)),
-            );
+            let expr: Arc<dyn datafusion::physical_plan::PhysicalExpr> =
+                Arc::new(BinaryExpr::new(col("age"), Operator::Gt, lit_i32(30)));
             let result = physical_expr_to_sql(&expr, default_dialect());
             assert_eq!(result, Some("(age > 30)".to_string()));
         }
 
         #[test]
         fn test_and_expression() {
-            let left: Arc<dyn datafusion::physical_plan::PhysicalExpr> = Arc::new(
-                BinaryExpr::new(col("a"), Operator::Gt, lit_i32(1)),
-            );
-            let right: Arc<dyn datafusion::physical_plan::PhysicalExpr> = Arc::new(
-                BinaryExpr::new(col("b"), Operator::Eq, lit_str("x")),
-            );
+            let left: Arc<dyn datafusion::physical_plan::PhysicalExpr> =
+                Arc::new(BinaryExpr::new(col("a"), Operator::Gt, lit_i32(1)));
+            let right: Arc<dyn datafusion::physical_plan::PhysicalExpr> =
+                Arc::new(BinaryExpr::new(col("b"), Operator::Eq, lit_str("x")));
             let expr: Arc<dyn datafusion::physical_plan::PhysicalExpr> =
                 Arc::new(BinaryExpr::new(left, Operator::And, right));
             let result = physical_expr_to_sql(&expr, default_dialect());
-            assert_eq!(
-                result,
-                Some("((a > 1) AND (b = 'x'))".to_string())
-            );
+            assert_eq!(result, Some("((a > 1) AND (b = 'x'))".to_string()));
         }
 
         #[test]
@@ -1401,9 +1395,8 @@ mod tests {
 
         #[test]
         fn test_not() {
-            let inner: Arc<dyn datafusion::physical_plan::PhysicalExpr> = Arc::new(
-                BinaryExpr::new(col("active"), Operator::Eq, lit_i32(1)),
-            );
+            let inner: Arc<dyn datafusion::physical_plan::PhysicalExpr> =
+                Arc::new(BinaryExpr::new(col("active"), Operator::Eq, lit_i32(1)));
             let expr: Arc<dyn datafusion::physical_plan::PhysicalExpr> =
                 Arc::new(NotExpr::new(inner));
             let result = physical_expr_to_sql(&expr, default_dialect());
@@ -1464,10 +1457,7 @@ mod tests {
         fn test_no_where_with_order_by_and_limit() {
             let sql = "SELECT * FROM t ORDER BY b LIMIT 5";
             let result = insert_where_clause(sql, "\"c\" > 3");
-            assert_eq!(
-                result,
-                "SELECT * FROM t WHERE \"c\" > 3 ORDER BY b LIMIT 5"
-            );
+            assert_eq!(result, "SELECT * FROM t WHERE \"c\" > 3 ORDER BY b LIMIT 5");
         }
     }
 }

--- a/core/src/sql/sql_provider_datafusion/mod.rs
+++ b/core/src/sql/sql_provider_datafusion/mod.rs
@@ -25,6 +25,7 @@ use std::{
 
 use datafusion::{
     arrow::datatypes::{DataType, Field, Schema, SchemaRef},
+    config::ConfigOptions,
     datasource::TableProvider,
     error::{DataFusionError, Result as DataFusionResult},
     execution::TaskContext,
@@ -32,10 +33,15 @@ use datafusion::{
         logical_plan::builder::LogicalTableSource, Expr, LogicalPlan, LogicalPlanBuilder,
         TableProviderFilterPushDown, TableType,
     },
-    physical_expr::EquivalenceProperties,
+    physical_expr::{EquivalenceProperties, PhysicalSortExpr},
     physical_plan::{
-        stream::RecordBatchStreamAdapter, DisplayAs, DisplayFormatType, ExecutionPlan,
-        Partitioning, PlanProperties, SendableRecordBatchStream,
+        filter_pushdown::{
+            ChildPushdownResult, FilterPushdownPhase, FilterPushdownPropagation, PushedDown,
+        },
+        sort_pushdown::SortOrderPushdownResult,
+        stream::RecordBatchStreamAdapter,
+        DisplayAs, DisplayFormatType, ExecutionPlan, Partitioning, PlanProperties,
+        SendableRecordBatchStream,
     },
     sql::{unparser::Unparser, TableReference},
 };
@@ -264,12 +270,22 @@ pub fn project_schema_safe(
     Ok(schema)
 }
 
-#[derive(Clone)]
 pub struct SqlExec<T, P> {
     projected_schema: SchemaRef,
     pool: Arc<dyn DbConnectionPool<T, P> + Send + Sync>,
     sql: String,
     properties: PlanProperties,
+}
+
+impl<T, P> Clone for SqlExec<T, P> {
+    fn clone(&self) -> Self {
+        Self {
+            projected_schema: Arc::clone(&self.projected_schema),
+            pool: Arc::clone(&self.pool),
+            sql: self.sql.clone(),
+            properties: self.properties.clone(),
+        }
+    }
 }
 
 impl<T, P> SqlExec<T, P> {
@@ -318,6 +334,179 @@ impl<T, P> DisplayAs for SqlExec<T, P> {
     }
 }
 
+/// Convert a `PhysicalExpr` to a SQL string fragment for filter pushdown.
+/// Returns `None` if the expression cannot be safely converted.
+fn physical_expr_to_sql(expr: &Arc<dyn datafusion::physical_plan::PhysicalExpr>) -> Option<String> {
+    use datafusion::physical_expr::expressions::{
+        BinaryExpr, CastExpr, Column, InListExpr, IsNotNullExpr, IsNullExpr, Literal, NegativeExpr,
+        NotExpr,
+    };
+
+    if let Some(col) = expr.as_any().downcast_ref::<Column>() {
+        return Some(format!("\"{}\"", col.name()));
+    }
+
+    if let Some(lit) = expr.as_any().downcast_ref::<Literal>() {
+        return scalar_value_to_sql(lit.value());
+    }
+
+    if let Some(bin) = expr.as_any().downcast_ref::<BinaryExpr>() {
+        let left = physical_expr_to_sql(bin.left())?;
+        let right = physical_expr_to_sql(bin.right())?;
+        let op = operator_to_sql(bin.op())?;
+        return Some(format!("({left} {op} {right})"));
+    }
+
+    if let Some(not) = expr.as_any().downcast_ref::<NotExpr>() {
+        let inner = physical_expr_to_sql(not.arg())?;
+        return Some(format!("(NOT {inner})"));
+    }
+
+    if let Some(is_null) = expr.as_any().downcast_ref::<IsNullExpr>() {
+        let inner = physical_expr_to_sql(is_null.arg())?;
+        return Some(format!("({inner} IS NULL)"));
+    }
+
+    if let Some(is_not_null) = expr.as_any().downcast_ref::<IsNotNullExpr>() {
+        let inner = physical_expr_to_sql(is_not_null.arg())?;
+        return Some(format!("({inner} IS NOT NULL)"));
+    }
+
+    if let Some(neg) = expr.as_any().downcast_ref::<NegativeExpr>() {
+        let inner = physical_expr_to_sql(neg.arg())?;
+        return Some(format!("(-{inner})"));
+    }
+
+    if let Some(cast) = expr.as_any().downcast_ref::<CastExpr>() {
+        let inner = physical_expr_to_sql(cast.expr())?;
+        let dt = cast.cast_type();
+        let sql_type = datatype_to_sql(dt)?;
+        return Some(format!("CAST({inner} AS {sql_type})"));
+    }
+
+    if let Some(in_list) = expr.as_any().downcast_ref::<InListExpr>() {
+        let value = physical_expr_to_sql(in_list.expr())?;
+        let list_items: Option<Vec<String>> =
+            in_list.list().iter().map(physical_expr_to_sql).collect();
+        let list_items = list_items?;
+        let not = if in_list.negated() { "NOT " } else { "" };
+        return Some(format!(
+            "({value} {not}IN ({}))",
+            list_items.join(", ")
+        ));
+    }
+
+    None
+}
+
+fn scalar_value_to_sql(value: &datafusion::scalar::ScalarValue) -> Option<String> {
+    use datafusion::scalar::ScalarValue;
+    match value {
+        ScalarValue::Null => Some("NULL".to_string()),
+        ScalarValue::Boolean(Some(b)) => Some(if *b { "TRUE" } else { "FALSE" }.to_string()),
+        ScalarValue::Int8(Some(v)) => Some(v.to_string()),
+        ScalarValue::Int16(Some(v)) => Some(v.to_string()),
+        ScalarValue::Int32(Some(v)) => Some(v.to_string()),
+        ScalarValue::Int64(Some(v)) => Some(v.to_string()),
+        ScalarValue::UInt8(Some(v)) => Some(v.to_string()),
+        ScalarValue::UInt16(Some(v)) => Some(v.to_string()),
+        ScalarValue::UInt32(Some(v)) => Some(v.to_string()),
+        ScalarValue::UInt64(Some(v)) => Some(v.to_string()),
+        ScalarValue::Float16(Some(v)) => Some(format!("{}", f32::from(*v))),
+        ScalarValue::Float32(Some(v)) => Some(v.to_string()),
+        ScalarValue::Float64(Some(v)) => Some(v.to_string()),
+        ScalarValue::Utf8(Some(s)) | ScalarValue::LargeUtf8(Some(s)) | ScalarValue::Utf8View(Some(s)) => {
+            // Escape single quotes to prevent SQL injection
+            Some(format!("'{}'", s.replace('\'', "''")))
+        }
+        _ => None,
+    }
+}
+
+fn operator_to_sql(op: &datafusion::logical_expr::Operator) -> Option<&'static str> {
+    use datafusion::logical_expr::Operator;
+    match op {
+        Operator::Eq => Some("="),
+        Operator::NotEq => Some("<>"),
+        Operator::Lt => Some("<"),
+        Operator::LtEq => Some("<="),
+        Operator::Gt => Some(">"),
+        Operator::GtEq => Some(">="),
+        Operator::And => Some("AND"),
+        Operator::Or => Some("OR"),
+        Operator::Plus => Some("+"),
+        Operator::Minus => Some("-"),
+        Operator::Multiply => Some("*"),
+        Operator::Divide => Some("/"),
+        Operator::Modulo => Some("%"),
+        Operator::IsDistinctFrom => Some("IS DISTINCT FROM"),
+        Operator::IsNotDistinctFrom => Some("IS NOT DISTINCT FROM"),
+        Operator::LikeMatch => Some("LIKE"),
+        Operator::ILikeMatch => Some("ILIKE"),
+        Operator::NotLikeMatch => Some("NOT LIKE"),
+        Operator::NotILikeMatch => Some("NOT ILIKE"),
+        _ => None,
+    }
+}
+
+fn datatype_to_sql(dt: &DataType) -> Option<&'static str> {
+    match dt {
+        DataType::Boolean => Some("BOOLEAN"),
+        DataType::Int8 => Some("SMALLINT"),
+        DataType::Int16 => Some("SMALLINT"),
+        DataType::Int32 => Some("INTEGER"),
+        DataType::Int64 => Some("BIGINT"),
+        DataType::UInt8 => Some("SMALLINT"),
+        DataType::UInt16 => Some("INTEGER"),
+        DataType::UInt32 => Some("BIGINT"),
+        DataType::UInt64 => Some("BIGINT"),
+        DataType::Float16 => Some("REAL"),
+        DataType::Float32 => Some("REAL"),
+        DataType::Float64 => Some("DOUBLE PRECISION"),
+        DataType::Utf8 | DataType::LargeUtf8 | DataType::Utf8View => Some("TEXT"),
+        _ => None,
+    }
+}
+
+/// Insert additional WHERE conditions into a SQL string.
+/// Handles the case where a WHERE clause already exists (appends with AND)
+/// and where it doesn't (inserts WHERE before ORDER BY / LIMIT / end).
+fn insert_where_clause(sql: &str, conditions: &str) -> String {
+    let upper = sql.to_uppercase();
+
+    // Find existing WHERE clause
+    if let Some(where_pos) = upper.find(" WHERE ") {
+        // Find the end of the WHERE clause (before ORDER BY, LIMIT, GROUP BY, HAVING)
+        let after_where = where_pos + 7; // skip " WHERE "
+
+        // Find the position of the next major clause
+        let next_clause_pos = [" ORDER BY ", " LIMIT ", " GROUP BY ", " HAVING "]
+            .iter()
+            .filter_map(|kw| upper[after_where..].find(kw).map(|p| after_where + p))
+            .min()
+            .unwrap_or(sql.len());
+
+        format!(
+            "{} AND ({conditions}){}",
+            &sql[..next_clause_pos],
+            &sql[next_clause_pos..]
+        )
+    } else {
+        // No WHERE clause — insert before ORDER BY / LIMIT or at end
+        let insert_pos = [" ORDER BY ", " LIMIT ", " GROUP BY ", " HAVING "]
+            .iter()
+            .filter_map(|kw| upper.find(kw).map(|p| p))
+            .min()
+            .unwrap_or(sql.len());
+
+        format!(
+            "{} WHERE {conditions}{}",
+            &sql[..insert_pos],
+            &sql[insert_pos..]
+        )
+    }
+}
+
 impl<T: 'static, P: 'static> ExecutionPlan for SqlExec<T, P> {
     fn name(&self) -> &'static str {
         "SqlExec"
@@ -344,6 +533,147 @@ impl<T: 'static, P: 'static> ExecutionPlan for SqlExec<T, P> {
         _children: Vec<Arc<dyn ExecutionPlan>>,
     ) -> DataFusionResult<Arc<dyn ExecutionPlan>> {
         Ok(self)
+    }
+
+    fn supports_limit_pushdown(&self) -> bool {
+        true
+    }
+
+    fn fetch(&self) -> Option<usize> {
+        let upper = self.sql.to_uppercase();
+        let limit_pos = upper.rfind(" LIMIT ")?;
+        let after_limit = &self.sql[limit_pos + 7..]; // skip " LIMIT "
+        after_limit.trim().parse::<usize>().ok()
+    }
+
+    fn try_pushdown_sort(
+        &self,
+        order: &[PhysicalSortExpr],
+    ) -> DataFusionResult<SortOrderPushdownResult<Arc<dyn ExecutionPlan>>> {
+        use datafusion::physical_expr::expressions::Column;
+
+        if order.is_empty() {
+            return Ok(SortOrderPushdownResult::Unsupported);
+        }
+
+        // Build ORDER BY clause from physical sort expressions
+        let mut order_by_parts = Vec::with_capacity(order.len());
+        for sort_expr in order {
+            let Some(col) = sort_expr.expr.as_any().downcast_ref::<Column>() else {
+                return Ok(SortOrderPushdownResult::Unsupported);
+            };
+            let direction = if sort_expr.options.descending {
+                "DESC"
+            } else {
+                "ASC"
+            };
+            let nulls = if sort_expr.options.nulls_first {
+                "NULLS FIRST"
+            } else {
+                "NULLS LAST"
+            };
+            order_by_parts.push(format!("\"{}\" {direction} {nulls}", col.name()));
+        }
+
+        let order_by_clause = format!("ORDER BY {}", order_by_parts.join(", "));
+
+        // Insert ORDER BY before LIMIT (if present) or at the end
+        let sql = &self.sql;
+        let new_sql = if let Some(limit_pos) = sql.to_uppercase().rfind(" LIMIT ") {
+            format!(
+                "{} {order_by_clause}{}",
+                &sql[..limit_pos],
+                &sql[limit_pos..]
+            )
+        } else {
+            format!("{sql} {order_by_clause}")
+        };
+
+        let mut new_exec = Self {
+            projected_schema: Arc::clone(&self.projected_schema),
+            pool: Arc::clone(&self.pool),
+            sql: new_sql,
+            properties: self.properties.clone(),
+        };
+
+        // Update equivalence properties to reflect the output ordering
+        let eq_properties = EquivalenceProperties::new_with_orderings(
+            Arc::clone(&self.projected_schema),
+            vec![order.to_vec()],
+        );
+        new_exec.properties = new_exec.properties.with_eq_properties(eq_properties);
+
+        Ok(SortOrderPushdownResult::Exact {
+            inner: Arc::new(new_exec),
+        })
+    }
+
+    fn with_fetch(&self, limit: Option<usize>) -> Option<Arc<dyn ExecutionPlan>> {
+        let limit = limit?;
+
+        let sql = &self.sql;
+        let upper = sql.to_uppercase();
+
+        // Replace existing LIMIT or append one
+        let new_sql = if let Some(limit_pos) = upper.rfind(" LIMIT ") {
+            format!("{} LIMIT {limit}", &sql[..limit_pos])
+        } else {
+            format!("{sql} LIMIT {limit}")
+        };
+
+        Some(Arc::new(Self {
+            projected_schema: Arc::clone(&self.projected_schema),
+            pool: Arc::clone(&self.pool),
+            sql: new_sql,
+            properties: self.properties.clone(),
+        }))
+    }
+
+    fn handle_child_pushdown_result(
+        &self,
+        _phase: FilterPushdownPhase,
+        child_pushdown_result: ChildPushdownResult,
+        _config: &ConfigOptions,
+    ) -> DataFusionResult<FilterPushdownPropagation<Arc<dyn ExecutionPlan>>> {
+        let mut accepted_filters = Vec::new();
+        let mut filter_results = Vec::with_capacity(child_pushdown_result.parent_filters.len());
+        let mut any_accepted = false;
+
+        for parent_filter in &child_pushdown_result.parent_filters {
+            match physical_expr_to_sql(&parent_filter.filter) {
+                Some(sql_fragment) => {
+                    accepted_filters.push(sql_fragment);
+                    filter_results.push(PushedDown::Yes);
+                    any_accepted = true;
+                }
+                None => {
+                    filter_results.push(PushedDown::No);
+                }
+            }
+        }
+
+        if !any_accepted {
+            return Ok(FilterPushdownPropagation::with_parent_pushdown_result(
+                filter_results,
+            ));
+        }
+
+        let where_clause = accepted_filters.join(" AND ");
+
+        // Insert WHERE conditions into the SQL
+        let new_sql = insert_where_clause(&self.sql, &where_clause);
+
+        let new_exec = Self {
+            projected_schema: Arc::clone(&self.projected_schema),
+            pool: Arc::clone(&self.pool),
+            sql: new_sql,
+            properties: self.properties.clone(),
+        };
+
+        Ok(
+            FilterPushdownPropagation::with_parent_pushdown_result(filter_results)
+                .with_updated_node(Arc::new(new_exec) as Arc<dyn ExecutionPlan>),
+        )
     }
 
     fn execute(
@@ -499,6 +829,317 @@ mod tests {
         }
     }
 
+    mod sort_pushdown_tests {
+        use crate::sql::sql_provider_datafusion::SqlExec;
+        use arrow_schema::SortOptions;
+        use datafusion::arrow::datatypes::{DataType, Field, Schema};
+        use datafusion::physical_expr::expressions::Column;
+        use datafusion::physical_expr::PhysicalSortExpr;
+        use datafusion::physical_plan::sort_pushdown::SortOrderPushdownResult;
+        use datafusion::physical_plan::ExecutionPlan;
+        use std::sync::Arc;
+
+        use crate::sql::db_connection_pool::{
+            dbconnection::DbConnection, DbConnectionPool, JoinPushDown,
+        };
+
+        struct MockConn {}
+
+        impl DbConnection<(), &'static dyn ToString> for MockConn {
+            fn as_any(&self) -> &dyn std::any::Any {
+                self
+            }
+
+            fn as_any_mut(&mut self) -> &mut dyn std::any::Any {
+                self
+            }
+        }
+
+        struct MockDBPool {}
+
+        #[async_trait::async_trait]
+        impl DbConnectionPool<(), &'static dyn ToString> for MockDBPool {
+            async fn connect(
+                &self,
+            ) -> Result<
+                Box<dyn DbConnection<(), &'static dyn ToString>>,
+                Box<dyn std::error::Error + Send + Sync>,
+            > {
+                Ok(Box::new(MockConn {}))
+            }
+
+            fn join_push_down(&self) -> JoinPushDown {
+                JoinPushDown::Disallow
+            }
+        }
+
+        fn make_exec(sql: &str) -> SqlExec<(), &'static dyn ToString> {
+            let schema = Arc::new(Schema::new(vec![
+                Field::new("name", DataType::Utf8, false),
+                Field::new("age", DataType::Int16, false),
+            ]));
+            let pool = Arc::new(MockDBPool {})
+                as Arc<dyn DbConnectionPool<(), &'static dyn ToString> + Send + Sync>;
+            SqlExec::new(None, &schema, pool, sql.to_string()).unwrap()
+        }
+
+        #[test]
+        fn test_sort_pushdown_single_column_asc() {
+            let exec = make_exec("SELECT \"name\", \"age\" FROM \"users\"");
+            let order = vec![PhysicalSortExpr {
+                expr: Arc::new(Column::new("name", 0)),
+                options: SortOptions {
+                    descending: false,
+                    nulls_first: true,
+                },
+            }];
+
+            match exec.try_pushdown_sort(&order).unwrap() {
+                SortOrderPushdownResult::Exact { inner } => {
+                    let sql_exec = inner
+                        .as_any()
+                        .downcast_ref::<SqlExec<(), &'static dyn ToString>>()
+                        .unwrap();
+                    assert_eq!(
+                        sql_exec.sql().unwrap(),
+                        "SELECT \"name\", \"age\" FROM \"users\" ORDER BY \"name\" ASC NULLS FIRST"
+                    );
+                }
+                other => panic!("Expected Exact, got {:?}", sort_result_name(&other)),
+            }
+        }
+
+        #[test]
+        fn test_sort_pushdown_desc_nulls_last() {
+            let exec = make_exec("SELECT \"name\", \"age\" FROM \"users\"");
+            let order = vec![PhysicalSortExpr {
+                expr: Arc::new(Column::new("age", 1)),
+                options: SortOptions {
+                    descending: true,
+                    nulls_first: false,
+                },
+            }];
+
+            match exec.try_pushdown_sort(&order).unwrap() {
+                SortOrderPushdownResult::Exact { inner } => {
+                    let sql_exec = inner
+                        .as_any()
+                        .downcast_ref::<SqlExec<(), &'static dyn ToString>>()
+                        .unwrap();
+                    assert_eq!(
+                        sql_exec.sql().unwrap(),
+                        "SELECT \"name\", \"age\" FROM \"users\" ORDER BY \"age\" DESC NULLS LAST"
+                    );
+                }
+                other => panic!("Expected Exact, got {:?}", sort_result_name(&other)),
+            }
+        }
+
+        #[test]
+        fn test_sort_pushdown_multiple_columns() {
+            let exec = make_exec("SELECT \"name\", \"age\" FROM \"users\"");
+            let order = vec![
+                PhysicalSortExpr {
+                    expr: Arc::new(Column::new("age", 1)),
+                    options: SortOptions {
+                        descending: true,
+                        nulls_first: true,
+                    },
+                },
+                PhysicalSortExpr {
+                    expr: Arc::new(Column::new("name", 0)),
+                    options: SortOptions {
+                        descending: false,
+                        nulls_first: false,
+                    },
+                },
+            ];
+
+            match exec.try_pushdown_sort(&order).unwrap() {
+                SortOrderPushdownResult::Exact { inner } => {
+                    let sql_exec = inner
+                        .as_any()
+                        .downcast_ref::<SqlExec<(), &'static dyn ToString>>()
+                        .unwrap();
+                    assert_eq!(
+                        sql_exec.sql().unwrap(),
+                        "SELECT \"name\", \"age\" FROM \"users\" ORDER BY \"age\" DESC NULLS FIRST, \"name\" ASC NULLS LAST"
+                    );
+                }
+                other => panic!("Expected Exact, got {:?}", sort_result_name(&other)),
+            }
+        }
+
+        #[test]
+        fn test_sort_pushdown_with_limit() {
+            let exec =
+                make_exec("SELECT \"name\", \"age\" FROM \"users\" WHERE \"age\" > 30 LIMIT 10");
+            let order = vec![PhysicalSortExpr {
+                expr: Arc::new(Column::new("name", 0)),
+                options: SortOptions {
+                    descending: false,
+                    nulls_first: true,
+                },
+            }];
+
+            match exec.try_pushdown_sort(&order).unwrap() {
+                SortOrderPushdownResult::Exact { inner } => {
+                    let sql_exec = inner
+                        .as_any()
+                        .downcast_ref::<SqlExec<(), &'static dyn ToString>>()
+                        .unwrap();
+                    assert_eq!(
+                        sql_exec.sql().unwrap(),
+                        "SELECT \"name\", \"age\" FROM \"users\" WHERE \"age\" > 30 ORDER BY \"name\" ASC NULLS FIRST LIMIT 10"
+                    );
+                }
+                other => panic!("Expected Exact, got {:?}", sort_result_name(&other)),
+            }
+        }
+
+        #[test]
+        fn test_sort_pushdown_empty_order_returns_unsupported() {
+            let exec = make_exec("SELECT \"name\" FROM \"users\"");
+            match exec.try_pushdown_sort(&[]).unwrap() {
+                SortOrderPushdownResult::Unsupported => {}
+                other => panic!("Expected Unsupported, got {:?}", sort_result_name(&other)),
+            }
+        }
+
+        #[test]
+        fn test_sort_pushdown_updates_output_ordering() {
+            let exec = make_exec("SELECT \"name\", \"age\" FROM \"users\"");
+            let order = vec![PhysicalSortExpr {
+                expr: Arc::new(Column::new("name", 0)),
+                options: SortOptions {
+                    descending: false,
+                    nulls_first: true,
+                },
+            }];
+
+            match exec.try_pushdown_sort(&order).unwrap() {
+                SortOrderPushdownResult::Exact { inner } => {
+                    let orderings = inner.properties().output_ordering();
+                    assert!(orderings.is_some(), "Output ordering should be set");
+                    let output_order = orderings.unwrap();
+                    assert_eq!(output_order.len(), 1);
+                }
+                other => panic!("Expected Exact, got {:?}", sort_result_name(&other)),
+            }
+        }
+
+        fn sort_result_name(
+            result: &SortOrderPushdownResult<Arc<dyn ExecutionPlan>>,
+        ) -> &'static str {
+            match result {
+                SortOrderPushdownResult::Exact { .. } => "Exact",
+                SortOrderPushdownResult::Inexact { .. } => "Inexact",
+                SortOrderPushdownResult::Unsupported => "Unsupported",
+            }
+        }
+    }
+
+    mod with_fetch_tests {
+        use crate::sql::sql_provider_datafusion::SqlExec;
+        use datafusion::arrow::datatypes::{DataType, Field, Schema};
+        use datafusion::physical_plan::ExecutionPlan;
+        use std::sync::Arc;
+
+        use crate::sql::db_connection_pool::{
+            dbconnection::DbConnection, DbConnectionPool, JoinPushDown,
+        };
+
+        struct MockConn {}
+
+        impl DbConnection<(), &'static dyn ToString> for MockConn {
+            fn as_any(&self) -> &dyn std::any::Any {
+                self
+            }
+
+            fn as_any_mut(&mut self) -> &mut dyn std::any::Any {
+                self
+            }
+        }
+
+        struct MockDBPool {}
+
+        #[async_trait::async_trait]
+        impl DbConnectionPool<(), &'static dyn ToString> for MockDBPool {
+            async fn connect(
+                &self,
+            ) -> Result<
+                Box<dyn DbConnection<(), &'static dyn ToString>>,
+                Box<dyn std::error::Error + Send + Sync>,
+            > {
+                Ok(Box::new(MockConn {}))
+            }
+
+            fn join_push_down(&self) -> JoinPushDown {
+                JoinPushDown::Disallow
+            }
+        }
+
+        fn make_exec(sql: &str) -> SqlExec<(), &'static dyn ToString> {
+            let schema = Arc::new(Schema::new(vec![
+                Field::new("name", DataType::Utf8, false),
+                Field::new("age", DataType::Int16, false),
+            ]));
+            let pool = Arc::new(MockDBPool {})
+                as Arc<dyn DbConnectionPool<(), &'static dyn ToString> + Send + Sync>;
+            SqlExec::new(None, &schema, pool, sql.to_string()).unwrap()
+        }
+
+        #[test]
+        fn test_with_fetch_appends_limit() {
+            let exec = make_exec("SELECT \"name\", \"age\" FROM \"users\"");
+            let result = exec.with_fetch(Some(10)).unwrap();
+            let sql_exec = result
+                .as_any()
+                .downcast_ref::<SqlExec<(), &'static dyn ToString>>()
+                .unwrap();
+            assert_eq!(
+                sql_exec.sql().unwrap(),
+                "SELECT \"name\", \"age\" FROM \"users\" LIMIT 10"
+            );
+        }
+
+        #[test]
+        fn test_with_fetch_replaces_existing_limit() {
+            let exec = make_exec("SELECT \"name\", \"age\" FROM \"users\" LIMIT 100");
+            let result = exec.with_fetch(Some(5)).unwrap();
+            let sql_exec = result
+                .as_any()
+                .downcast_ref::<SqlExec<(), &'static dyn ToString>>()
+                .unwrap();
+            assert_eq!(
+                sql_exec.sql().unwrap(),
+                "SELECT \"name\", \"age\" FROM \"users\" LIMIT 5"
+            );
+        }
+
+        #[test]
+        fn test_with_fetch_none_returns_none() {
+            let exec = make_exec("SELECT \"name\" FROM \"users\"");
+            assert!(exec.with_fetch(None).is_none());
+        }
+
+        #[test]
+        fn test_with_fetch_preserves_order_by() {
+            let exec = make_exec(
+                "SELECT \"name\", \"age\" FROM \"users\" ORDER BY \"name\" ASC NULLS FIRST LIMIT 50",
+            );
+            let result = exec.with_fetch(Some(10)).unwrap();
+            let sql_exec = result
+                .as_any()
+                .downcast_ref::<SqlExec<(), &'static dyn ToString>>()
+                .unwrap();
+            assert_eq!(
+                sql_exec.sql().unwrap(),
+                "SELECT \"name\", \"age\" FROM \"users\" ORDER BY \"name\" ASC NULLS FIRST LIMIT 10"
+            );
+        }
+    }
+
     #[test]
     fn test_references() {
         let table_ref = TableReference::bare("test");
@@ -583,6 +1224,242 @@ mod tests {
             df.show().await?;
             drop(t);
             Ok(())
+        }
+    }
+
+    mod fetch_tests {
+        use crate::sql::sql_provider_datafusion::SqlExec;
+        use datafusion::arrow::datatypes::{DataType, Field, Schema};
+        use datafusion::physical_plan::ExecutionPlan;
+        use std::sync::Arc;
+
+        use crate::sql::db_connection_pool::{
+            dbconnection::DbConnection, DbConnectionPool, JoinPushDown,
+        };
+
+        struct MockConn {}
+        impl DbConnection<(), &'static dyn ToString> for MockConn {
+            fn as_any(&self) -> &dyn std::any::Any {
+                self
+            }
+            fn as_any_mut(&mut self) -> &mut dyn std::any::Any {
+                self
+            }
+        }
+        struct MockDBPool {}
+        #[async_trait::async_trait]
+        impl DbConnectionPool<(), &'static dyn ToString> for MockDBPool {
+            async fn connect(
+                &self,
+            ) -> Result<
+                Box<dyn DbConnection<(), &'static dyn ToString>>,
+                Box<dyn std::error::Error + Send + Sync>,
+            > {
+                Ok(Box::new(MockConn {}))
+            }
+            fn join_push_down(&self) -> JoinPushDown {
+                JoinPushDown::Disallow
+            }
+        }
+
+        fn make_exec(sql: &str) -> SqlExec<(), &'static dyn ToString> {
+            let schema = Arc::new(Schema::new(vec![
+                Field::new("a", DataType::Int32, false),
+                Field::new("b", DataType::Utf8, false),
+            ]));
+            let pool = Arc::new(MockDBPool {})
+                as Arc<dyn DbConnectionPool<(), &'static dyn ToString> + Send + Sync>;
+            SqlExec::new(None, &schema, pool, sql.to_string()).unwrap()
+        }
+
+        #[test]
+        fn test_fetch_returns_none_when_no_limit() {
+            let exec = make_exec("SELECT * FROM t");
+            assert_eq!(exec.fetch(), None);
+        }
+
+        #[test]
+        fn test_fetch_returns_limit_value() {
+            let exec = make_exec("SELECT * FROM t LIMIT 42");
+            assert_eq!(exec.fetch(), Some(42));
+        }
+
+        #[test]
+        fn test_fetch_with_order_by_and_limit() {
+            let exec = make_exec("SELECT * FROM t ORDER BY a LIMIT 10");
+            assert_eq!(exec.fetch(), Some(10));
+        }
+
+        #[test]
+        fn test_supports_limit_pushdown() {
+            let exec = make_exec("SELECT * FROM t");
+            assert!(exec.supports_limit_pushdown());
+        }
+    }
+
+    mod physical_expr_to_sql_tests {
+        use super::super::*;
+        use datafusion::physical_expr::expressions::{
+            BinaryExpr, Column, IsNotNullExpr, IsNullExpr, Literal, NotExpr,
+        };
+        use datafusion::logical_expr::Operator;
+        use datafusion::scalar::ScalarValue;
+
+        fn col(name: &str) -> Arc<dyn datafusion::physical_plan::PhysicalExpr> {
+            Arc::new(Column::new(name, 0))
+        }
+
+        fn lit_i32(v: i32) -> Arc<dyn datafusion::physical_plan::PhysicalExpr> {
+            Arc::new(Literal::new(ScalarValue::Int32(Some(v))))
+        }
+
+        fn lit_str(s: &str) -> Arc<dyn datafusion::physical_plan::PhysicalExpr> {
+            Arc::new(Literal::new(ScalarValue::Utf8(Some(s.to_string()))))
+        }
+
+        #[test]
+        fn test_column() {
+            let result = physical_expr_to_sql(&col("name"));
+            assert_eq!(result, Some("\"name\"".to_string()));
+        }
+
+        #[test]
+        fn test_literal_int() {
+            let result = physical_expr_to_sql(&lit_i32(42));
+            assert_eq!(result, Some("42".to_string()));
+        }
+
+        #[test]
+        fn test_literal_string() {
+            let result = physical_expr_to_sql(&lit_str("hello"));
+            assert_eq!(result, Some("'hello'".to_string()));
+        }
+
+        #[test]
+        fn test_literal_string_with_quote() {
+            let result = physical_expr_to_sql(&lit_str("it's"));
+            assert_eq!(result, Some("'it''s'".to_string()));
+        }
+
+        #[test]
+        fn test_literal_null() {
+            let expr: Arc<dyn datafusion::physical_plan::PhysicalExpr> =
+                Arc::new(Literal::new(ScalarValue::Null));
+            let result = physical_expr_to_sql(&expr);
+            assert_eq!(result, Some("NULL".to_string()));
+        }
+
+        #[test]
+        fn test_binary_eq() {
+            let expr: Arc<dyn datafusion::physical_plan::PhysicalExpr> = Arc::new(
+                BinaryExpr::new(col("age"), Operator::Gt, lit_i32(30)),
+            );
+            let result = physical_expr_to_sql(&expr);
+            assert_eq!(result, Some("(\"age\" > 30)".to_string()));
+        }
+
+        #[test]
+        fn test_and_expression() {
+            let left: Arc<dyn datafusion::physical_plan::PhysicalExpr> = Arc::new(
+                BinaryExpr::new(col("a"), Operator::Gt, lit_i32(1)),
+            );
+            let right: Arc<dyn datafusion::physical_plan::PhysicalExpr> = Arc::new(
+                BinaryExpr::new(col("b"), Operator::Eq, lit_str("x")),
+            );
+            let expr: Arc<dyn datafusion::physical_plan::PhysicalExpr> =
+                Arc::new(BinaryExpr::new(left, Operator::And, right));
+            let result = physical_expr_to_sql(&expr);
+            assert_eq!(
+                result,
+                Some("((\"a\" > 1) AND (\"b\" = 'x'))".to_string())
+            );
+        }
+
+        #[test]
+        fn test_is_null() {
+            let expr: Arc<dyn datafusion::physical_plan::PhysicalExpr> =
+                Arc::new(IsNullExpr::new(col("x")));
+            let result = physical_expr_to_sql(&expr);
+            assert_eq!(result, Some("(\"x\" IS NULL)".to_string()));
+        }
+
+        #[test]
+        fn test_is_not_null() {
+            let expr: Arc<dyn datafusion::physical_plan::PhysicalExpr> =
+                Arc::new(IsNotNullExpr::new(col("x")));
+            let result = physical_expr_to_sql(&expr);
+            assert_eq!(result, Some("(\"x\" IS NOT NULL)".to_string()));
+        }
+
+        #[test]
+        fn test_not() {
+            let inner: Arc<dyn datafusion::physical_plan::PhysicalExpr> = Arc::new(
+                BinaryExpr::new(col("active"), Operator::Eq, lit_i32(1)),
+            );
+            let expr: Arc<dyn datafusion::physical_plan::PhysicalExpr> =
+                Arc::new(NotExpr::new(inner));
+            let result = physical_expr_to_sql(&expr);
+            assert_eq!(result, Some("(NOT (\"active\" = 1))".to_string()));
+        }
+
+        #[test]
+        fn test_literal_bool() {
+            let expr: Arc<dyn datafusion::physical_plan::PhysicalExpr> =
+                Arc::new(Literal::new(ScalarValue::Boolean(Some(true))));
+            let result = physical_expr_to_sql(&expr);
+            assert_eq!(result, Some("TRUE".to_string()));
+        }
+    }
+
+    mod insert_where_clause_tests {
+        use super::super::insert_where_clause;
+
+        #[test]
+        fn test_no_existing_where() {
+            let sql = "SELECT * FROM t";
+            let result = insert_where_clause(sql, "\"a\" > 1");
+            assert_eq!(result, "SELECT * FROM t WHERE \"a\" > 1");
+        }
+
+        #[test]
+        fn test_existing_where() {
+            let sql = "SELECT * FROM t WHERE \"b\" = 2";
+            let result = insert_where_clause(sql, "\"a\" > 1");
+            assert_eq!(result, "SELECT * FROM t WHERE \"b\" = 2 AND (\"a\" > 1)");
+        }
+
+        #[test]
+        fn test_no_where_with_order_by() {
+            let sql = "SELECT * FROM t ORDER BY a";
+            let result = insert_where_clause(sql, "\"x\" = 1");
+            assert_eq!(result, "SELECT * FROM t WHERE \"x\" = 1 ORDER BY a");
+        }
+
+        #[test]
+        fn test_no_where_with_limit() {
+            let sql = "SELECT * FROM t LIMIT 10";
+            let result = insert_where_clause(sql, "\"x\" = 1");
+            assert_eq!(result, "SELECT * FROM t WHERE \"x\" = 1 LIMIT 10");
+        }
+
+        #[test]
+        fn test_existing_where_with_order_by_and_limit() {
+            let sql = "SELECT * FROM t WHERE \"a\" = 1 ORDER BY b LIMIT 5";
+            let result = insert_where_clause(sql, "\"c\" > 3");
+            assert_eq!(
+                result,
+                "SELECT * FROM t WHERE \"a\" = 1 AND (\"c\" > 3) ORDER BY b LIMIT 5"
+            );
+        }
+
+        #[test]
+        fn test_no_where_with_order_by_and_limit() {
+            let sql = "SELECT * FROM t ORDER BY b LIMIT 5";
+            let result = insert_where_clause(sql, "\"c\" > 3");
+            assert_eq!(
+                result,
+                "SELECT * FROM t WHERE \"c\" > 3 ORDER BY b LIMIT 5"
+            );
         }
     }
 }

--- a/core/src/sqlite/sql_table.rs
+++ b/core/src/sqlite/sql_table.rs
@@ -11,13 +11,19 @@ use crate::sql::sql_provider_datafusion::{
 };
 use datafusion::{
     arrow::datatypes::SchemaRef,
+    config::ConfigOptions,
     datasource::TableProvider,
-    error::Result as DataFusionResult,
+    error::{DataFusionError, Result as DataFusionResult},
     execution::TaskContext,
     logical_expr::{Expr, TableProviderFilterPushDown, TableType},
+    physical_expr::PhysicalSortExpr,
     physical_plan::{
-        stream::RecordBatchStreamAdapter, DisplayAs, DisplayFormatType, ExecutionPlan,
-        PlanProperties, SendableRecordBatchStream,
+        filter_pushdown::{
+            ChildPushdownResult, FilterPushdownPhase, FilterPushdownPropagation,
+        },
+        sort_pushdown::SortOrderPushdownResult,
+        stream::RecordBatchStreamAdapter,
+        DisplayAs, DisplayFormatType, ExecutionPlan, PlanProperties, SendableRecordBatchStream,
     },
     sql::TableReference,
 };
@@ -162,6 +168,85 @@ impl<T: 'static, P: 'static> ExecutionPlan for SQLiteSqlExec<T, P> {
         _children: Vec<Arc<dyn ExecutionPlan>>,
     ) -> DataFusionResult<Arc<dyn ExecutionPlan>> {
         Ok(self)
+    }
+
+    fn try_pushdown_sort(
+        &self,
+        order: &[PhysicalSortExpr],
+    ) -> DataFusionResult<SortOrderPushdownResult<Arc<dyn ExecutionPlan>>> {
+        match self.base_exec.try_pushdown_sort(order)? {
+            SortOrderPushdownResult::Exact { inner } => {
+                let base_exec = inner
+                    .as_any()
+                    .downcast_ref::<SqlExec<T, P>>()
+                    .ok_or_else(|| {
+                        DataFusionError::Internal(
+                            "Failed to downcast SqlExec in sort pushdown".to_string(),
+                        )
+                    })?
+                    .clone();
+                Ok(SortOrderPushdownResult::Exact {
+                    inner: Arc::new(SQLiteSqlExec { base_exec }),
+                })
+            }
+            SortOrderPushdownResult::Inexact { inner } => {
+                let base_exec = inner
+                    .as_any()
+                    .downcast_ref::<SqlExec<T, P>>()
+                    .ok_or_else(|| {
+                        DataFusionError::Internal(
+                            "Failed to downcast SqlExec in sort pushdown".to_string(),
+                        )
+                    })?
+                    .clone();
+                Ok(SortOrderPushdownResult::Inexact {
+                    inner: Arc::new(SQLiteSqlExec { base_exec }),
+                })
+            }
+            SortOrderPushdownResult::Unsupported => Ok(SortOrderPushdownResult::Unsupported),
+        }
+    }
+
+    fn supports_limit_pushdown(&self) -> bool {
+        true
+    }
+
+    fn fetch(&self) -> Option<usize> {
+        self.base_exec.fetch()
+    }
+
+    fn with_fetch(&self, limit: Option<usize>) -> Option<Arc<dyn ExecutionPlan>> {
+        let base_exec = self
+            .base_exec
+            .with_fetch(limit)?
+            .as_any()
+            .downcast_ref::<SqlExec<T, P>>()?
+            .clone();
+        Some(Arc::new(SQLiteSqlExec { base_exec }))
+    }
+
+    fn handle_child_pushdown_result(
+        &self,
+        phase: FilterPushdownPhase,
+        child_pushdown_result: ChildPushdownResult,
+        config: &ConfigOptions,
+    ) -> DataFusionResult<FilterPushdownPropagation<Arc<dyn ExecutionPlan>>> {
+        let result = self.base_exec.handle_child_pushdown_result(
+            phase,
+            child_pushdown_result,
+            config,
+        )?;
+        Ok(FilterPushdownPropagation {
+            filters: result.filters,
+            updated_node: result.updated_node.map(|node| {
+                let base_exec = node
+                    .as_any()
+                    .downcast_ref::<SqlExec<T, P>>()
+                    .expect("Failed to downcast SqlExec in filter pushdown")
+                    .clone();
+                Arc::new(SQLiteSqlExec { base_exec }) as Arc<dyn ExecutionPlan>
+            }),
+        })
     }
 
     fn execute(

--- a/core/src/sqlite/sql_table.rs
+++ b/core/src/sqlite/sql_table.rs
@@ -1,7 +1,7 @@
 use crate::sql::db_connection_pool::DbConnectionPool;
 use async_trait::async_trait;
 use datafusion::catalog::Session;
-use datafusion::sql::unparser::dialect::SqliteDialect;
+use datafusion::sql::unparser::dialect::{Dialect, SqliteDialect};
 use futures::TryStreamExt;
 use std::fmt::Display;
 use std::{any::Any, fmt, sync::Arc};
@@ -63,6 +63,7 @@ impl<T, P> SQLiteTable<T, P> {
             schema,
             self.base_table.clone_pool(),
             sql,
+            self.base_table.dialect_arc(),
         )?))
     }
 }
@@ -117,8 +118,9 @@ impl<T, P> SQLiteSqlExec<T, P> {
         schema: &SchemaRef,
         pool: Arc<dyn DbConnectionPool<T, P> + Send + Sync>,
         sql: String,
+        dialect: Arc<dyn Dialect + Send + Sync>,
     ) -> DataFusionResult<Self> {
-        let base_exec = SqlExec::new(projection, schema, pool, sql)?;
+        let base_exec = SqlExec::new(projection, schema, pool, sql, dialect)?;
 
         Ok(Self { base_exec })
     }
@@ -236,16 +238,24 @@ impl<T: 'static, P: 'static> ExecutionPlan for SQLiteSqlExec<T, P> {
             child_pushdown_result,
             config,
         )?;
-        Ok(FilterPushdownPropagation {
-            filters: result.filters,
-            updated_node: result.updated_node.map(|node| {
+        let updated_node = result
+            .updated_node
+            .map(|node| {
                 let base_exec = node
                     .as_any()
                     .downcast_ref::<SqlExec<T, P>>()
-                    .expect("Failed to downcast SqlExec in filter pushdown")
+                    .ok_or_else(|| {
+                        DataFusionError::Internal(
+                            "Failed to downcast SqlExec in filter pushdown".to_string(),
+                        )
+                    })?
                     .clone();
-                Arc::new(SQLiteSqlExec { base_exec }) as Arc<dyn ExecutionPlan>
-            }),
+                Ok::<_, DataFusionError>(Arc::new(SQLiteSqlExec { base_exec }) as Arc<dyn ExecutionPlan>)
+            })
+            .transpose()?;
+        Ok(FilterPushdownPropagation {
+            filters: result.filters,
+            updated_node,
         })
     }
 

--- a/core/src/sqlite/sql_table.rs
+++ b/core/src/sqlite/sql_table.rs
@@ -18,9 +18,7 @@ use datafusion::{
     logical_expr::{Expr, TableProviderFilterPushDown, TableType},
     physical_expr::PhysicalSortExpr,
     physical_plan::{
-        filter_pushdown::{
-            ChildPushdownResult, FilterPushdownPhase, FilterPushdownPropagation,
-        },
+        filter_pushdown::{ChildPushdownResult, FilterPushdownPhase, FilterPushdownPropagation},
         sort_pushdown::SortOrderPushdownResult,
         stream::RecordBatchStreamAdapter,
         DisplayAs, DisplayFormatType, ExecutionPlan, PlanProperties, SendableRecordBatchStream,
@@ -233,11 +231,9 @@ impl<T: 'static, P: 'static> ExecutionPlan for SQLiteSqlExec<T, P> {
         child_pushdown_result: ChildPushdownResult,
         config: &ConfigOptions,
     ) -> DataFusionResult<FilterPushdownPropagation<Arc<dyn ExecutionPlan>>> {
-        let result = self.base_exec.handle_child_pushdown_result(
-            phase,
-            child_pushdown_result,
-            config,
-        )?;
+        let result =
+            self.base_exec
+                .handle_child_pushdown_result(phase, child_pushdown_result, config)?;
         let updated_node = result
             .updated_node
             .map(|node| {
@@ -250,7 +246,9 @@ impl<T: 'static, P: 'static> ExecutionPlan for SQLiteSqlExec<T, P> {
                         )
                     })?
                     .clone();
-                Ok::<_, DataFusionError>(Arc::new(SQLiteSqlExec { base_exec }) as Arc<dyn ExecutionPlan>)
+                Ok::<_, DataFusionError>(
+                    Arc::new(SQLiteSqlExec { base_exec }) as Arc<dyn ExecutionPlan>
+                )
             })
             .transpose()?;
         Ok(FilterPushdownPropagation {

--- a/core/tests/adbc/mod.rs
+++ b/core/tests/adbc/mod.rs
@@ -150,3 +150,263 @@ async fn test_arrow_adbc_roundtrip(
     )
     .await;
 }
+
+/// Tests for ADBC pushdown optimizations: projection, filter, limit, sort
+mod pushdown_tests {
+    use super::*;
+    use datafusion::prelude::SessionContext;
+
+    fn try_get_db(driver_name: &str) -> Option<ManagedDatabase> {
+        let mut driver = ManagedDriver::load_from_name(
+            driver_name,
+            None,
+            AdbcVersion::V110,
+            LOAD_FLAG_DEFAULT,
+            None,
+        )
+        .ok()?;
+
+        driver
+            .new_database_with_opts([(
+                OptionDatabase::Uri,
+                OptionValue::String(":memory:".to_string()),
+            )])
+            .ok()
+    }
+
+    /// Helper: create an ADBC-backed table with test data.
+    /// Returns None if the ADBC driver is not available.
+    async fn setup_adbc_table(
+        ctx: &SessionContext,
+        table_name: &str,
+    ) -> Option<Arc<dyn datafusion::datasource::TableProvider>> {
+        let db = try_get_db("sqlite")?;
+
+        let schema = Arc::new(arrow::datatypes::Schema::new(vec![
+            arrow::datatypes::Field::new("id", arrow::datatypes::DataType::Int32, false),
+            arrow::datatypes::Field::new("name", arrow::datatypes::DataType::Utf8, false),
+            arrow::datatypes::Field::new("age", arrow::datatypes::DataType::Int32, false),
+        ]));
+
+        let batch = RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![
+                Arc::new(arrow::array::Int32Array::from(vec![1, 2, 3, 4, 5])),
+                Arc::new(arrow::array::StringArray::from(vec![
+                    "Alice", "Bob", "Charlie", "Diana", "Eve",
+                ])),
+                Arc::new(arrow::array::Int32Array::from(vec![30, 25, 35, 28, 22])),
+            ],
+        )
+        .unwrap();
+
+        let adbc_pool = Arc::new(ADBCPool::new(db, None).expect("Failed to create ADBC pool"));
+        let table_factory = AdbcTableFactory::new(adbc_pool);
+
+        let mem_exec = MemorySourceConfig::try_new_exec(&[vec![batch]], Arc::clone(&schema), None)
+            .expect("Failed to create memory source execution plan");
+
+        let create_plan = table_factory
+            .create_from(&ctx.state(), mem_exec, table_name.into())
+            .await
+            .expect("Failed to create table");
+
+        let _ = collect(create_plan, ctx.task_ctx())
+            .await
+            .expect("Table creation failed");
+
+        let table_provider = table_factory
+            .table_provider(table_name.into(), None)
+            .await
+            .expect("Failed to get table provider");
+
+        ctx.register_table(table_name, Arc::clone(&table_provider))
+            .expect("Failed to register table");
+
+        Some(table_provider)
+    }
+
+    macro_rules! adbc_test {
+        ($ctx:ident, $table:literal) => {
+            let $ctx = SessionContext::new();
+            if setup_adbc_table(&$ctx, $table).await.is_none() {
+                eprintln!("Skipping test: ADBC SQLite driver not found");
+                return;
+            }
+        };
+    }
+
+    #[test_log::test(tokio::test)]
+    async fn test_adbc_projection_pushdown() {
+        adbc_test!(ctx, "proj_test");
+
+        let df = ctx
+            .sql("SELECT name FROM proj_test")
+            .await
+            .expect("Query should succeed");
+        let batches = df.collect().await.expect("Should collect results");
+
+        assert_eq!(batches[0].num_columns(), 1);
+        assert_eq!(batches[0].num_rows(), 5);
+    }
+
+    #[test_log::test(tokio::test)]
+    async fn test_adbc_filter_pushdown() {
+        adbc_test!(ctx, "filter_test");
+
+        let df = ctx
+            .sql("SELECT * FROM filter_test WHERE age > 27")
+            .await
+            .expect("Query should succeed");
+        let batches = df.collect().await.expect("Should collect results");
+
+        let total_rows: usize = batches.iter().map(|b| b.num_rows()).sum();
+        assert_eq!(total_rows, 3); // Alice(30), Charlie(35), Diana(28)
+    }
+
+    #[test_log::test(tokio::test)]
+    async fn test_adbc_limit_pushdown() {
+        adbc_test!(ctx, "limit_test");
+
+        let df = ctx
+            .sql("SELECT * FROM limit_test LIMIT 2")
+            .await
+            .expect("Query should succeed");
+        let batches = df.collect().await.expect("Should collect results");
+
+        let total_rows: usize = batches.iter().map(|b| b.num_rows()).sum();
+        assert_eq!(total_rows, 2);
+    }
+
+    #[test_log::test(tokio::test)]
+    async fn test_adbc_filter_and_limit_pushdown() {
+        adbc_test!(ctx, "filter_limit_test");
+
+        let df = ctx
+            .sql("SELECT * FROM filter_limit_test WHERE age >= 28 LIMIT 2")
+            .await
+            .expect("Query should succeed");
+        let batches = df.collect().await.expect("Should collect results");
+
+        let total_rows: usize = batches.iter().map(|b| b.num_rows()).sum();
+        assert!(total_rows <= 2);
+    }
+
+    #[test_log::test(tokio::test)]
+    async fn test_adbc_projection_and_filter_pushdown() {
+        adbc_test!(ctx, "proj_filter_test");
+
+        let df = ctx
+            .sql("SELECT name, age FROM proj_filter_test WHERE age < 30")
+            .await
+            .expect("Query should succeed");
+        let batches = df.collect().await.expect("Should collect results");
+
+        assert_eq!(batches[0].num_columns(), 2);
+        let total_rows: usize = batches.iter().map(|b| b.num_rows()).sum();
+        assert_eq!(total_rows, 3); // Bob(25), Diana(28), Eve(22)
+    }
+
+    #[test_log::test(tokio::test)]
+    async fn test_adbc_sort_pushdown() {
+        adbc_test!(ctx, "sort_test");
+
+        let df = ctx
+            .sql("SELECT name, age FROM sort_test ORDER BY age ASC")
+            .await
+            .expect("Query should succeed");
+        let batches = df.collect().await.expect("Should collect results");
+
+        let age_col = batches[0]
+            .column(1)
+            .as_any()
+            .downcast_ref::<arrow::array::Int32Array>()
+            .unwrap();
+
+        let ages: Vec<i32> = (0..age_col.len()).map(|i| age_col.value(i)).collect();
+        assert_eq!(ages, vec![22, 25, 28, 30, 35]);
+    }
+
+    #[test_log::test(tokio::test)]
+    async fn test_adbc_sort_desc_pushdown() {
+        adbc_test!(ctx, "sort_desc_test");
+
+        let df = ctx
+            .sql("SELECT name, age FROM sort_desc_test ORDER BY age DESC")
+            .await
+            .expect("Query should succeed");
+        let batches = df.collect().await.expect("Should collect results");
+
+        let age_col = batches[0]
+            .column(1)
+            .as_any()
+            .downcast_ref::<arrow::array::Int32Array>()
+            .unwrap();
+
+        let ages: Vec<i32> = (0..age_col.len()).map(|i| age_col.value(i)).collect();
+        assert_eq!(ages, vec![35, 30, 28, 25, 22]);
+    }
+
+    #[test_log::test(tokio::test)]
+    async fn test_adbc_sort_with_limit_pushdown() {
+        adbc_test!(ctx, "sort_limit_test");
+
+        // TopK pattern: ORDER BY + LIMIT
+        let df = ctx
+            .sql("SELECT name, age FROM sort_limit_test ORDER BY age DESC LIMIT 3")
+            .await
+            .expect("Query should succeed");
+        let batches = df.collect().await.expect("Should collect results");
+
+        let total_rows: usize = batches.iter().map(|b| b.num_rows()).sum();
+        assert_eq!(total_rows, 3);
+
+        let age_col = batches[0]
+            .column(1)
+            .as_any()
+            .downcast_ref::<arrow::array::Int32Array>()
+            .unwrap();
+
+        let ages: Vec<i32> = (0..age_col.len()).map(|i| age_col.value(i)).collect();
+        assert_eq!(ages, vec![35, 30, 28]);
+    }
+
+    #[test_log::test(tokio::test)]
+    async fn test_adbc_multi_column_sort_pushdown() {
+        adbc_test!(ctx, "multi_sort_test");
+
+        let df = ctx
+            .sql("SELECT * FROM multi_sort_test ORDER BY age ASC, name DESC")
+            .await
+            .expect("Query should succeed");
+        let batches = df.collect().await.expect("Should collect results");
+
+        let total_rows: usize = batches.iter().map(|b| b.num_rows()).sum();
+        assert_eq!(total_rows, 5);
+    }
+
+    #[test_log::test(tokio::test)]
+    async fn test_adbc_all_pushdowns_combined() {
+        adbc_test!(ctx, "combined_test");
+
+        // projection + filter + sort + limit all at once
+        let df = ctx
+            .sql("SELECT name, age FROM combined_test WHERE age >= 25 ORDER BY age ASC LIMIT 3")
+            .await
+            .expect("Query should succeed");
+        let batches = df.collect().await.expect("Should collect results");
+
+        let total_rows: usize = batches.iter().map(|b| b.num_rows()).sum();
+        assert_eq!(total_rows, 3);
+        assert_eq!(batches[0].num_columns(), 2);
+
+        let age_col = batches[0]
+            .column(1)
+            .as_any()
+            .downcast_ref::<arrow::array::Int32Array>()
+            .unwrap();
+
+        let ages: Vec<i32> = (0..age_col.len()).map(|i| age_col.value(i)).collect();
+        assert_eq!(ages, vec![25, 28, 30]);
+    }
+}

--- a/core/tests/integration.rs
+++ b/core/tests/integration.rs
@@ -5,6 +5,12 @@ mod adbc;
 mod arrow_record_batch_gen;
 #[cfg(feature = "clickhouse")]
 mod clickhouse;
+#[cfg(any(
+    feature = "clickhouse",
+    feature = "mongodb",
+    feature = "mysql",
+    feature = "postgres"
+))]
 mod docker;
 #[cfg(all(feature = "duckdb", feature = "federation"))]
 mod duckdb;


### PR DESCRIPTION
## Summary

Implements missing `ExecutionPlan` pushdown methods across all SQL connectors (ADBC, SQLite, DuckDB, MySQL, Postgres), closing pushdown gaps identified during an audit of the ADBC connector.

## Changes

### New pushdown methods on `SqlExec` (base) + all wrappers

| Method | Purpose |
|--------|---------|
| `try_pushdown_sort` | Pushes `ORDER BY` into generated SQL from `PhysicalSortExpr` |
| `with_fetch` / `fetch` / `supports_limit_pushdown` | Pushes `LIMIT` into SQL; reports current limit for optimizer introspection |
| `handle_child_pushdown_result` | Physical filter pushdown — converts `PhysicalExpr` predicates into SQL `WHERE` conditions |

### Supporting infrastructure

- `physical_expr_to_sql()` — converts `Column`, `Literal`, `BinaryExpr`, `NotExpr`, `IsNull`, `IsNotNull`, `NegativeExpr`, `CastExpr`, `InListExpr` to SQL (with SQL injection protection via quote escaping)
- `insert_where_clause()` — safely injects WHERE conditions into existing SQL, respecting ORDER BY / LIMIT / GROUP BY clause positions
- `scalar_value_to_sql()`, `operator_to_sql()`, `datatype_to_sql()` — type conversion helpers

### Wrapper propagation

All five connector-specific `ExecutionPlan` wrappers (`AdbcSqlExec`, `SQLiteSqlExec`, `DuckSqlExec`, `MySQLSQLExec`, and Postgres via base `SqlExec`) delegate to the base implementation and rewrap the result.

### Tests

- **36 unit tests**: sort pushdown (6), with_fetch (4), fetch/supports_limit_pushdown (4), physical_expr_to_sql conversion (11), insert_where_clause SQL manipulation (6), existing tests (5)
- **10 ADBC integration tests**: projection, filter, limit, sort ASC/DESC, TopK (sort+limit), multi-column sort, combined (projection+filter+sort+limit)
- Tests gracefully skip when ADBC SQLite driver is not installed

### Bug fix

- Feature-gated `mod docker` in integration tests to fix pre-existing compilation errors when building without container features (clickhouse, mongodb, mysql, postgres)