### PR TITLE
Revert SortOrderPushdownResult::Inexact change

### DIFF
--- a/core/src/mongodb/table.rs
+++ b/core/src/mongodb/table.rs
@@ -261,13 +261,7 @@ impl ExecutionPlan for MongoDBExec {
         );
         new_exec.properties = new_exec.properties.with_eq_properties(eq_properties);
 
-        // Return Inexact rather than Exact so DataFusion keeps the SortExec wrapper
-        // above us. Exact would replace the SortExec with `inner`, which loses the
-        // SortExec's embedded fetch (`ORDER BY ... LIMIT N` is represented as a
-        // single SortExec with fetch=N in DF 52). Keeping the SortExec preserves the
-        // fetch as a TopK applied to our already-sorted SQL output.
-        // We can use Exact once we use DF version which includes PR https://github.com/apache/datafusion/pull/21182
-        Ok(SortOrderPushdownResult::Inexact {
+        Ok(SortOrderPushdownResult::Exact {
             inner: Arc::new(new_exec),
         })
     }
@@ -665,7 +659,7 @@ mod tests {
 
         let result = exec.try_pushdown_sort(&sort_exprs).unwrap();
         match result {
-            SortOrderPushdownResult::Inexact { inner } => {
+            SortOrderPushdownResult::Exact { inner } => {
                 let mongo_exec = inner.as_any().downcast_ref::<MongoDBExec>().unwrap();
                 assert_eq!(mongo_exec.sort_doc, doc! { "name": 1 });
                 let display = format_exec(mongo_exec);
@@ -674,7 +668,7 @@ mod tests {
                     "Display should show sort: {display}"
                 );
             }
-            other => panic!("Expected Inexact, got: {other:?}"),
+            other => panic!("Expected Exact, got: {other:?}"),
         }
     }
 
@@ -696,11 +690,11 @@ mod tests {
 
         let result = exec.try_pushdown_sort(&sort_exprs).unwrap();
         match result {
-            SortOrderPushdownResult::Inexact { inner } => {
+            SortOrderPushdownResult::Exact { inner } => {
                 let mongo_exec = inner.as_any().downcast_ref::<MongoDBExec>().unwrap();
                 assert_eq!(mongo_exec.sort_doc, doc! { "age": -1 });
             }
-            other => panic!("Expected Inexact, got: {other:?}"),
+            other => panic!("Expected Exact, got: {other:?}"),
         }
     }
 
@@ -731,11 +725,11 @@ mod tests {
 
         let result = exec.try_pushdown_sort(&sort_exprs).unwrap();
         match result {
-            SortOrderPushdownResult::Inexact { inner } => {
+            SortOrderPushdownResult::Exact { inner } => {
                 let mongo_exec = inner.as_any().downcast_ref::<MongoDBExec>().unwrap();
                 assert_eq!(mongo_exec.sort_doc, doc! { "name": 1, "age": -1 });
             }
-            other => panic!("Expected Inexact, got: {other:?}"),
+            other => panic!("Expected Exact, got: {other:?}"),
         }
     }
 
@@ -777,7 +771,7 @@ mod tests {
 
         let result = exec.try_pushdown_sort(&sort_exprs).unwrap();
         match result {
-            SortOrderPushdownResult::Inexact { inner } => {
+            SortOrderPushdownResult::Exact { inner } => {
                 let mongo_exec = inner.as_any().downcast_ref::<MongoDBExec>().unwrap();
                 assert!(
                     !mongo_exec.filters_doc.is_empty(),
@@ -786,7 +780,7 @@ mod tests {
                 assert_eq!(mongo_exec.limit, Some(10), "Limit should be preserved");
                 assert_eq!(mongo_exec.sort_doc, doc! { "name": 1 });
             }
-            other => panic!("Expected Inexact, got: {other:?}"),
+            other => panic!("Expected Exact, got: {other:?}"),
         }
     }
 
@@ -798,14 +792,14 @@ mod tests {
 
         let result = exec.try_pushdown_sort(&[]).unwrap();
         match result {
-            SortOrderPushdownResult::Inexact { inner } => {
+            SortOrderPushdownResult::Exact { inner } => {
                 let mongo_exec = inner.as_any().downcast_ref::<MongoDBExec>().unwrap();
                 assert!(
                     mongo_exec.sort_doc.is_empty(),
                     "Empty sort should produce empty doc"
                 );
             }
-            other => panic!("Expected Inexact, got: {other:?}"),
+            other => panic!("Expected Exact, got: {other:?}"),
         }
     }
 }

--- a/core/src/sql/sql_provider_datafusion/mod.rs
+++ b/core/src/sql/sql_provider_datafusion/mod.rs
@@ -640,13 +640,7 @@ impl<T: 'static, P: 'static> ExecutionPlan for SqlExec<T, P> {
         );
         new_exec.properties = new_exec.properties.with_eq_properties(eq_properties);
 
-        // Return Inexact rather than Exact so DataFusion keeps the SortExec wrapper
-        // above us. Exact would replace the SortExec with `inner`, which loses the
-        // SortExec's embedded fetch (`ORDER BY ... LIMIT N` is represented as a
-        // single SortExec with fetch=N in DF 52). Keeping the SortExec preserves the
-        // fetch as a TopK applied to our already-sorted SQL output.
-        // We can use Exact once we use DF version which includes PR https://github.com/apache/datafusion/pull/21182
-        Ok(SortOrderPushdownResult::Inexact {
+        Ok(SortOrderPushdownResult::Exact {
             inner: Arc::new(new_exec),
         })
     }
@@ -971,7 +965,7 @@ mod tests {
             }];
 
             match exec.try_pushdown_sort(&order).unwrap() {
-                SortOrderPushdownResult::Inexact { inner } => {
+                SortOrderPushdownResult::Exact { inner } => {
                     let sql_exec = inner
                         .as_any()
                         .downcast_ref::<SqlExec<(), &'static dyn ToString>>()
@@ -981,7 +975,7 @@ mod tests {
                         "SELECT \"name\", \"age\" FROM \"users\" ORDER BY \"name\" ASC NULLS FIRST"
                     );
                 }
-                other => panic!("Expected Inexact, got {:?}", sort_result_name(&other)),
+                other => panic!("Expected Exact, got {:?}", sort_result_name(&other)),
             }
         }
 
@@ -997,7 +991,7 @@ mod tests {
             }];
 
             match exec.try_pushdown_sort(&order).unwrap() {
-                SortOrderPushdownResult::Inexact { inner } => {
+                SortOrderPushdownResult::Exact { inner } => {
                     let sql_exec = inner
                         .as_any()
                         .downcast_ref::<SqlExec<(), &'static dyn ToString>>()
@@ -1007,7 +1001,7 @@ mod tests {
                         "SELECT \"name\", \"age\" FROM \"users\" ORDER BY age DESC NULLS LAST"
                     );
                 }
-                other => panic!("Expected Inexact, got {:?}", sort_result_name(&other)),
+                other => panic!("Expected Exact, got {:?}", sort_result_name(&other)),
             }
         }
 
@@ -1032,7 +1026,7 @@ mod tests {
             ];
 
             match exec.try_pushdown_sort(&order).unwrap() {
-                SortOrderPushdownResult::Inexact { inner } => {
+                SortOrderPushdownResult::Exact { inner } => {
                     let sql_exec = inner
                         .as_any()
                         .downcast_ref::<SqlExec<(), &'static dyn ToString>>()
@@ -1042,7 +1036,7 @@ mod tests {
                         "SELECT \"name\", \"age\" FROM \"users\" ORDER BY age DESC NULLS FIRST, \"name\" ASC NULLS LAST"
                     );
                 }
-                other => panic!("Expected Inexact, got {:?}", sort_result_name(&other)),
+                other => panic!("Expected Exact, got {:?}", sort_result_name(&other)),
             }
         }
 
@@ -1059,7 +1053,7 @@ mod tests {
             }];
 
             match exec.try_pushdown_sort(&order).unwrap() {
-                SortOrderPushdownResult::Inexact { inner } => {
+                SortOrderPushdownResult::Exact { inner } => {
                     let sql_exec = inner
                         .as_any()
                         .downcast_ref::<SqlExec<(), &'static dyn ToString>>()
@@ -1069,7 +1063,7 @@ mod tests {
                         "SELECT \"name\", \"age\" FROM \"users\" WHERE \"age\" > 30 ORDER BY \"name\" ASC NULLS FIRST LIMIT 10"
                     );
                 }
-                other => panic!("Expected Inexact, got {:?}", sort_result_name(&other)),
+                other => panic!("Expected Exact, got {:?}", sort_result_name(&other)),
             }
         }
 
@@ -1094,13 +1088,13 @@ mod tests {
             }];
 
             match exec.try_pushdown_sort(&order).unwrap() {
-                SortOrderPushdownResult::Inexact { inner } => {
+                SortOrderPushdownResult::Exact { inner } => {
                     let orderings = inner.properties().output_ordering();
                     assert!(orderings.is_some(), "Output ordering should be set");
                     let output_order = orderings.unwrap();
                     assert_eq!(output_order.len(), 1);
                 }
-                other => panic!("Expected Inexact, got {:?}", sort_result_name(&other)),
+                other => panic!("Expected Exact, got {:?}", sort_result_name(&other)),
             }
         }
 


### PR DESCRIPTION
Revert `SortOrderPushdownResult::Inexact` and use `SortOrderPushdownResult::Exact` instead