### PR TITLE
feat(mysql): add mysql_zero_date_behavior (null|error) to handle '0000-00-00' on NOT NULL columns

### DIFF
--- a/core/src/mysql.rs
+++ b/core/src/mysql.rs
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 use crate::mysql::write::MySQLTableWriter;
+use crate::sql::arrow_sql_gen::mysql::MysqlZeroDateBehavior;
 use crate::sql::arrow_sql_gen::statement::{CreateTableBuilder, IndexBuilder, InsertBuilder};
 use crate::sql::db_connection_pool::dbconnection::mysqlconn::MySQLConnection;
 use crate::sql::db_connection_pool::dbconnection::DbConnection;
@@ -128,6 +129,19 @@ impl MySQLTableFactory {
     pub fn with_function_support(mut self, function_support: FunctionSupport) -> Self {
         self.function_support = Some(function_support);
         self
+    }
+
+    /// Override the [`MysqlZeroDateBehavior`] applied to connections obtained from this
+    /// factory's pool. This is a convenience setter equivalent to constructing the pool with
+    /// [`MySQLConnectionPool::with_zero_date_behavior`]. Note that the underlying pool is
+    /// shared, so this affects all consumers of the pool.
+    #[must_use]
+    pub fn with_zero_date_behavior(self, behavior: MysqlZeroDateBehavior) -> Self {
+        let pool = (*self.pool).clone().with_zero_date_behavior(behavior);
+        Self {
+            pool: Arc::new(pool),
+            function_support: self.function_support,
+        }
     }
 
     pub async fn table_provider(

--- a/core/src/sql/arrow_sql_gen/mysql.rs
+++ b/core/src/sql/arrow_sql_gen/mysql.rs
@@ -58,9 +58,33 @@ pub enum Error {
 
     #[snafu(display("No column name for index: {index}"))]
     NoColumnNameForIndex { index: usize },
+
+    #[snafu(display(
+        "Encountered MySQL zero date '0000-00-00' in column '{column}' but mysql_zero_date_behavior is set to 'error'. Set mysql_zero_date_behavior to 'null' to coerce zero dates to NULL, or fix the source data."
+    ))]
+    ZeroDateEncountered { column: String },
 }
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
+
+/// Controls how the MySQL connector handles the `0000-00-00` / `0000-00-00 00:00:00` zero-date
+/// sentinel produced by MySQL for `DATE`, `DATETIME`, and `TIMESTAMP` columns.
+///
+/// Arrow has no representation for the zero-date sentinel (`year=0, month=0, day=0` is not a
+/// valid date in any calendar), so it must either be coerced to Arrow `NULL` or raised as an
+/// error.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum MysqlZeroDateBehavior {
+    /// Silently coerce zero-dates to Arrow `NULL`. When this mode is in effect, the schema
+    /// reported for `DATE`/`DATETIME`/`TIMESTAMP` columns is widened to `nullable=true`
+    /// regardless of the column's `NOT NULL` constraint, since a zero-date row would otherwise
+    /// fail Arrow's `RecordBatch` validation.
+    #[default]
+    Null,
+    /// Return an error when a zero-date is encountered. The reported schema honors the source
+    /// column's `NOT NULL` constraint exactly.
+    Error,
+}
 
 macro_rules! handle_primitive_type {
     ($builder:expr, $type:expr, $builder_ty:ty, $value_ty:ty, $row:expr, $index:expr, $column_name:expr) => {{
@@ -94,7 +118,11 @@ macro_rules! handle_primitive_type {
 ///
 /// Returns an error if there is a failure in converting the rows to a `RecordBatch`.
 #[allow(clippy::too_many_lines)]
-pub fn rows_to_arrow(rows: &[Row], projected_schema: &Option<SchemaRef>) -> Result<RecordBatch> {
+pub fn rows_to_arrow(
+    rows: &[Row],
+    projected_schema: &Option<SchemaRef>,
+    zero_date_behavior: MysqlZeroDateBehavior,
+) -> Result<RecordBatch> {
     let mut arrow_fields: Vec<Option<Field>> = Vec::new();
     let mut arrow_columns_builders: Vec<Option<Box<dyn ArrayBuilder>>> = Vec::new();
     let mut mysql_types: Vec<ColumnType> = Vec::new();
@@ -136,12 +164,28 @@ pub fn rows_to_arrow(rows: &[Row], projected_schema: &Option<SchemaRef>) -> Resu
                 decimal_scale,
             );
 
-            // Determine nullability from projected_schema if available, otherwise default to true
-            let nullable = projected_schema
-                .as_ref()
-                .and_then(|schema| schema.field_with_name(&column_name).ok())
-                .map(|field| field.is_nullable())
-                .unwrap_or(true);
+            // Determine nullability from projected_schema if available, otherwise default to true.
+            // For date/time column types, widen to nullable when zero_date_behavior is Null,
+            // because the row decoder may emit Arrow NULLs for the MySQL zero-date sentinel
+            // ('0000-00-00' / '0000-00-00 00:00:00') even on `NOT NULL` columns.
+            let is_temporal = matches!(
+                column_type,
+                ColumnType::MYSQL_TYPE_DATE
+                    | ColumnType::MYSQL_TYPE_DATETIME
+                    | ColumnType::MYSQL_TYPE_TIMESTAMP
+                    | ColumnType::MYSQL_TYPE_TIMESTAMP2
+                    | ColumnType::MYSQL_TYPE_DATETIME2
+                    | ColumnType::MYSQL_TYPE_NEWDATE
+            );
+            let nullable = if is_temporal && zero_date_behavior == MysqlZeroDateBehavior::Null {
+                true
+            } else {
+                projected_schema
+                    .as_ref()
+                    .and_then(|schema| schema.field_with_name(&column_name).ok())
+                    .map(|field| field.is_nullable())
+                    .unwrap_or(true)
+            };
 
             arrow_fields.push(
                 data_type
@@ -474,7 +518,15 @@ pub fn rows_to_arrow(rows: &[Row], projected_schema: &Option<SchemaRef>) -> Resu
                         Err(err) => {
                             // Handle '0000-00-00', that can't be parsed automatically. For more details: https://dev.mysql.com/doc/refman/8.4/en/using-date.html
                             if matches!(err, FromValueError(Value::Date(0, 0, 0, 0, 0, 0, 0))) {
-                                None
+                                match zero_date_behavior {
+                                    MysqlZeroDateBehavior::Null => None,
+                                    MysqlZeroDateBehavior::Error => {
+                                        return ZeroDateEncounteredSnafu {
+                                            column: column_name,
+                                        }
+                                        .fail();
+                                    }
+                                }
                             } else {
                                 return Err(Error::FailedToGetRowValue {
                                     column: column_name,
@@ -542,7 +594,15 @@ pub fn rows_to_arrow(rows: &[Row], projected_schema: &Option<SchemaRef>) -> Resu
                         Err(err) => {
                             // Handle '0000-00-00', that can't be parsed automatically. For more details: https://dev.mysql.com/doc/refman/8.4/en/using-date.html
                             if matches!(err, FromValueError(Value::Date(0, 0, 0, 0, 0, 0, 0))) {
-                                None
+                                match zero_date_behavior {
+                                    MysqlZeroDateBehavior::Null => None,
+                                    MysqlZeroDateBehavior::Error => {
+                                        return ZeroDateEncounteredSnafu {
+                                            column: column_name,
+                                        }
+                                        .fail();
+                                    }
+                                }
                             } else {
                                 return Err(Error::FailedToGetRowValue {
                                     column: column_name,

--- a/core/src/sql/db_connection_pool/dbconnection/mysqlconn.rs
+++ b/core/src/sql/db_connection_pool/dbconnection/mysqlconn.rs
@@ -1,6 +1,7 @@
 use std::{any::Any, sync::Arc};
 
 use crate::sql::arrow_sql_gen::mysql::map_column_to_data_type;
+use crate::sql::arrow_sql_gen::mysql::MysqlZeroDateBehavior;
 use crate::sql::arrow_sql_gen::{self, mysql::rows_to_arrow};
 use async_stream::stream;
 use datafusion::arrow::datatypes::{Field, Schema, SchemaRef};
@@ -45,9 +46,18 @@ pub enum Error {
 
 pub struct MySQLConnection {
     pub conn: Arc<Mutex<Conn>>,
+    pub zero_date_behavior: MysqlZeroDateBehavior,
 }
 
 impl MySQLConnection {
+    /// Set the zero-date handling behavior for this connection. Affects both schema inference
+    /// (`get_schema`) and row decoding (`query_arrow`). See [`MysqlZeroDateBehavior`].
+    #[must_use]
+    pub fn with_zero_date_behavior(mut self, behavior: MysqlZeroDateBehavior) -> Self {
+        self.zero_date_behavior = behavior;
+        self
+    }
+
     /// Create a [`TableReference`] in a manner that properly handles the unique quote style of MySQL.
     ///
     /// [`TableReference::from`] uses `DefaultDialect` and therefore gets quoting incorrect.
@@ -90,6 +100,7 @@ impl<'a> AsyncDbConnection<Conn, &'a (dyn ToValue + Sync)> for MySQLConnection {
     fn new(conn: Conn) -> Self {
         MySQLConnection {
             conn: Arc::new(Mutex::new(conn)),
+            zero_date_behavior: MysqlZeroDateBehavior::default(),
         }
     }
 
@@ -175,7 +186,10 @@ impl<'a> AsyncDbConnection<Conn, &'a (dyn ToValue + Sync)> for MySQLConnection {
             },
         };
 
-        Ok(columns_meta_to_schema(columns_meta).context(super::UnableToGetSchemaSnafu)?)
+        Ok(
+            columns_meta_to_schema(columns_meta, self.zero_date_behavior)
+                .context(super::UnableToGetSchemaSnafu)?,
+        )
     }
 
     async fn query_arrow(
@@ -188,6 +202,7 @@ impl<'a> AsyncDbConnection<Conn, &'a (dyn ToValue + Sync)> for MySQLConnection {
         let sql = sql.replace('"', "");
 
         let conn = Arc::clone(&self.conn);
+        let zero_date_behavior = self.zero_date_behavior;
 
         let mut stream = Box::pin(stream! {
             let mut conn = conn.lock().await;
@@ -209,7 +224,7 @@ impl<'a> AsyncDbConnection<Conn, &'a (dyn ToValue + Sync)> for MySQLConnection {
                     .collect::<Result<Vec<_>, _>>()
                     .context(QuerySnafu)?;
 
-                let rec = rows_to_arrow(&rows, &projected_schema).context(ConversionSnafu)?;
+                let rec = rows_to_arrow(&rows, &projected_schema, zero_date_behavior).context(ConversionSnafu)?;
                 yield Ok::<_, Error>(rec)
             }
         });
@@ -247,7 +262,10 @@ impl<'a> AsyncDbConnection<Conn, &'a (dyn ToValue + Sync)> for MySQLConnection {
     }
 }
 
-fn columns_meta_to_schema(columns_meta: Vec<Row>) -> Result<SchemaRef> {
+fn columns_meta_to_schema(
+    columns_meta: Vec<Row>,
+    zero_date_behavior: MysqlZeroDateBehavior,
+) -> Result<SchemaRef> {
     let mut fields = Vec::new();
 
     for row in columns_meta.iter() {
@@ -263,8 +281,26 @@ fn columns_meta_to_schema(columns_meta: Vec<Row>) -> Result<SchemaRef> {
             field: "Null".to_string(),
         })?;
 
-        let nullable = nullable_str == "YES";
         let column_type = map_str_type_to_column_type(&column_name, &data_type)?;
+
+        // For date/time columns, force nullable=true when zero_date_behavior is Null because
+        // MySQL's '0000-00-00' / '0000-00-00 00:00:00' sentinel cannot be represented in Arrow
+        // and is coerced to NULL by the row decoder. Honoring `NOT NULL` on such columns would
+        // cause Arrow's RecordBatch validation to fail at scan time.
+        let is_temporal = matches!(
+            column_type,
+            ColumnType::MYSQL_TYPE_DATE
+                | ColumnType::MYSQL_TYPE_DATETIME
+                | ColumnType::MYSQL_TYPE_TIMESTAMP
+                | ColumnType::MYSQL_TYPE_TIMESTAMP2
+                | ColumnType::MYSQL_TYPE_DATETIME2
+                | ColumnType::MYSQL_TYPE_NEWDATE
+        );
+        let nullable = if is_temporal && zero_date_behavior == MysqlZeroDateBehavior::Null {
+            true
+        } else {
+            nullable_str == "YES"
+        };
         let column_is_binary = map_str_type_to_is_binary(&data_type);
         let column_is_enum = map_str_type_to_is_enum(&data_type);
         let column_use_large_str_or_blob = map_str_type_to_use_large_str_or_blob(&data_type);

--- a/core/src/sql/db_connection_pool/mysqlpool.rs
+++ b/core/src/sql/db_connection_pool/mysqlpool.rs
@@ -10,9 +10,12 @@ use secrecy::{ExposeSecret, SecretBox, SecretString};
 use snafu::{ResultExt, Snafu};
 
 use crate::{
-    sql::db_connection_pool::{
-        dbconnection::{mysqlconn::MySQLConnection, AsyncDbConnection, DbConnection},
-        JoinPushDown,
+    sql::{
+        arrow_sql_gen::mysql::MysqlZeroDateBehavior,
+        db_connection_pool::{
+            dbconnection::{mysqlconn::MySQLConnection, AsyncDbConnection, DbConnection},
+            JoinPushDown,
+        },
     },
     util::{self, ns_lookup::verify_ns_lookup_and_tcp_connect},
 };
@@ -55,6 +58,7 @@ pub enum Error {
 pub struct MySQLConnectionPool {
     pool: Arc<mysql_async::Pool>,
     join_push_down: JoinPushDown,
+    zero_date_behavior: MysqlZeroDateBehavior,
 }
 
 #[allow(dead_code)]
@@ -223,7 +227,23 @@ impl MySQLConnectionPool {
         Ok(Self {
             pool: Arc::new(pool),
             join_push_down,
+            zero_date_behavior: MysqlZeroDateBehavior::default(),
         })
+    }
+
+    /// Override the [`MysqlZeroDateBehavior`] used by connections created from this pool.
+    /// Connections created before this call are unaffected.
+    #[must_use]
+    pub fn with_zero_date_behavior(mut self, behavior: MysqlZeroDateBehavior) -> Self {
+        self.zero_date_behavior = behavior;
+        self
+    }
+
+    /// Returns the [`MysqlZeroDateBehavior`] that will be applied to connections created from
+    /// this pool.
+    #[must_use]
+    pub fn zero_date_behavior(&self) -> MysqlZeroDateBehavior {
+        self.zero_date_behavior
     }
 
     /// Returns a direct connection to the underlying database.
@@ -235,7 +255,7 @@ impl MySQLConnectionPool {
         let pool = Arc::clone(&self.pool);
         let conn = pool.get_conn().await.context(MySQLConnectionSnafu)?;
 
-        Ok(MySQLConnection::new(conn))
+        Ok(MySQLConnection::new(conn).with_zero_date_behavior(self.zero_date_behavior))
     }
 
     pub fn metrics(&self) -> Arc<Metrics> {
@@ -299,7 +319,9 @@ impl DbConnectionPool<mysql_async::Conn, &'static (dyn ToValue + Sync)> for MySQ
         let pool = Arc::clone(&self.pool);
         let conn = pool.get_conn().await.context(MySQLConnectionSnafu)?;
 
-        Ok(Box::new(MySQLConnection::new(conn)))
+        Ok(Box::new(
+            MySQLConnection::new(conn).with_zero_date_behavior(self.zero_date_behavior),
+        ))
     }
 
     fn join_push_down(&self) -> JoinPushDown {


### PR DESCRIPTION
## Summary

Adds a new `MysqlZeroDateBehavior` knob (`Null` default / `Error`) that controls how the MySQL connector handles MySQL's `'0000-00-00'` / `'0000-00-00 00:00:00'` zero-date sentinel for `DATE` / `DATETIME` / `TIMESTAMP` columns.

This restores the pre-#490 user-visible behavior by **default** while still letting consumers opt into strict validation.

## Background

MySQL allows zero-date sentinel values (`0000-00-00`, `0000-00-00 00:00:00`) in `DATE` / `DATETIME` / `TIMESTAMP` columns when `NO_ZERO_DATE` / `NO_ZERO_IN_DATE` are not in `sql_mode`. This occurs in schemas where columns are declared `NOT NULL DEFAULT '0000-00-00 00:00:00'`.

Arrow has no representation for the zero-date sentinel — `chrono::NaiveDate::from_ymd_opt(0, 0, 0)` returns `None` because year/month/day = 0 is not a valid date in any calendar. The historical row decoder in `arrow_sql_gen::mysql` (`rows_to_arrow`) already coerced these to Arrow `NULL`s via `append_null()`.

PR #490 made `columns_meta_to_schema` parse `Null: NO` from `SHOW COLUMNS` and emit `nullable=false` Arrow fields, and made `rows_to_arrow` propagate `is_nullable()` from `projected_schema`. The combination caused `RecordBatch::try_new_with_options` to reject any batch where a `NOT NULL` date column had a row containing the zero-date sentinel:

```
Column 'DateCreated' is declared as non-nullable but contains null values
```

This is a regression for any caller relying on the prior silent coercion (Spice runtime in particular).

## Change

Adds a public enum:

```rust
pub enum MysqlZeroDateBehavior {
    Null,   // default — coerce to Arrow NULL, widen schema to nullable
    Error,  // strict — return Error::ZeroDateEncountered, honor source NOT NULL
}
```

Threaded through:

- `rows_to_arrow(rows, projected_schema, zero_date_behavior)` — row decoder consults the enum at the two existing zero-date sites and either returns `None` (Null) or fails with `Error::ZeroDateEncountered { column }` (Error). Field nullability for date/time columns is also widened in the per-batch schema when behavior is `Null`.
- `columns_meta_to_schema(columns_meta, zero_date_behavior)` — when `Null`, force `nullable=true` for `MYSQL_TYPE_DATE` / `DATETIME` / `TIMESTAMP` / `TIMESTAMP2` / `DATETIME2` / `NEWDATE` regardless of `Null=NO`. Non-temporal columns still honor source nullability exactly. When `Error`, all source nullability is honored exactly (the post-#490 behavior, now safe because the row decoder hard-fails).
- `MySQLConnection` — new `zero_date_behavior` field + `with_zero_date_behavior(b)` builder; `get_schema` and `query_arrow` consult it.
- `MySQLConnectionPool` — new field + `with_zero_date_behavior(b)` / `zero_date_behavior()` accessors. `connect()` and `connect_direct()` propagate to each new `MySQLConnection`.
- `MySQLTableFactory::with_zero_date_behavior(b)` convenience setter.

`Default` is `Null`, so all existing callers preserve current (working) behavior with **zero source changes**.

## Why widen nullability in the schema

The row decoder cannot emit Arrow NULLs into a non-nullable Arrow field — `RecordBatch::try_new_with_options` rejects the batch. When `Null` mode is in effect, the schema must report `nullable=true` for any column that *could* contain a zero-date, which (since we can't know without scanning) means all date/time columns. This trades one bit of metadata fidelity for the ability to actually load the data — the same trade-off the row decoder has always implicitly made.

## Verification

Tested locally end-to-end against MySQL 8.4 with `sql_mode=''`:

```sql
CREATE TABLE some_table (
  id INT PRIMARY KEY,
  name VARCHAR(50) NOT NULL,
  date_created TIMESTAMP NOT NULL DEFAULT '0000-00-00 00:00:00',
  date_modified DATE      NOT NULL DEFAULT '0000-00-00'
);
INSERT INTO some_table VALUES
  (1, 'alice', '2024-01-15 10:00:00', '2024-01-15'),
  (2, 'bob',   '0000-00-00 00:00:00', '0000-00-00'),
  (3, 'carol', '2024-03-20 14:30:00', '2024-03-20');
```

Connecting via the Spice MySQL connector built against this branch:

| Mode | `DESCRIBE` output | `SELECT *` result |
|---|---|---|
| `Null` (default) | `id`/`name` → `NO`, `date_created`/`date_modified` → `YES` | 3 rows; bob's row returns NULL for both date columns |
| `Error` | All four columns → `NO` (source-exact) | Errors with `Encountered MySQL zero date '0000-00-00' in column 'date_created' but mysql_zero_date_behavior is set to 'error'.` |
| `Error` + `WHERE id != 2` | (same schema) | 2 rows succeed (predicate pushdown skips the bad row) |

Pre-fix, the default-mode query would fail with the regression error.

`cargo check`, `cargo clippy --lib -- -D warnings`, and `cargo fmt --check` all clean (`mysql,mysql-federation` features). Pre-existing integration test compile errors in `tests/mysql/common.rs` (bollard private symbols) are unrelated to this change.