### PR TITLE
fix: handle empty projection in SqlTable for count(*) queries

### DIFF
--- a/core/src/sql/sql_provider_datafusion/mod.rs
+++ b/core/src/sql/sql_provider_datafusion/mod.rs
@@ -266,10 +266,12 @@ pub fn project_schema_safe(
     let schema = match projection {
         Some(columns) => {
             if columns.is_empty() {
-                // If the projection is Some([]) then it gets unparsed as `SELECT 1`, so return a schema with a single Int64 column.
-                //
-                // See: <https://github.com/apache/datafusion/blob/83ce79c39412a4f150167d00e40ea05948c4870f/datafusion/sql/src/unparser/plan.rs#L998>
-                Arc::clone(&ONE_COLUMN_SCHEMA)
+                // Empty projection: return empty schema (0 columns).
+                // The SQL will still be `SELECT 1` (SQL syntax requires at least one column),
+                // but the physical output schema must match the logical schema (0 columns)
+                // to satisfy DataFusion's schema consistency check.
+                // The execute() method handles stripping the extra column from the result.
+                Arc::new(Schema::empty())
             } else {
                 Arc::new(schema.project(columns)?)
             }
@@ -281,6 +283,10 @@ pub fn project_schema_safe(
 
 pub struct SqlExec<T, P> {
     projected_schema: SchemaRef,
+    /// Schema of the actual SQL result. When projection is empty, SQL returns
+    /// `SELECT 1` (1 column) but projected_schema is empty (0 columns).
+    /// This field is used to parse the SQL result correctly.
+    sql_schema: SchemaRef,
     pool: Arc<dyn DbConnectionPool<T, P> + Send + Sync>,
     sql: String,
     properties: Arc<PlanProperties>,
@@ -291,6 +297,7 @@ impl<T, P> Clone for SqlExec<T, P> {
     fn clone(&self) -> Self {
         Self {
             projected_schema: Arc::clone(&self.projected_schema),
+            sql_schema: Arc::clone(&self.sql_schema),
             pool: Arc::clone(&self.pool),
             sql: self.sql.clone(),
             properties: self.properties.clone(),
@@ -309,8 +316,17 @@ impl<T, P> SqlExec<T, P> {
     ) -> DataFusionResult<Self> {
         let projected_schema = project_schema_safe(schema, projection)?;
 
+        // When projection is empty, SQL returns `SELECT 1` (1 column) but
+        // projected_schema is empty (0 columns). We need sql_schema to parse
+        // the actual SQL result.
+        let sql_schema = match projection {
+            Some(columns) if columns.is_empty() => Arc::clone(&ONE_COLUMN_SCHEMA),
+            _ => Arc::clone(&projected_schema),
+        };
+
         Ok(Self {
             projected_schema: Arc::clone(&projected_schema),
+            sql_schema,
             pool,
             sql,
             properties: Arc::new(PlanProperties::new(
@@ -567,6 +583,7 @@ impl<T: 'static, P: 'static> ExecutionPlan for SqlExec<T, P> {
 
         let mut new_exec = Self {
             projected_schema: Arc::clone(&self.projected_schema),
+            sql_schema: Arc::clone(&self.sql_schema),
             pool: Arc::clone(&self.pool),
             sql: new_sql,
             properties: self.properties.clone(),
@@ -607,6 +624,7 @@ impl<T: 'static, P: 'static> ExecutionPlan for SqlExec<T, P> {
 
         Some(Arc::new(Self {
             projected_schema: Arc::clone(&self.projected_schema),
+            sql_schema: Arc::clone(&self.sql_schema),
             pool: Arc::clone(&self.pool),
             sql: new_sql,
             properties: self.properties.clone(),
@@ -650,6 +668,7 @@ impl<T: 'static, P: 'static> ExecutionPlan for SqlExec<T, P> {
 
         let new_exec = Self {
             projected_schema: Arc::clone(&self.projected_schema),
+            sql_schema: Arc::clone(&self.sql_schema),
             pool: Arc::clone(&self.pool),
             sql: new_sql,
             properties: self.properties.clone(),
@@ -670,12 +689,40 @@ impl<T: 'static, P: 'static> ExecutionPlan for SqlExec<T, P> {
         let sql = self.sql().map_err(to_execution_error)?;
         tracing::debug!("SqlExec sql: {sql}");
 
-        let schema = self.schema();
+        let projected_schema = self.schema();
 
-        let fut = get_stream(Arc::clone(&self.pool), sql, Arc::clone(&schema));
+        // When projection is empty (0 columns), SQL still returns 1 column (`SELECT 1`)
+        // but we need to return 0-column batches to match the logical schema.
+        // We execute with sql_schema (1 column) and strip the result to 0 columns.
+        if projected_schema.fields().is_empty() {
+            let sql_schema = Arc::clone(&self.sql_schema);
+            let pool = Arc::clone(&self.pool);
+            let empty_schema = Arc::clone(&projected_schema);
+            let empty_schema_for_stream = Arc::clone(&empty_schema);
+
+            let fut = async move {
+                let stream = get_stream(pool, sql, sql_schema).await?;
+                // Map each batch to an empty batch (0 columns, same row count)
+                let empty_stream = stream.map_ok(move |_b| {
+                    datafusion::arrow::record_batch::RecordBatch::new_empty(Arc::clone(
+                        &empty_schema,
+                    ))
+                });
+                let result: SendableRecordBatchStream = Box::pin(RecordBatchStreamAdapter::new(
+                    Arc::clone(&empty_schema_for_stream),
+                    empty_stream,
+                ));
+                Ok::<SendableRecordBatchStream, DataFusionError>(result)
+            };
+
+            let stream = futures::stream::once(fut).try_flatten();
+            return Ok(Box::pin(RecordBatchStreamAdapter::new(projected_schema, stream)));
+        }
+
+        let fut = get_stream(Arc::clone(&self.pool), sql, Arc::clone(&projected_schema));
 
         let stream = futures::stream::once(fut).try_flatten();
-        Ok(Box::pin(RecordBatchStreamAdapter::new(schema, stream)))
+        Ok(Box::pin(RecordBatchStreamAdapter::new(projected_schema, stream)))
     }
 }
 

--- a/core/src/sql/sql_provider_datafusion/mod.rs
+++ b/core/src/sql/sql_provider_datafusion/mod.rs
@@ -716,13 +716,19 @@ impl<T: 'static, P: 'static> ExecutionPlan for SqlExec<T, P> {
             };
 
             let stream = futures::stream::once(fut).try_flatten();
-            return Ok(Box::pin(RecordBatchStreamAdapter::new(projected_schema, stream)));
+            return Ok(Box::pin(RecordBatchStreamAdapter::new(
+                projected_schema,
+                stream,
+            )));
         }
 
         let fut = get_stream(Arc::clone(&self.pool), sql, Arc::clone(&projected_schema));
 
         let stream = futures::stream::once(fut).try_flatten();
-        Ok(Box::pin(RecordBatchStreamAdapter::new(projected_schema, stream)))
+        Ok(Box::pin(RecordBatchStreamAdapter::new(
+            projected_schema,
+            stream,
+        )))
     }
 }
 

--- a/core/src/sql/sql_provider_datafusion/mod.rs
+++ b/core/src/sql/sql_provider_datafusion/mod.rs
@@ -702,11 +702,17 @@ impl<T: 'static, P: 'static> ExecutionPlan for SqlExec<T, P> {
 
             let fut = async move {
                 let stream = get_stream(pool, sql, sql_schema).await?;
-                // Map each batch to an empty batch (0 columns, same row count)
-                let empty_stream = stream.map_ok(move |_b| {
-                    datafusion::arrow::record_batch::RecordBatch::new_empty(Arc::clone(
-                        &empty_schema,
-                    ))
+                // Strip columns but preserve row count.
+                // RecordBatch::new_empty() hardcodes row_count to 0, which would
+                // break count(*) queries. Use try_new_with_options instead.
+                let empty_stream = stream.map_ok(move |b| {
+                    datafusion::arrow::record_batch::RecordBatch::try_new_with_options(
+                        Arc::clone(&empty_schema),
+                        vec![],
+                        &datafusion::arrow::record_batch::RecordBatchOptions::new()
+                            .with_row_count(Some(b.num_rows())),
+                    )
+                    .expect("empty schema with valid row_count should never fail")
                 });
                 let result: SendableRecordBatchStream = Box::pin(RecordBatchStreamAdapter::new(
                     Arc::clone(&empty_schema_for_stream),


### PR DESCRIPTION
## Summary

Fixes a schema mismatch error when executing ` SELECT count(*) ` or ` SELECT count(1) ` queries against SQL-backed tables (MySQL, PostgreSQL, SQLite, etc.).

## Problem

When DataFusion's ` OptimizeProjections ` rule optimizes ` SELECT count(*) ` queries, it reduces the TableScan projection to 0 columns since no columns are referenced. Previously, ` SqlTable ` would return a 1-column schema (` ONE_COLUMN_SCHEMA `) for empty projections (since the SQL ` SELECT 1 ` returns 1 column), causing a physical vs logical schema mismatch:

`
Physical input schema should be the same as the one converted from logical input schema. 
Differences: Different number of fields: (physical) 1 vs (logical) 0
`

This affected ` count(*) `, ` count(1) `, and any aggregation that doesn't reference table columns. ` count(col) ` worked fine because the projection retained at least 1 column.

## Fix

1. **` project_schema_safe() `**: Returns an empty schema (0 columns) for empty projections instead of ` ONE_COLUMN_SCHEMA `. This matches the logical schema that DataFusion expects.

2. **` SqlExec `**: Adds a ` sql_schema ` field that tracks the actual SQL result schema. When projection is empty, ` sql_schema ` is ` ONE_COLUMN_SCHEMA ` (for ` SELECT 1 `) while ` projected_schema ` is empty.

3. **` SqlExec::execute() `**: When projection is empty, executes the SQL with ` sql_schema ` (1 column) and strips the result to 0-column batches that preserve row count, satisfying DataFusion's schema consistency check.

## Testing

Verified with a standalone reproduction against MySQL 8.0:

`
Test 1: SELECT * FROM mysql.testdb.orders LIMIT 1         ... OK (1 rows)
Test 2: SELECT count(id) AS total FROM mysql.testdb.orders ... OK (1 rows)
Test 3: SELECT count(*) AS total FROM mysql.testdb.orders  ... OK (1 rows)  <- was FAILED
Test 4: SELECT count(1) AS total FROM mysql.testdb.orders  ... OK (1 rows)  <- was FAILED
`

All ` SqlExec ` struct construction sites (sort pushdown, limit pushdown, filter pushdown) are updated to propagate the ` sql_schema ` field.