### PR TITLE
fix: Align SqlTable::supports_filters_pushdown with scan_to_sql by using Unparser

### DIFF
--- a/core/src/sql/sql_provider_datafusion/expr.rs
+++ b/core/src/sql/sql_provider_datafusion/expr.rs
@@ -267,20 +267,22 @@ fn handle_cast(cast: &Cast, engine: Option<Engine>, expr: &Expr) -> Result<Strin
     }
 }
 
-// Helper function to check if expression contains subquery
+// Helper function to check if expression contains subquery or outer reference
 use datafusion::common::tree_node::{TreeNode, TreeNodeRecursion};
 
-#[allow(dead_code)]
-pub(super) fn expr_contains_subquery(expr: &Expr) -> datafusion::error::Result<bool> {
-    let mut contains_subquery = false;
+pub(super) fn expr_contains_subquery_or_outer_ref(expr: &Expr) -> datafusion::error::Result<bool> {
+    let mut found = false;
     expr.apply(|expr| match expr {
-        Expr::ScalarSubquery(_) | Expr::InSubquery(_) | Expr::Exists(_) => {
-            contains_subquery = true;
+        Expr::ScalarSubquery(_)
+        | Expr::InSubquery(_)
+        | Expr::Exists(_)
+        | Expr::OuterReferenceColumn(_, _) => {
+            found = true;
             Ok(TreeNodeRecursion::Stop)
         }
         _ => Ok(TreeNodeRecursion::Continue),
     })?;
-    Ok(contains_subquery)
+    Ok(found)
 }
 
 #[cfg(test)]

--- a/core/src/sql/sql_provider_datafusion/mod.rs
+++ b/core/src/sql/sql_provider_datafusion/mod.rs
@@ -293,11 +293,27 @@ impl<T, P> TableProvider for SqlTable<T, P> {
         &self,
         filters: &[&Expr],
     ) -> DataFusionResult<Vec<TableProviderFilterPushDown>> {
+        let dialect = self.dialect_arc();
+        let unparser = Unparser::new(dialect.as_ref());
+
         let filter_push_down: Vec<TableProviderFilterPushDown> = filters
             .iter()
-            .map(|f| match expr::to_sql_with_engine(f, self.engine) {
-                Ok(_) => TableProviderFilterPushDown::Exact,
-                Err(_) => TableProviderFilterPushDown::Unsupported,
+            .map(|f| {
+                // Expressions containing subqueries or outer references must not be
+                // pushed down. Subqueries are handled at the plan level and may
+                // reference tables in other databases not accessible from this
+                // connection. Outer references refer to columns from an enclosing
+                // query that the table provider cannot resolve.
+                if expr::expr_contains_subquery_or_outer_ref(f).unwrap_or(true) {
+                    return TableProviderFilterPushDown::Unsupported;
+                }
+                // Use the same Unparser that scan_to_sql() uses for actual SQL
+                // generation, so the capability check matches what can really
+                // be converted to SQL for the target dialect.
+                match unparser.expr_to_sql(f) {
+                    Ok(_) => TableProviderFilterPushDown::Exact,
+                    Err(_) => TableProviderFilterPushDown::Unsupported,
+                }
             })
             .collect();
 


### PR DESCRIPTION
`SqlTable::supports_filters_pushdown()` used `expr::to_sql_with_engine()` to check filter pushdown capability, while `scan_to_sql()` used `Unparser::expr_to_sql()` for actual SQL generation. The custom converter has a narrow `match` with a `_ => Err` catch-all that rejects valid expressions like `CASE WHEN`, `IS NULL`, and `IS NOT NULL` — even though the Unparser handles them correctly.

This mismatch causes filters to be incorrectly reported as `Unsupported`, preventing pushdown of expressions that `scan_to_sql()` can convert to SQL.

**Changes:**
- Switch `supports_filters_pushdown()` to use `Unparser::expr_to_sql()` with the table's dialect, matching the converter used by `scan_to_sql()`
- Reject subqueries (`Exists`, `InSubquery`, `ScalarSubquery`) and `OuterReferenceColumn` before the Unparser check, since the Unparser can convert these to SQL text but they must not be pushed into `TableScan.full_filters` — subqueries reference tables potentially in other databases, and outer references belong to an enclosing query the table provider cannot resolve