### PR TITLE
Add `ignored_index_prefixes` to `TableDefinition` for externally-managed index drift exclusion

### DIFF
--- a/core/src/duckdb/creator.rs
+++ b/core/src/duckdb/creator.rs
@@ -15,7 +15,7 @@ use itertools::Itertools;
 use snafu::prelude::*;
 use std::collections::HashSet;
 use std::fmt::Display;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 use super::DuckDB;
 use crate::util::{
@@ -57,7 +57,8 @@ pub struct TableDefinition {
     /// Index name prefixes that are managed externally to the write pipeline.
     /// Indexes whose names start with any of these prefixes are excluded from
     /// the drift-check comparison in [`TableManager::verify_indexes_match`].
-    ignored_index_prefixes: Vec<String>,
+    /// Uses interior mutability so callers can register prefixes after construction.
+    ignored_index_prefixes: Mutex<Vec<String>>,
 }
 
 impl TableDefinition {
@@ -68,7 +69,7 @@ impl TableDefinition {
             schema,
             constraints: None,
             indexes: Vec::new(),
-            ignored_index_prefixes: Vec::new(),
+            ignored_index_prefixes: Mutex::new(Vec::new()),
         }
     }
 
@@ -84,28 +85,27 @@ impl TableDefinition {
         self
     }
 
-    /// Register index name prefixes that are managed outside the write pipeline
-    /// (e.g. by the application layer). Indexes matching these prefixes are
-    /// excluded from the index drift check so that externally-managed indexes do
-    /// not cause refresh failures.
-    #[must_use]
-    pub fn with_ignored_index_prefixes(mut self, prefixes: Vec<String>) -> Self {
-        self.ignored_index_prefixes = prefixes;
-        self
-    }
-
-    pub fn ignored_index_prefixes(&self) -> &[String] {
-        &self.ignored_index_prefixes
+    /// Register an index name prefix whose indexes are managed outside the write pipeline.
+    /// Indexes whose names start with this prefix are excluded from the drift-check
+    /// comparison so that externally-managed indexes do not cause refresh failures.
+    ///
+    /// May be called after construction (e.g. after the vector engine is configured).
+    pub fn add_ignored_index_prefix(&self, prefix: impl Into<String>) {
+        self.ignored_index_prefixes
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .push(prefix.into());
     }
 
     #[must_use]
     pub fn with_name(self, name: RelationName) -> Self {
+        let prefixes = self.ignored_index_prefixes.into_inner().unwrap_or_default();
         Self {
             name,
             schema: self.schema,
             constraints: self.constraints,
             indexes: self.indexes,
-            ignored_index_prefixes: self.ignored_index_prefixes,
+            ignored_index_prefixes: Mutex::new(prefixes),
         }
     }
 
@@ -657,7 +657,9 @@ impl TableManager {
             .map(|index| index.replace(&self.table_name().to_string(), ""))
             .collect::<HashSet<_>>();
 
-        let ignored_prefixes = self.table_definition.ignored_index_prefixes();
+        let ignored_prefixes = self.table_definition.ignored_index_prefixes
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         let actual_indexes_str_map = actual_indexes_str_map
             .iter()
             .filter(|index| !ignored_prefixes.iter().any(|prefix| index.starts_with(prefix.as_str())))

--- a/core/src/duckdb/creator.rs
+++ b/core/src/duckdb/creator.rs
@@ -639,6 +639,7 @@ impl TableManager {
 
         let actual_indexes_str_map = actual_indexes_str_map
             .iter()
+            .filter(|index| !index.starts_with("__spice_vss_"))
             .map(|index| index.replace(&other_table.table_name().to_string(), ""))
             .collect::<HashSet<_>>();
 

--- a/core/src/duckdb/creator.rs
+++ b/core/src/duckdb/creator.rs
@@ -48,7 +48,7 @@ impl From<TableReference> for RelationName {
 
 /// A table definition, which includes the table name, schema, constraints, and indexes.
 /// This is used to store the definition of a table for a dataset, and can be re-used to create one or more tables (like internal data tables).
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug)]
 pub struct TableDefinition {
     name: RelationName,
     schema: SchemaRef,
@@ -116,6 +116,25 @@ impl TableDefinition {
     pub fn schema(&self) -> SchemaRef {
         Arc::clone(&self.schema)
     }
+}
+
+impl Clone for TableDefinition {
+    fn clone(&self) -> Self {
+        let prefixes = self.ignored_index_prefixes
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .clone();
+        Self {
+            name: self.name.clone(),
+            schema: Arc::clone(&self.schema),
+            constraints: self.constraints.clone(),
+            indexes: self.indexes.clone(),
+            ignored_index_prefixes: Mutex::new(prefixes),
+        }
+    }
+}
+
+impl TableDefinition {
 
     pub fn indexes(&self) -> &[(ColumnReference, IndexType)] {
         &self.indexes

--- a/core/src/duckdb/creator.rs
+++ b/core/src/duckdb/creator.rs
@@ -118,9 +118,19 @@ impl TableDefinition {
     }
 }
 
+impl PartialEq for TableDefinition {
+    fn eq(&self, other: &Self) -> bool {
+        self.name == other.name
+            && self.schema == other.schema
+            && self.constraints == other.constraints
+            && self.indexes == other.indexes
+    }
+}
+
 impl Clone for TableDefinition {
     fn clone(&self) -> Self {
-        let prefixes = self.ignored_index_prefixes
+        let prefixes = self
+            .ignored_index_prefixes
             .lock()
             .unwrap_or_else(|e| e.into_inner())
             .clone();
@@ -135,7 +145,6 @@ impl Clone for TableDefinition {
 }
 
 impl TableDefinition {
-
     pub fn indexes(&self) -> &[(ColumnReference, IndexType)] {
         &self.indexes
     }
@@ -676,12 +685,18 @@ impl TableManager {
             .map(|index| index.replace(&self.table_name().to_string(), ""))
             .collect::<HashSet<_>>();
 
-        let ignored_prefixes = self.table_definition.ignored_index_prefixes
+        let ignored_prefixes = self
+            .table_definition
+            .ignored_index_prefixes
             .lock()
             .unwrap_or_else(|e| e.into_inner());
         let actual_indexes_str_map = actual_indexes_str_map
             .iter()
-            .filter(|index| !ignored_prefixes.iter().any(|prefix| index.starts_with(prefix.as_str())))
+            .filter(|index| {
+                !ignored_prefixes
+                    .iter()
+                    .any(|prefix| index.starts_with(prefix.as_str()))
+            })
             .map(|index| index.replace(&other_table.table_name().to_string(), ""))
             .collect::<HashSet<_>>();
 

--- a/core/src/duckdb/creator.rs
+++ b/core/src/duckdb/creator.rs
@@ -54,6 +54,10 @@ pub struct TableDefinition {
     schema: SchemaRef,
     constraints: Option<Constraints>,
     indexes: Vec<(ColumnReference, IndexType)>,
+    /// Index name prefixes that are managed externally to the write pipeline.
+    /// Indexes whose names start with any of these prefixes are excluded from
+    /// the drift-check comparison in [`TableManager::verify_indexes_match`].
+    ignored_index_prefixes: Vec<String>,
 }
 
 impl TableDefinition {
@@ -64,6 +68,7 @@ impl TableDefinition {
             schema,
             constraints: None,
             indexes: Vec::new(),
+            ignored_index_prefixes: Vec::new(),
         }
     }
 
@@ -79,6 +84,20 @@ impl TableDefinition {
         self
     }
 
+    /// Register index name prefixes that are managed outside the write pipeline
+    /// (e.g. by the application layer). Indexes matching these prefixes are
+    /// excluded from the index drift check so that externally-managed indexes do
+    /// not cause refresh failures.
+    #[must_use]
+    pub fn with_ignored_index_prefixes(mut self, prefixes: Vec<String>) -> Self {
+        self.ignored_index_prefixes = prefixes;
+        self
+    }
+
+    pub fn ignored_index_prefixes(&self) -> &[String] {
+        &self.ignored_index_prefixes
+    }
+
     #[must_use]
     pub fn with_name(self, name: RelationName) -> Self {
         Self {
@@ -86,6 +105,7 @@ impl TableDefinition {
             schema: self.schema,
             constraints: self.constraints,
             indexes: self.indexes,
+            ignored_index_prefixes: self.ignored_index_prefixes,
         }
     }
 
@@ -637,9 +657,10 @@ impl TableManager {
             .map(|index| index.replace(&self.table_name().to_string(), ""))
             .collect::<HashSet<_>>();
 
+        let ignored_prefixes = self.table_definition.ignored_index_prefixes();
         let actual_indexes_str_map = actual_indexes_str_map
             .iter()
-            .filter(|index| !index.starts_with("__spice_vss_"))
+            .filter(|index| !ignored_prefixes.iter().any(|prefix| index.starts_with(prefix.as_str())))
             .map(|index| index.replace(&other_table.table_name().to_string(), ""))
             .collect::<HashSet<_>>();
 


### PR DESCRIPTION
#### Problem
  Applications that create indexes on DuckDB internal tables outside the write pipeline (i.e. not registered in TableDefinition) hit spurious refresh failures. On each overwrite refresh the writer compares the indexes on the previous
  internal table with the new empty one. Any index not defined in TableDefinition is flagged as "unexpected" and the refresh is aborted:

Unexpected index(es) detected in table '__data_foo_123': __spice_vss_foo_embedding.
  Indexes do not match between the new table and the existing table.

#### Solution
Add ignored_index_prefixes: Mutex<Vec<String>> to TableDefinition. Index names matching any registered prefix are excluded from both sides of verify_indexes_match, so they are invisible to the drift check. The Mutex allows callers to
  register prefixes after construction — important when the decision to create such indexes is made in a separate setup step (e.g. vector engine registration) from table creation.

  table_definition.add_ignored_index_prefix("__spice_vss_");

#### What it is not
This does not change index creation — callers remain fully responsible for creating and managing those indexes. This only prevents the drift check from failing on indexes it doesn't own.