### PR TITLE
Upgrade to DuckDB 1.5.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1119,6 +1119,7 @@ version = "7.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "958c5d6ecf1f214b4c2bbbbf6ab9523a864bd136dcf71a7e8904799acfe1ad47"
 dependencies = [
+ "crossterm",
  "unicode-segmentation",
  "unicode-width",
 ]
@@ -1344,6 +1345,29 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crossterm"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
+dependencies = [
+ "bitflags 2.11.1",
+ "crossterm_winapi",
+ "document-features",
+ "parking_lot",
+ "rustix 1.1.4",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "crunchy"
@@ -2442,6 +2466,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "document-features"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
+dependencies = [
+ "litrs",
+]
+
+[[package]]
 name = "dpi"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2449,15 +2482,16 @@ checksum = "d8b14ccef22fc6f5a8f4d7d768562a182c04ce9a3b3157b91390b52ddfdf1a76"
 
 [[package]]
 name = "duckdb"
-version = "1.4.4"
-source = "git+https://github.com/spiceai/duckdb-rs.git?rev=f4096c7592ed46b9e68755a49252d69783dece96#f4096c7592ed46b9e68755a49252d69783dece96"
+version = "1.10502.0"
+source = "git+https://github.com/spiceai/duckdb-rs.git?rev=119fc5df0568fa165154697eb9c6a302938fe848#119fc5df0568fa165154697eb9c6a302938fe848"
 dependencies = [
  "arrow",
  "cast",
+ "comfy-table",
  "fallible-iterator 0.3.0",
  "fallible-streaming-iterator",
  "hashlink",
- "libduckdb-sys 1.4.4",
+ "libduckdb-sys 1.10502.0",
  "num",
  "num-integer",
  "r2d2",
@@ -3685,8 +3719,8 @@ dependencies = [
 
 [[package]]
 name = "libduckdb-sys"
-version = "1.4.4"
-source = "git+https://github.com/spiceai/duckdb-rs.git?rev=f4096c7592ed46b9e68755a49252d69783dece96#f4096c7592ed46b9e68755a49252d69783dece96"
+version = "1.10502.0"
+source = "git+https://github.com/spiceai/duckdb-rs.git?rev=119fc5df0568fa165154697eb9c6a302938fe848#119fc5df0568fa165154697eb9c6a302938fe848"
 dependencies = [
  "cc",
  "flate2",
@@ -3795,6 +3829,12 @@ name = "litemap"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
+
+[[package]]
+name = "litrs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
 
 [[package]]
 name = "lock_api"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ datafusion-proto = { version = "52" }
 datafusion-physical-expr = { version = "52" }
 datafusion-physical-plan = { version = "52" }
 datafusion-table-providers = { path = "core" }
-duckdb = { git = "https://github.com/spiceai/duckdb-rs.git", rev = "f4096c7592ed46b9e68755a49252d69783dece96" } # Forked to add support for duckdb_scan_arrow, pending: https://github.com/duckdb/duckdb-rs/pull/488
+duckdb = { git = "https://github.com/spiceai/duckdb-rs.git", rev = "119fc5df0568fa165154697eb9c6a302938fe848" } # Forked to add support for duckdb_scan_arrow, pending: https://github.com/duckdb/duckdb-rs/pull/488
 adbc_core = { version = "0.23" }
 adbc_driver_manager = { version = "0.23" }
 parquet = "57"

--- a/core/src/duckdb/creator.rs
+++ b/core/src/duckdb/creator.rs
@@ -848,9 +848,9 @@ pub(crate) mod tests {
         datasource::sink::DataSink,
         execution::{SendableRecordBatchStream, TaskContext},
         logical_expr::dml::InsertOp,
-        parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder,
         physical_plan::memory::MemoryStream,
     };
+    use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
     use tracing::subscriber::DefaultGuard;
     use tracing_subscriber::EnvFilter;
 
@@ -1818,8 +1818,8 @@ pub(crate) mod tests {
             insta::with_settings!({
                 filters => vec![
                     (r"Total Time: \d+\.\d+s", "Total Time: replaced"),
-                    (r"\(\d+\.\d+s\)", "(0.00s)"),
-                    (r"│__data_test_table_\d+│\n│\s+\d+\s+│", "│__data_test_table_redacted│\n│     redacted     │"),
+                    (r"\(?\d+\.\d+s\)?", "0.00s"),
+                    (r"(│\s+memory\.main\s+│\n)?│\.?__data_test_table_\d+│\n│\s+\d+\s+│", "│__data_test_table_redacted│\n│     redacted     │"),
                 ],
             }, {
                 insta::assert_snapshot!(format!("explain_analyze_{idx}"), explain_result);
@@ -1954,8 +1954,8 @@ pub(crate) mod tests {
             insta::with_settings!({
                 filters => vec![
                     (r"Total Time: \d+\.\d+s", "Total Time: replaced"),
-                    (r"\(\d+\.\d+s\)", "(0.00s)"),
-                    (r"│__data_test_table_\d+│\n│\s+\d+\s+│", "│__data_test_table_redacted│\n│     redacted     │"),
+                    (r"\(?\d+\.\d+s\)?", "0.00s"),
+                    (r"(│\s+memory\.main\s+│\n)?│\.?__data_test_table_\d+│\n│\s+\d+\s+│", "│__data_test_table_redacted│\n│     redacted     │"),
                 ],
             }, {
                 insta::assert_snapshot!(format!("explain_analyze_multiple_indexes_{idx}"), explain_result);
@@ -2064,8 +2064,8 @@ pub(crate) mod tests {
             insta::with_settings!({
                 filters => vec![
                     (r"Total Time: \d+\.\d+s", "Total Time: replaced"),
-                    (r"\(\d+\.\d+s\)", "(0.00s)"),
-                    (r"│__data_test_table_\d+│\n│\s+\d+\s+│", "│__data_test_table_redacted│\n│     redacted     │"),
+                    (r"\(?\d+\.\d+s\)?", "0.00s"),
+                    (r"(│\s+memory\.main\s+│\n)?│\.?__data_test_table_\d+│\n│\s+\d+\s+│", "│__data_test_table_redacted│\n│     redacted     │"),
                 ],
             }, {
                 insta::assert_snapshot!(format!("explain_analyze_primary_key_and_index_{idx}"), explain_result);

--- a/core/src/duckdb/snapshots/datafusion_table_providers__duckdb__creator__tests__explain_analyze_0.snap
+++ b/core/src/duckdb/snapshots/datafusion_table_providers__duckdb__creator__tests__explain_analyze_0.snap
@@ -19,8 +19,9 @@ EXPLAIN ANALYZE SELECT * FROM test_table WHERE id = 1
 ┌─────────────┴─────────────┐
 │      EXPLAIN_ANALYZE      │
 │    ────────────────────   │
+│                           │
 │           0 rows          │
-│          (0.00s)          │
+│           0.00s           │
 └─────────────┬─────────────┘
 ┌─────────────┴─────────────┐
 │         TABLE_SCAN        │
@@ -39,6 +40,8 @@ EXPLAIN ANALYZE SELECT * FROM test_table WHERE id = 1
 │                           │
 │       Filters: id=1       │
 │                           │
+│                           │
+│                           │
 │           1 row           │
-│          (0.00s)          │
+│           0.00s           │
 └───────────────────────────┘

--- a/core/src/duckdb/snapshots/datafusion_table_providers__duckdb__creator__tests__explain_analyze_1.snap
+++ b/core/src/duckdb/snapshots/datafusion_table_providers__duckdb__creator__tests__explain_analyze_1.snap
@@ -19,8 +19,9 @@ EXPLAIN ANALYZE SELECT name FROM test_table WHERE id = 1
 ┌─────────────┴─────────────┐
 │      EXPLAIN_ANALYZE      │
 │    ────────────────────   │
+│                           │
 │           0 rows          │
-│          (0.00s)          │
+│           0.00s           │
 └─────────────┬─────────────┘
 ┌─────────────┴─────────────┐
 │         TABLE_SCAN        │
@@ -33,6 +34,8 @@ EXPLAIN ANALYZE SELECT name FROM test_table WHERE id = 1
 │     Projections: name     │
 │       Filters: id=1       │
 │                           │
+│                           │
+│                           │
 │           1 row           │
-│          (0.00s)          │
+│           0.00s           │
 └───────────────────────────┘

--- a/core/src/duckdb/snapshots/datafusion_table_providers__duckdb__creator__tests__explain_analyze_multiple_indexes_0.snap
+++ b/core/src/duckdb/snapshots/datafusion_table_providers__duckdb__creator__tests__explain_analyze_multiple_indexes_0.snap
@@ -19,8 +19,9 @@ EXPLAIN ANALYZE SELECT * FROM test_table WHERE id = 1
 ┌─────────────┴─────────────┐
 │      EXPLAIN_ANALYZE      │
 │    ────────────────────   │
+│                           │
 │           0 rows          │
-│          (0.00s)          │
+│           0.00s           │
 └─────────────┬─────────────┘
 ┌─────────────┴─────────────┐
 │         TABLE_SCAN        │
@@ -39,6 +40,8 @@ EXPLAIN ANALYZE SELECT * FROM test_table WHERE id = 1
 │                           │
 │       Filters: id=1       │
 │                           │
+│                           │
+│                           │
 │           1 row           │
-│          (0.00s)          │
+│           0.00s           │
 └───────────────────────────┘

--- a/core/src/duckdb/snapshots/datafusion_table_providers__duckdb__creator__tests__explain_analyze_multiple_indexes_1.snap
+++ b/core/src/duckdb/snapshots/datafusion_table_providers__duckdb__creator__tests__explain_analyze_multiple_indexes_1.snap
@@ -19,8 +19,9 @@ EXPLAIN ANALYZE SELECT name FROM test_table WHERE id = 1
 ┌─────────────┴─────────────┐
 │      EXPLAIN_ANALYZE      │
 │    ────────────────────   │
+│                           │
 │           0 rows          │
-│          (0.00s)          │
+│           0.00s           │
 └─────────────┬─────────────┘
 ┌─────────────┴─────────────┐
 │         TABLE_SCAN        │
@@ -33,6 +34,8 @@ EXPLAIN ANALYZE SELECT name FROM test_table WHERE id = 1
 │     Projections: name     │
 │       Filters: id=1       │
 │                           │
+│                           │
+│                           │
 │           1 row           │
-│          (0.00s)          │
+│           0.00s           │
 └───────────────────────────┘

--- a/core/src/duckdb/snapshots/datafusion_table_providers__duckdb__creator__tests__explain_analyze_multiple_indexes_2.snap
+++ b/core/src/duckdb/snapshots/datafusion_table_providers__duckdb__creator__tests__explain_analyze_multiple_indexes_2.snap
@@ -19,8 +19,9 @@ EXPLAIN ANALYZE SELECT name, status FROM test_table WHERE id = 1
 ┌─────────────┴─────────────┐
 │      EXPLAIN_ANALYZE      │
 │    ────────────────────   │
+│                           │
 │           0 rows          │
-│          (0.00s)          │
+│           0.00s           │
 └─────────────┬─────────────┘
 ┌─────────────┴─────────────┐
 │         TABLE_SCAN        │
@@ -37,6 +38,8 @@ EXPLAIN ANALYZE SELECT name, status FROM test_table WHERE id = 1
 │                           │
 │       Filters: id=1       │
 │                           │
+│                           │
+│                           │
 │           1 row           │
-│          (0.00s)          │
+│           0.00s           │
 └───────────────────────────┘

--- a/core/src/duckdb/snapshots/datafusion_table_providers__duckdb__creator__tests__explain_analyze_multiple_indexes_3.snap
+++ b/core/src/duckdb/snapshots/datafusion_table_providers__duckdb__creator__tests__explain_analyze_multiple_indexes_3.snap
@@ -19,8 +19,9 @@ EXPLAIN ANALYZE SELECT * FROM test_table WHERE age = 30
 ┌─────────────┴─────────────┐
 │      EXPLAIN_ANALYZE      │
 │    ────────────────────   │
+│                           │
 │           0 rows          │
-│          (0.00s)          │
+│           0.00s           │
 └─────────────┬─────────────┘
 ┌─────────────┴─────────────┐
 │         TABLE_SCAN        │
@@ -39,6 +40,8 @@ EXPLAIN ANALYZE SELECT * FROM test_table WHERE age = 30
 │                           │
 │      Filters: age=30      │
 │                           │
+│                           │
+│                           │
 │           2 rows          │
-│          (0.00s)          │
+│           0.00s           │
 └───────────────────────────┘

--- a/core/src/duckdb/snapshots/datafusion_table_providers__duckdb__creator__tests__explain_analyze_multiple_indexes_4.snap
+++ b/core/src/duckdb/snapshots/datafusion_table_providers__duckdb__creator__tests__explain_analyze_multiple_indexes_4.snap
@@ -19,8 +19,9 @@ EXPLAIN ANALYZE SELECT name FROM test_table WHERE age = 30
 ┌─────────────┴─────────────┐
 │      EXPLAIN_ANALYZE      │
 │    ────────────────────   │
+│                           │
 │           0 rows          │
-│          (0.00s)          │
+│           0.00s           │
 └─────────────┬─────────────┘
 ┌─────────────┴─────────────┐
 │         TABLE_SCAN        │
@@ -33,6 +34,8 @@ EXPLAIN ANALYZE SELECT name FROM test_table WHERE age = 30
 │     Projections: name     │
 │      Filters: age=30      │
 │                           │
+│                           │
+│                           │
 │           2 rows          │
-│          (0.00s)          │
+│           0.00s           │
 └───────────────────────────┘

--- a/core/src/duckdb/snapshots/datafusion_table_providers__duckdb__creator__tests__explain_analyze_multiple_indexes_5.snap
+++ b/core/src/duckdb/snapshots/datafusion_table_providers__duckdb__creator__tests__explain_analyze_multiple_indexes_5.snap
@@ -19,8 +19,9 @@ EXPLAIN ANALYZE SELECT id, name FROM test_table WHERE age = 30
 ┌─────────────┴─────────────┐
 │      EXPLAIN_ANALYZE      │
 │    ────────────────────   │
+│                           │
 │           0 rows          │
-│          (0.00s)          │
+│           0.00s           │
 └─────────────┬─────────────┘
 ┌─────────────┴─────────────┐
 │         PROJECTION        │
@@ -28,8 +29,10 @@ EXPLAIN ANALYZE SELECT id, name FROM test_table WHERE age = 30
 │             id            │
 │            name           │
 │                           │
+│                           │
+│                           │
 │           2 rows          │
-│          (0.00s)          │
+│           0.00s           │
 └─────────────┬─────────────┘
 ┌─────────────┴─────────────┐
 │         TABLE_SCAN        │
@@ -46,6 +49,8 @@ EXPLAIN ANALYZE SELECT id, name FROM test_table WHERE age = 30
 │                           │
 │      Filters: age=30      │
 │                           │
+│                           │
+│                           │
 │           2 rows          │
-│          (0.00s)          │
+│           0.00s           │
 └───────────────────────────┘

--- a/core/src/duckdb/snapshots/datafusion_table_providers__duckdb__creator__tests__explain_analyze_multiple_indexes_6.snap
+++ b/core/src/duckdb/snapshots/datafusion_table_providers__duckdb__creator__tests__explain_analyze_multiple_indexes_6.snap
@@ -19,8 +19,9 @@ EXPLAIN ANALYZE SELECT * FROM test_table WHERE status = 'active'
 ┌─────────────┴─────────────┐
 │      EXPLAIN_ANALYZE      │
 │    ────────────────────   │
+│                           │
 │           0 rows          │
-│          (0.00s)          │
+│           0.00s           │
 └─────────────┬─────────────┘
 ┌─────────────┴─────────────┐
 │         TABLE_SCAN        │
@@ -40,6 +41,8 @@ EXPLAIN ANALYZE SELECT * FROM test_table WHERE status = 'active'
 │          Filters:         │
 │      status='active'      │
 │                           │
+│                           │
+│                           │
 │           3 rows          │
-│          (0.00s)          │
+│           0.00s           │
 └───────────────────────────┘

--- a/core/src/duckdb/snapshots/datafusion_table_providers__duckdb__creator__tests__explain_analyze_multiple_indexes_7.snap
+++ b/core/src/duckdb/snapshots/datafusion_table_providers__duckdb__creator__tests__explain_analyze_multiple_indexes_7.snap
@@ -19,8 +19,9 @@ EXPLAIN ANALYZE SELECT name FROM test_table WHERE status = 'active'
 ┌─────────────┴─────────────┐
 │      EXPLAIN_ANALYZE      │
 │    ────────────────────   │
+│                           │
 │           0 rows          │
-│          (0.00s)          │
+│           0.00s           │
 └─────────────┬─────────────┘
 ┌─────────────┴─────────────┐
 │         TABLE_SCAN        │
@@ -35,6 +36,8 @@ EXPLAIN ANALYZE SELECT name FROM test_table WHERE status = 'active'
 │          Filters:         │
 │      status='active'      │
 │                           │
+│                           │
+│                           │
 │           3 rows          │
-│          (0.00s)          │
+│           0.00s           │
 └───────────────────────────┘

--- a/core/src/duckdb/snapshots/datafusion_table_providers__duckdb__creator__tests__explain_analyze_multiple_indexes_8.snap
+++ b/core/src/duckdb/snapshots/datafusion_table_providers__duckdb__creator__tests__explain_analyze_multiple_indexes_8.snap
@@ -19,8 +19,9 @@ EXPLAIN ANALYZE SELECT id, age FROM test_table WHERE status = 'active'
 ┌─────────────┴─────────────┐
 │      EXPLAIN_ANALYZE      │
 │    ────────────────────   │
+│                           │
 │           0 rows          │
-│          (0.00s)          │
+│           0.00s           │
 └─────────────┬─────────────┘
 ┌─────────────┴─────────────┐
 │         TABLE_SCAN        │
@@ -38,6 +39,8 @@ EXPLAIN ANALYZE SELECT id, age FROM test_table WHERE status = 'active'
 │          Filters:         │
 │      status='active'      │
 │                           │
+│                           │
+│                           │
 │           3 rows          │
-│          (0.00s)          │
+│           0.00s           │
 └───────────────────────────┘

--- a/core/src/duckdb/snapshots/datafusion_table_providers__duckdb__creator__tests__explain_analyze_primary_key_and_index_0.snap
+++ b/core/src/duckdb/snapshots/datafusion_table_providers__duckdb__creator__tests__explain_analyze_primary_key_and_index_0.snap
@@ -19,8 +19,9 @@ EXPLAIN ANALYZE SELECT * FROM test_table WHERE id = 1
 ┌─────────────┴─────────────┐
 │      EXPLAIN_ANALYZE      │
 │    ────────────────────   │
+│                           │
 │           0 rows          │
-│          (0.00s)          │
+│           0.00s           │
 └─────────────┬─────────────┘
 ┌─────────────┴─────────────┐
 │         TABLE_SCAN        │
@@ -39,6 +40,8 @@ EXPLAIN ANALYZE SELECT * FROM test_table WHERE id = 1
 │                           │
 │       Filters: id=1       │
 │                           │
+│                           │
+│                           │
 │           1 row           │
-│          (0.00s)          │
+│           0.00s           │
 └───────────────────────────┘

--- a/core/src/duckdb/snapshots/datafusion_table_providers__duckdb__creator__tests__explain_analyze_primary_key_and_index_1.snap
+++ b/core/src/duckdb/snapshots/datafusion_table_providers__duckdb__creator__tests__explain_analyze_primary_key_and_index_1.snap
@@ -19,8 +19,9 @@ EXPLAIN ANALYZE SELECT name FROM test_table WHERE id = 1
 ┌─────────────┴─────────────┐
 │      EXPLAIN_ANALYZE      │
 │    ────────────────────   │
+│                           │
 │           0 rows          │
-│          (0.00s)          │
+│           0.00s           │
 └─────────────┬─────────────┘
 ┌─────────────┴─────────────┐
 │         TABLE_SCAN        │
@@ -33,6 +34,8 @@ EXPLAIN ANALYZE SELECT name FROM test_table WHERE id = 1
 │     Projections: name     │
 │       Filters: id=1       │
 │                           │
+│                           │
+│                           │
 │           1 row           │
-│          (0.00s)          │
+│           0.00s           │
 └───────────────────────────┘

--- a/core/src/duckdb/snapshots/datafusion_table_providers__duckdb__creator__tests__explain_analyze_primary_key_and_index_2.snap
+++ b/core/src/duckdb/snapshots/datafusion_table_providers__duckdb__creator__tests__explain_analyze_primary_key_and_index_2.snap
@@ -19,8 +19,9 @@ EXPLAIN ANALYZE SELECT name, status FROM test_table WHERE id = 1
 ┌─────────────┴─────────────┐
 │      EXPLAIN_ANALYZE      │
 │    ────────────────────   │
+│                           │
 │           0 rows          │
-│          (0.00s)          │
+│           0.00s           │
 └─────────────┬─────────────┘
 ┌─────────────┴─────────────┐
 │         TABLE_SCAN        │
@@ -37,6 +38,8 @@ EXPLAIN ANALYZE SELECT name, status FROM test_table WHERE id = 1
 │                           │
 │       Filters: id=1       │
 │                           │
+│                           │
+│                           │
 │           1 row           │
-│          (0.00s)          │
+│           0.00s           │
 └───────────────────────────┘

--- a/core/src/duckdb/snapshots/datafusion_table_providers__duckdb__creator__tests__explain_analyze_primary_key_and_index_3.snap
+++ b/core/src/duckdb/snapshots/datafusion_table_providers__duckdb__creator__tests__explain_analyze_primary_key_and_index_3.snap
@@ -19,8 +19,9 @@ EXPLAIN ANALYZE SELECT * FROM test_table WHERE name = 'Alice'
 ┌─────────────┴─────────────┐
 │      EXPLAIN_ANALYZE      │
 │    ────────────────────   │
+│                           │
 │           0 rows          │
-│          (0.00s)          │
+│           0.00s           │
 └─────────────┬─────────────┘
 ┌─────────────┴─────────────┐
 │         TABLE_SCAN        │
@@ -39,6 +40,8 @@ EXPLAIN ANALYZE SELECT * FROM test_table WHERE name = 'Alice'
 │                           │
 │   Filters: name='Alice'   │
 │                           │
+│                           │
+│                           │
 │           1 row           │
-│          (0.00s)          │
+│           0.00s           │
 └───────────────────────────┘

--- a/core/src/duckdb/snapshots/datafusion_table_providers__duckdb__creator__tests__explain_analyze_primary_key_and_index_4.snap
+++ b/core/src/duckdb/snapshots/datafusion_table_providers__duckdb__creator__tests__explain_analyze_primary_key_and_index_4.snap
@@ -19,8 +19,9 @@ EXPLAIN ANALYZE SELECT id, status FROM test_table WHERE name = 'Bob'
 ┌─────────────┴─────────────┐
 │      EXPLAIN_ANALYZE      │
 │    ────────────────────   │
+│                           │
 │           0 rows          │
-│          (0.00s)          │
+│           0.00s           │
 └─────────────┬─────────────┘
 ┌─────────────┴─────────────┐
 │         TABLE_SCAN        │
@@ -37,6 +38,8 @@ EXPLAIN ANALYZE SELECT id, status FROM test_table WHERE name = 'Bob'
 │                           │
 │    Filters: name='Bob'    │
 │                           │
+│                           │
+│                           │
 │           1 row           │
-│          (0.00s)          │
+│           0.00s           │
 └───────────────────────────┘


### PR DESCRIPTION
Upgrade DuckDB version to 1.5.2 that implements support for `duckdb_arrow_scan` for ingesting data via Arrow 
- https://github.com/spiceai/duckdb-rs/pull/33