### PR TITLE
Handle `declared_schema` in MongoDB table provider

### DIFF
--- a/core/src/mongodb.rs
+++ b/core/src/mongodb.rs
@@ -78,21 +78,12 @@ impl MongoDBTableFactory {
         Self { pool }
     }
 
-    pub async fn table_provider(
-        &self,
-        table_reference: TableReference,
-    ) -> Result<Arc<dyn TableProvider + 'static>, Box<dyn std::error::Error + Send + Sync>> {
-        self.table_provider_with_schema(table_reference, None).await
-    }
-
-    /// Like [`table_provider`] but accepts an optional declared schema.
-    ///
     /// When the collection is empty and `declared_schema` is `Some`, the
     /// declared schema is used directly so the dataset can register without
     /// any documents being present.  When the collection has documents, the
     /// inferred schema is merged with the declared schema (declared fields
     /// take precedence).
-    pub async fn table_provider_with_schema(
+    pub async fn table_provider(
         &self,
         table_reference: TableReference,
         declared_schema: Option<SchemaRef>,

--- a/core/src/mongodb.rs
+++ b/core/src/mongodb.rs
@@ -35,6 +35,11 @@ pub enum Error {
         source: Box<dyn std::error::Error + std::marker::Send + Sync>,
     },
 
+    #[snafu(display(
+        "Unable to infer schema. Collection empty or non-existent: {collection_name}"
+    ))]
+    EmptyCollection { collection_name: String },
+
     #[snafu(display("Unable to get schemas: {source}"))]
     UnableToGetSchemas {
         source: Box<dyn std::error::Error + std::marker::Send + Sync>,

--- a/core/src/mongodb.rs
+++ b/core/src/mongodb.rs
@@ -6,6 +6,7 @@ pub mod utils;
 use crate::mongodb::connection_pool::MongoDBConnectionPool;
 use crate::mongodb::table::MongoDBTable;
 use arrow_schema::ArrowError;
+use datafusion::arrow::datatypes::SchemaRef;
 use datafusion::datasource::TableProvider;
 use datafusion::sql::TableReference;
 use snafu::prelude::*;
@@ -81,9 +82,24 @@ impl MongoDBTableFactory {
         &self,
         table_reference: TableReference,
     ) -> Result<Arc<dyn TableProvider + 'static>, Box<dyn std::error::Error + Send + Sync>> {
+        self.table_provider_with_schema(table_reference, None).await
+    }
+
+    /// Like [`table_provider`] but accepts an optional declared schema.
+    ///
+    /// When the collection is empty and `declared_schema` is `Some`, the
+    /// declared schema is used directly so the dataset can register without
+    /// any documents being present.  When the collection has documents, the
+    /// inferred schema is merged with the declared schema (declared fields
+    /// take precedence).
+    pub async fn table_provider_with_schema(
+        &self,
+        table_reference: TableReference,
+        declared_schema: Option<SchemaRef>,
+    ) -> Result<Arc<dyn TableProvider + 'static>, Box<dyn std::error::Error + Send + Sync>> {
         let pool = Arc::clone(&self.pool);
         let table_provider = Arc::new(
-            MongoDBTable::new(&pool, table_reference)
+            MongoDBTable::new(&pool, table_reference, declared_schema)
                 .await
                 .map_err(|e| Box::new(e) as Box<dyn std::error::Error + Send + Sync>)?,
         );

--- a/core/src/mongodb/connection.rs
+++ b/core/src/mongodb/connection.rs
@@ -15,6 +15,7 @@ use crate::mongodb::utils::arrow::mongo_docs_to_arrow;
 use crate::mongodb::utils::schema::infer_arrow_schema_from_documents;
 use crate::mongodb::utils::unnest::{unnest_bson_documents, UnnestBehavior, UnnestParameters};
 use crate::mongodb::{Error, QuerySnafu, Result, UnableToGetSchemaSnafu, UnableToGetTablesSnafu};
+use crate::util::schema::merge_inferred_and_declared_schemas;
 
 pub struct MongoDBConnection {
     pub client: Arc<Client>,
@@ -55,7 +56,20 @@ impl MongoDBConnection {
         Ok(collections)
     }
 
-    pub async fn get_schema(&self, table_reference: &TableReference) -> Result<SchemaRef, Error> {
+    /// Get the schema for a collection, optionally merging with a declared schema.
+    ///
+    /// * If the collection has documents, the inferred schema is merged with
+    ///   the declared schema (declared fields take precedence over inferred ones
+    ///   with the same name; extra declared fields are appended).
+    /// * If the collection is empty and a declared schema is provided, the
+    ///   declared schema is returned directly — no error, no retry needed.
+    /// * If the collection is empty and no declared schema is provided, the
+    ///   `EmptyCollection` error is returned.
+    pub async fn get_schema(
+        &self,
+        table_reference: &TableReference,
+        declared_schema: Option<SchemaRef>,
+    ) -> Result<SchemaRef, Error> {
         let collection_name = table_reference.table();
         let coll = self.get_collection(collection_name);
 
@@ -77,13 +91,24 @@ impl MongoDBConnection {
             _ => unnest_bson_documents(docs, &self.unnest_parameters)?,
         };
 
-        infer_arrow_schema_from_documents(
+        if unnested_docs.is_empty() {
+            return match declared_schema {
+                Some(schema) => Ok(schema),
+                None => Err(Error::EmptyCollection {
+                    collection_name: collection_name.to_string(),
+                }),
+            };
+        }
+
+        let inferred = infer_arrow_schema_from_documents(
             collection_name,
             &unnested_docs,
             self.tz.clone().as_deref(),
         )
         .boxed()
-        .context(UnableToGetSchemaSnafu)
+        .context(UnableToGetSchemaSnafu)?;
+
+        Ok(merge_inferred_and_declared_schemas(inferred, declared_schema.as_ref()))
     }
 
     pub async fn query_arrow(

--- a/core/src/mongodb/connection.rs
+++ b/core/src/mongodb/connection.rs
@@ -108,7 +108,10 @@ impl MongoDBConnection {
         .boxed()
         .context(UnableToGetSchemaSnafu)?;
 
-        Ok(merge_inferred_and_declared_schemas(inferred, declared_schema.as_ref()))
+        Ok(merge_inferred_and_declared_schemas(
+            inferred,
+            declared_schema.as_ref(),
+        ))
     }
 
     pub async fn query_arrow(

--- a/core/src/mongodb/connection.rs
+++ b/core/src/mongodb/connection.rs
@@ -77,9 +77,13 @@ impl MongoDBConnection {
             _ => unnest_bson_documents(docs, &self.unnest_parameters)?,
         };
 
-        infer_arrow_schema_from_documents(&unnested_docs, self.tz.clone().as_deref())
-            .boxed()
-            .context(UnableToGetSchemaSnafu)
+        infer_arrow_schema_from_documents(
+            collection_name,
+            &unnested_docs,
+            self.tz.clone().as_deref(),
+        )
+        .boxed()
+        .context(UnableToGetSchemaSnafu)
     }
 
     pub async fn query_arrow(

--- a/core/src/mongodb/table.rs
+++ b/core/src/mongodb/table.rs
@@ -33,9 +33,14 @@ impl MongoDBTable {
     pub async fn new(
         pool: &Arc<MongoDBConnectionPool>,
         table_reference: impl Into<TableReference>,
+        declared_schema: Option<SchemaRef>,
     ) -> Result<Self, Error> {
         let table_reference = table_reference.into();
-        let schema = pool.connect().await?.get_schema(&table_reference).await?;
+        let schema = pool
+            .connect()
+            .await?
+            .get_schema(&table_reference, declared_schema)
+            .await?;
 
         Ok(Self {
             pool: Arc::clone(pool),

--- a/core/src/mongodb/utils/schema.rs
+++ b/core/src/mongodb/utils/schema.rs
@@ -7,11 +7,14 @@ use crate::mongodb::{Error, Result};
 use chrono::{LocalResult, TimeZone, Timelike, Utc};
 
 pub fn infer_arrow_schema_from_documents(
+    collection_name: &str,
     docs: &[Document],
     tz: Option<&str>,
 ) -> Result<SchemaRef, Error> {
     if docs.is_empty() {
-        return Ok(Arc::new(Schema::empty()));
+        return Err(Error::EmptyCollection {
+            collection_name: collection_name.to_string(),
+        });
     }
 
     let mut field_types: HashMap<String, DataType> = HashMap::new();
@@ -132,8 +135,14 @@ mod tests {
     #[test]
     fn test_empty_documents() {
         let docs: Vec<Document> = vec![];
-        let schema = infer_arrow_schema_from_documents(&docs, None).unwrap();
-        assert_eq!(schema.fields().len(), 0);
+        let err = infer_arrow_schema_from_documents("my_collection", &docs, None).unwrap_err();
+        assert!(
+            matches!(err, Error::EmptyCollection { ref collection_name } if collection_name == "my_collection")
+        );
+        assert_eq!(
+            err.to_string(),
+            "Unable to infer schema. Collection empty or non-existent: my_collection"
+        );
     }
 
     #[test]
@@ -146,7 +155,7 @@ mod tests {
         };
         let docs = vec![doc];
 
-        let schema = infer_arrow_schema_from_documents(&docs, None).unwrap();
+        let schema = infer_arrow_schema_from_documents("test_collection", &docs, None).unwrap();
 
         // Check field count
         assert_eq!(schema.fields().len(), 4);
@@ -180,7 +189,7 @@ mod tests {
         };
         let docs = vec![doc];
 
-        let schema = infer_arrow_schema_from_documents(&docs, None).unwrap();
+        let schema = infer_arrow_schema_from_documents("test_collection", &docs, None).unwrap();
         let field_map: HashMap<String, &DataType> = schema
             .fields()
             .iter()
@@ -213,7 +222,8 @@ mod tests {
         };
         let docs = vec![doc];
 
-        let schema = infer_arrow_schema_from_documents(&docs, Some("+02:00")).unwrap();
+        let schema =
+            infer_arrow_schema_from_documents("test_collection", &docs, Some("+02:00")).unwrap();
         let field_map: HashMap<String, &DataType> = schema
             .fields()
             .iter()
@@ -254,7 +264,7 @@ mod tests {
             doc! { "created_at": midnight },
             doc! { "created_at": non_midnight },
         ];
-        let schema = infer_arrow_schema_from_documents(&docs, None).unwrap();
+        let schema = infer_arrow_schema_from_documents("test_collection", &docs, None).unwrap();
         assert_eq!(
             schema.field_with_name("created_at").unwrap().data_type(),
             &DataType::Timestamp(TimeUnit::Millisecond, Some("UTC".into()))
@@ -265,7 +275,7 @@ mod tests {
             doc! { "created_at": non_midnight },
             doc! { "created_at": midnight },
         ];
-        let schema = infer_arrow_schema_from_documents(&docs, None).unwrap();
+        let schema = infer_arrow_schema_from_documents("test_collection", &docs, None).unwrap();
         assert_eq!(
             schema.field_with_name("created_at").unwrap().data_type(),
             &DataType::Timestamp(TimeUnit::Millisecond, Some("UTC".into()))
@@ -279,7 +289,7 @@ mod tests {
         };
         let docs = vec![doc];
 
-        let schema = infer_arrow_schema_from_documents(&docs, None).unwrap();
+        let schema = infer_arrow_schema_from_documents("test_collection", &docs, None).unwrap();
         let field_map: HashMap<String, &DataType> = schema
             .fields()
             .iter()
@@ -300,7 +310,7 @@ mod tests {
         };
         let docs = vec![doc];
 
-        let schema = infer_arrow_schema_from_documents(&docs, None).unwrap();
+        let schema = infer_arrow_schema_from_documents("test_collection", &docs, None).unwrap();
         let field_map: HashMap<String, &DataType> = schema
             .fields()
             .iter()
@@ -348,7 +358,7 @@ mod tests {
         };
         let docs = vec![doc];
 
-        let schema = infer_arrow_schema_from_documents(&docs, None).unwrap();
+        let schema = infer_arrow_schema_from_documents("test_collection", &docs, None).unwrap();
         let field_map: HashMap<String, &DataType> = schema
             .fields()
             .iter()
@@ -367,7 +377,7 @@ mod tests {
             doc! { "value": 20_i64 }, // Int64 -> should promote to Int64
         ];
 
-        let schema = infer_arrow_schema_from_documents(&docs, None).unwrap();
+        let schema = infer_arrow_schema_from_documents("test_collection", &docs, None).unwrap();
         let field = schema.field_with_name("value").unwrap();
         assert_eq!(field.data_type(), &DataType::Int64);
     }
@@ -380,7 +390,7 @@ mod tests {
             doc! { "value": 3.14_f64 }, // Float64 -> should promote to Float64
         ];
 
-        let schema = infer_arrow_schema_from_documents(&docs, None).unwrap();
+        let schema = infer_arrow_schema_from_documents("test_collection", &docs, None).unwrap();
         let field = schema.field_with_name("value").unwrap();
         assert_eq!(field.data_type(), &DataType::Float64);
     }
@@ -392,7 +402,7 @@ mod tests {
             doc! { "value": "text" }, // String -> should fallback to String
         ];
 
-        let schema = infer_arrow_schema_from_documents(&docs, None).unwrap();
+        let schema = infer_arrow_schema_from_documents("test_collection", &docs, None).unwrap();
         let field = schema.field_with_name("value").unwrap();
         assert_eq!(field.data_type(), &DataType::Utf8);
     }
@@ -404,7 +414,7 @@ mod tests {
             doc! { "value": "text" },     // String -> should be String
         ];
 
-        let schema = infer_arrow_schema_from_documents(&docs, None).unwrap();
+        let schema = infer_arrow_schema_from_documents("test_collection", &docs, None).unwrap();
         let field = schema.field_with_name("value").unwrap();
         assert_eq!(field.data_type(), &DataType::Utf8);
     }
@@ -413,7 +423,7 @@ mod tests {
     fn test_only_null_values() {
         let docs = vec![doc! { "value": Bson::Null }, doc! { "value": Bson::Null }];
 
-        let schema = infer_arrow_schema_from_documents(&docs, None).unwrap();
+        let schema = infer_arrow_schema_from_documents("test_collection", &docs, None).unwrap();
         let field = schema.field_with_name("value").unwrap();
         assert_eq!(field.data_type(), &DataType::Null);
     }
@@ -426,7 +436,7 @@ mod tests {
             doc! { "age": 25_i32, "country": "US" },
         ];
 
-        let schema = infer_arrow_schema_from_documents(&docs, None).unwrap();
+        let schema = infer_arrow_schema_from_documents("test_collection", &docs, None).unwrap();
 
         // Should have all unique fields
         assert_eq!(schema.fields().len(), 4);
@@ -455,7 +465,7 @@ mod tests {
         };
         let docs = vec![doc];
 
-        let schema = infer_arrow_schema_from_documents(&docs, None).unwrap();
+        let schema = infer_arrow_schema_from_documents("test_collection", &docs, None).unwrap();
 
         let field_names: Vec<&str> = schema.fields().iter().map(|f| f.name().as_str()).collect();
         assert_eq!(field_names, vec!["apple", "banana", "monkey", "zebra"]);
@@ -485,7 +495,7 @@ mod tests {
             docs.push(doc);
         }
 
-        let schema = infer_arrow_schema_from_documents(&docs, None).unwrap();
+        let schema = infer_arrow_schema_from_documents("test_collection", &docs, None).unwrap();
 
         // Should have all the fields
         let field_names: std::collections::HashSet<&str> =

--- a/core/src/mongodb/utils/schema.rs
+++ b/core/src/mongodb/utils/schema.rs
@@ -155,7 +155,8 @@ mod tests {
         };
         let docs = vec![doc];
 
-        let schema = infer_arrow_schema_from_documents("test_collection", &docs, None).expect("schema inference failed");
+        let schema = infer_arrow_schema_from_documents("test_collection", &docs, None)
+            .expect("schema inference failed");
 
         // Check field count
         assert_eq!(schema.fields().len(), 4);
@@ -189,7 +190,8 @@ mod tests {
         };
         let docs = vec![doc];
 
-        let schema = infer_arrow_schema_from_documents("test_collection", &docs, None).expect("schema inference failed");
+        let schema = infer_arrow_schema_from_documents("test_collection", &docs, None)
+            .expect("schema inference failed");
         let field_map: HashMap<String, &DataType> = schema
             .fields()
             .iter()
@@ -222,8 +224,8 @@ mod tests {
         };
         let docs = vec![doc];
 
-        let schema =
-            infer_arrow_schema_from_documents("test_collection", &docs, Some("+02:00")).expect("schema inference failed");
+        let schema = infer_arrow_schema_from_documents("test_collection", &docs, Some("+02:00"))
+            .expect("schema inference failed");
         let field_map: HashMap<String, &DataType> = schema
             .fields()
             .iter()
@@ -264,9 +266,13 @@ mod tests {
             doc! { "created_at": midnight },
             doc! { "created_at": non_midnight },
         ];
-        let schema = infer_arrow_schema_from_documents("test_collection", &docs, None).expect("schema inference failed");
+        let schema = infer_arrow_schema_from_documents("test_collection", &docs, None)
+            .expect("schema inference failed");
         assert_eq!(
-            schema.field_with_name("created_at").expect("field exists").data_type(),
+            schema
+                .field_with_name("created_at")
+                .expect("field exists")
+                .data_type(),
             &DataType::Timestamp(TimeUnit::Millisecond, Some("UTC".into()))
         );
 
@@ -275,9 +281,13 @@ mod tests {
             doc! { "created_at": non_midnight },
             doc! { "created_at": midnight },
         ];
-        let schema = infer_arrow_schema_from_documents("test_collection", &docs, None).expect("schema inference failed");
+        let schema = infer_arrow_schema_from_documents("test_collection", &docs, None)
+            .expect("schema inference failed");
         assert_eq!(
-            schema.field_with_name("created_at").expect("field exists").data_type(),
+            schema
+                .field_with_name("created_at")
+                .expect("field exists")
+                .data_type(),
             &DataType::Timestamp(TimeUnit::Millisecond, Some("UTC".into()))
         );
     }
@@ -289,7 +299,8 @@ mod tests {
         };
         let docs = vec![doc];
 
-        let schema = infer_arrow_schema_from_documents("test_collection", &docs, None).expect("schema inference failed");
+        let schema = infer_arrow_schema_from_documents("test_collection", &docs, None)
+            .expect("schema inference failed");
         let field_map: HashMap<String, &DataType> = schema
             .fields()
             .iter()
@@ -310,7 +321,8 @@ mod tests {
         };
         let docs = vec![doc];
 
-        let schema = infer_arrow_schema_from_documents("test_collection", &docs, None).expect("schema inference failed");
+        let schema = infer_arrow_schema_from_documents("test_collection", &docs, None)
+            .expect("schema inference failed");
         let field_map: HashMap<String, &DataType> = schema
             .fields()
             .iter()
@@ -358,7 +370,8 @@ mod tests {
         };
         let docs = vec![doc];
 
-        let schema = infer_arrow_schema_from_documents("test_collection", &docs, None).expect("schema inference failed");
+        let schema = infer_arrow_schema_from_documents("test_collection", &docs, None)
+            .expect("schema inference failed");
         let field_map: HashMap<String, &DataType> = schema
             .fields()
             .iter()
@@ -377,7 +390,8 @@ mod tests {
             doc! { "value": 20_i64 }, // Int64 -> should promote to Int64
         ];
 
-        let schema = infer_arrow_schema_from_documents("test_collection", &docs, None).expect("schema inference failed");
+        let schema = infer_arrow_schema_from_documents("test_collection", &docs, None)
+            .expect("schema inference failed");
         let field = schema.field_with_name("value").expect("field exists");
         assert_eq!(field.data_type(), &DataType::Int64);
     }
@@ -390,7 +404,8 @@ mod tests {
             doc! { "value": 3.14_f64 }, // Float64 -> should promote to Float64
         ];
 
-        let schema = infer_arrow_schema_from_documents("test_collection", &docs, None).expect("schema inference failed");
+        let schema = infer_arrow_schema_from_documents("test_collection", &docs, None)
+            .expect("schema inference failed");
         let field = schema.field_with_name("value").expect("field exists");
         assert_eq!(field.data_type(), &DataType::Float64);
     }
@@ -402,7 +417,8 @@ mod tests {
             doc! { "value": "text" }, // String -> should fallback to String
         ];
 
-        let schema = infer_arrow_schema_from_documents("test_collection", &docs, None).expect("schema inference failed");
+        let schema = infer_arrow_schema_from_documents("test_collection", &docs, None)
+            .expect("schema inference failed");
         let field = schema.field_with_name("value").expect("field exists");
         assert_eq!(field.data_type(), &DataType::Utf8);
     }
@@ -414,7 +430,8 @@ mod tests {
             doc! { "value": "text" },     // String -> should be String
         ];
 
-        let schema = infer_arrow_schema_from_documents("test_collection", &docs, None).expect("schema inference failed");
+        let schema = infer_arrow_schema_from_documents("test_collection", &docs, None)
+            .expect("schema inference failed");
         let field = schema.field_with_name("value").expect("field exists");
         assert_eq!(field.data_type(), &DataType::Utf8);
     }
@@ -423,7 +440,8 @@ mod tests {
     fn test_only_null_values() {
         let docs = vec![doc! { "value": Bson::Null }, doc! { "value": Bson::Null }];
 
-        let schema = infer_arrow_schema_from_documents("test_collection", &docs, None).expect("schema inference failed");
+        let schema = infer_arrow_schema_from_documents("test_collection", &docs, None)
+            .expect("schema inference failed");
         let field = schema.field_with_name("value").expect("field exists");
         assert_eq!(field.data_type(), &DataType::Null);
     }
@@ -436,7 +454,8 @@ mod tests {
             doc! { "age": 25_i32, "country": "US" },
         ];
 
-        let schema = infer_arrow_schema_from_documents("test_collection", &docs, None).expect("schema inference failed");
+        let schema = infer_arrow_schema_from_documents("test_collection", &docs, None)
+            .expect("schema inference failed");
 
         // Should have all unique fields
         assert_eq!(schema.fields().len(), 4);
@@ -465,7 +484,8 @@ mod tests {
         };
         let docs = vec![doc];
 
-        let schema = infer_arrow_schema_from_documents("test_collection", &docs, None).expect("schema inference failed");
+        let schema = infer_arrow_schema_from_documents("test_collection", &docs, None)
+            .expect("schema inference failed");
 
         let field_names: Vec<&str> = schema.fields().iter().map(|f| f.name().as_str()).collect();
         assert_eq!(field_names, vec!["apple", "banana", "monkey", "zebra"]);
@@ -495,7 +515,8 @@ mod tests {
             docs.push(doc);
         }
 
-        let schema = infer_arrow_schema_from_documents("test_collection", &docs, None).expect("schema inference failed");
+        let schema = infer_arrow_schema_from_documents("test_collection", &docs, None)
+            .expect("schema inference failed");
 
         // Should have all the fields
         let field_names: std::collections::HashSet<&str> =

--- a/core/src/mongodb/utils/schema.rs
+++ b/core/src/mongodb/utils/schema.rs
@@ -155,7 +155,7 @@ mod tests {
         };
         let docs = vec![doc];
 
-        let schema = infer_arrow_schema_from_documents("test_collection", &docs, None).unwrap();
+        let schema = infer_arrow_schema_from_documents("test_collection", &docs, None).expect("schema inference failed");
 
         // Check field count
         assert_eq!(schema.fields().len(), 4);
@@ -185,11 +185,11 @@ mod tests {
             "created_at": mongodb::bson::DateTime::now(),
             "timestamp": mongodb::bson::Timestamp { time: 1234567890, increment: 1 },
             "binary_data": mongodb::bson::Binary { subtype: mongodb::bson::spec::BinarySubtype::Generic, bytes: vec![1, 2, 3] },
-            "decimal": mongodb::bson::Decimal128::from_str("123.456").unwrap(),
+            "decimal": mongodb::bson::Decimal128::from_str("123.456").expect("valid decimal"),
         };
         let docs = vec![doc];
 
-        let schema = infer_arrow_schema_from_documents("test_collection", &docs, None).unwrap();
+        let schema = infer_arrow_schema_from_documents("test_collection", &docs, None).expect("schema inference failed");
         let field_map: HashMap<String, &DataType> = schema
             .fields()
             .iter()
@@ -223,7 +223,7 @@ mod tests {
         let docs = vec![doc];
 
         let schema =
-            infer_arrow_schema_from_documents("test_collection", &docs, Some("+02:00")).unwrap();
+            infer_arrow_schema_from_documents("test_collection", &docs, Some("+02:00")).expect("schema inference failed");
         let field_map: HashMap<String, &DataType> = schema
             .fields()
             .iter()
@@ -250,23 +250,23 @@ mod tests {
             .month(1)
             .day(1)
             .build()
-            .unwrap();
+            .expect("valid datetime");
         let non_midnight = mongodb::bson::DateTime::builder()
             .year(2024)
             .month(6)
             .day(15)
             .hour(12)
             .build()
-            .unwrap();
+            .expect("valid datetime");
 
         // Order A: midnight first, then non-midnight
         let docs = vec![
             doc! { "created_at": midnight },
             doc! { "created_at": non_midnight },
         ];
-        let schema = infer_arrow_schema_from_documents("test_collection", &docs, None).unwrap();
+        let schema = infer_arrow_schema_from_documents("test_collection", &docs, None).expect("schema inference failed");
         assert_eq!(
-            schema.field_with_name("created_at").unwrap().data_type(),
+            schema.field_with_name("created_at").expect("field exists").data_type(),
             &DataType::Timestamp(TimeUnit::Millisecond, Some("UTC".into()))
         );
 
@@ -275,9 +275,9 @@ mod tests {
             doc! { "created_at": non_midnight },
             doc! { "created_at": midnight },
         ];
-        let schema = infer_arrow_schema_from_documents("test_collection", &docs, None).unwrap();
+        let schema = infer_arrow_schema_from_documents("test_collection", &docs, None).expect("schema inference failed");
         assert_eq!(
-            schema.field_with_name("created_at").unwrap().data_type(),
+            schema.field_with_name("created_at").expect("field exists").data_type(),
             &DataType::Timestamp(TimeUnit::Millisecond, Some("UTC".into()))
         );
     }
@@ -285,11 +285,11 @@ mod tests {
     #[test]
     fn test_date32_detection() {
         let doc = doc! {
-            "created_date": mongodb::bson::DateTime::builder().year(2021).month(1).day(1).build().unwrap(),
+            "created_date": mongodb::bson::DateTime::builder().year(2021).month(1).day(1).build().expect("valid datetime"),
         };
         let docs = vec![doc];
 
-        let schema = infer_arrow_schema_from_documents("test_collection", &docs, None).unwrap();
+        let schema = infer_arrow_schema_from_documents("test_collection", &docs, None).expect("schema inference failed");
         let field_map: HashMap<String, &DataType> = schema
             .fields()
             .iter()
@@ -310,7 +310,7 @@ mod tests {
         };
         let docs = vec![doc];
 
-        let schema = infer_arrow_schema_from_documents("test_collection", &docs, None).unwrap();
+        let schema = infer_arrow_schema_from_documents("test_collection", &docs, None).expect("schema inference failed");
         let field_map: HashMap<String, &DataType> = schema
             .fields()
             .iter()
@@ -358,7 +358,7 @@ mod tests {
         };
         let docs = vec![doc];
 
-        let schema = infer_arrow_schema_from_documents("test_collection", &docs, None).unwrap();
+        let schema = infer_arrow_schema_from_documents("test_collection", &docs, None).expect("schema inference failed");
         let field_map: HashMap<String, &DataType> = schema
             .fields()
             .iter()
@@ -377,8 +377,8 @@ mod tests {
             doc! { "value": 20_i64 }, // Int64 -> should promote to Int64
         ];
 
-        let schema = infer_arrow_schema_from_documents("test_collection", &docs, None).unwrap();
-        let field = schema.field_with_name("value").unwrap();
+        let schema = infer_arrow_schema_from_documents("test_collection", &docs, None).expect("schema inference failed");
+        let field = schema.field_with_name("value").expect("field exists");
         assert_eq!(field.data_type(), &DataType::Int64);
     }
 
@@ -390,8 +390,8 @@ mod tests {
             doc! { "value": 3.14_f64 }, // Float64 -> should promote to Float64
         ];
 
-        let schema = infer_arrow_schema_from_documents("test_collection", &docs, None).unwrap();
-        let field = schema.field_with_name("value").unwrap();
+        let schema = infer_arrow_schema_from_documents("test_collection", &docs, None).expect("schema inference failed");
+        let field = schema.field_with_name("value").expect("field exists");
         assert_eq!(field.data_type(), &DataType::Float64);
     }
 
@@ -402,8 +402,8 @@ mod tests {
             doc! { "value": "text" }, // String -> should fallback to String
         ];
 
-        let schema = infer_arrow_schema_from_documents("test_collection", &docs, None).unwrap();
-        let field = schema.field_with_name("value").unwrap();
+        let schema = infer_arrow_schema_from_documents("test_collection", &docs, None).expect("schema inference failed");
+        let field = schema.field_with_name("value").expect("field exists");
         assert_eq!(field.data_type(), &DataType::Utf8);
     }
 
@@ -414,8 +414,8 @@ mod tests {
             doc! { "value": "text" },     // String -> should be String
         ];
 
-        let schema = infer_arrow_schema_from_documents("test_collection", &docs, None).unwrap();
-        let field = schema.field_with_name("value").unwrap();
+        let schema = infer_arrow_schema_from_documents("test_collection", &docs, None).expect("schema inference failed");
+        let field = schema.field_with_name("value").expect("field exists");
         assert_eq!(field.data_type(), &DataType::Utf8);
     }
 
@@ -423,8 +423,8 @@ mod tests {
     fn test_only_null_values() {
         let docs = vec![doc! { "value": Bson::Null }, doc! { "value": Bson::Null }];
 
-        let schema = infer_arrow_schema_from_documents("test_collection", &docs, None).unwrap();
-        let field = schema.field_with_name("value").unwrap();
+        let schema = infer_arrow_schema_from_documents("test_collection", &docs, None).expect("schema inference failed");
+        let field = schema.field_with_name("value").expect("field exists");
         assert_eq!(field.data_type(), &DataType::Null);
     }
 
@@ -436,7 +436,7 @@ mod tests {
             doc! { "age": 25_i32, "country": "US" },
         ];
 
-        let schema = infer_arrow_schema_from_documents("test_collection", &docs, None).unwrap();
+        let schema = infer_arrow_schema_from_documents("test_collection", &docs, None).expect("schema inference failed");
 
         // Should have all unique fields
         assert_eq!(schema.fields().len(), 4);
@@ -465,7 +465,7 @@ mod tests {
         };
         let docs = vec![doc];
 
-        let schema = infer_arrow_schema_from_documents("test_collection", &docs, None).unwrap();
+        let schema = infer_arrow_schema_from_documents("test_collection", &docs, None).expect("schema inference failed");
 
         let field_names: Vec<&str> = schema.fields().iter().map(|f| f.name().as_str()).collect();
         assert_eq!(field_names, vec!["apple", "banana", "monkey", "zebra"]);
@@ -495,7 +495,7 @@ mod tests {
             docs.push(doc);
         }
 
-        let schema = infer_arrow_schema_from_documents("test_collection", &docs, None).unwrap();
+        let schema = infer_arrow_schema_from_documents("test_collection", &docs, None).expect("schema inference failed");
 
         // Should have all the fields
         let field_names: std::collections::HashSet<&str> =

--- a/core/src/util/mod.rs
+++ b/core/src/util/mod.rs
@@ -14,7 +14,6 @@ pub mod indexes;
 pub mod ns_lookup;
 pub mod on_conflict;
 pub mod retriable_error;
-#[cfg(any(feature = "sqlite", feature = "duckdb", feature = "postgres"))]
 pub mod schema;
 pub mod secrets;
 pub mod supported_functions;

--- a/core/src/util/schema.rs
+++ b/core/src/util/schema.rs
@@ -105,7 +105,10 @@ mod tests {
 /// only appear in the inferred schema are kept; fields that only appear in
 /// the declared schema are appended after the inferred ones.
 #[must_use]
-pub fn merge_inferred_and_declared_schemas(inferred: SchemaRef, declared: Option<&SchemaRef>) -> SchemaRef {
+pub fn merge_inferred_and_declared_schemas(
+    inferred: SchemaRef,
+    declared: Option<&SchemaRef>,
+) -> SchemaRef {
     let Some(declared) = declared else {
         return inferred;
     };

--- a/core/src/util/schema.rs
+++ b/core/src/util/schema.rs
@@ -3,8 +3,7 @@ use std::sync::Arc;
 
 use super::handle_unsupported_type_error;
 use crate::UnsupportedTypeAction;
-use arrow_schema::{DataType, Field, Schema, SchemaBuilder};
-use datafusion::arrow::datatypes::SchemaRef;
+use datafusion::arrow::datatypes::{DataType, Field, Schema, SchemaBuilder, SchemaRef};
 
 type GenericError = Box<dyn std::error::Error + Send + Sync>;
 type Result<T, E = GenericError> = std::result::Result<T, E>;
@@ -12,7 +11,7 @@ type Result<T, E = GenericError> = std::result::Result<T, E>;
 #[cfg(test)]
 mod tests {
     use super::*;
-    use arrow_schema::{DataType, Field, Schema};
+    use datafusion::arrow::datatypes::{DataType, Field, Schema};
 
     fn schema(fields: Vec<(&str, DataType, bool)>) -> SchemaRef {
         Arc::new(Schema::new(

--- a/core/src/util/schema.rs
+++ b/core/src/util/schema.rs
@@ -1,12 +1,147 @@
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
 use super::handle_unsupported_type_error;
 use crate::UnsupportedTypeAction;
-use arrow_schema::{DataType, Field, SchemaBuilder};
+use arrow_schema::{DataType, Field, Schema, SchemaBuilder};
 use datafusion::arrow::datatypes::SchemaRef;
 
 type GenericError = Box<dyn std::error::Error + Send + Sync>;
 type Result<T, E = GenericError> = std::result::Result<T, E>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow_schema::{DataType, Field, Schema};
+
+    fn schema(fields: Vec<(&str, DataType, bool)>) -> SchemaRef {
+        Arc::new(Schema::new(
+            fields
+                .into_iter()
+                .map(|(name, dt, nullable)| Field::new(name, dt, nullable))
+                .collect::<Vec<_>>(),
+        ))
+    }
+
+    #[test]
+    fn test_merge_schemas_no_declared_returns_inferred() {
+        let inferred = schema(vec![
+            ("id", DataType::Int32, true),
+            ("name", DataType::Utf8, true),
+        ]);
+        let result = merge_inferred_and_declared_schemas(Arc::clone(&inferred), None);
+        assert_eq!(result, inferred);
+    }
+
+    #[test]
+    fn test_merge_schemas_declared_overrides_inferred_field() {
+        // inferred has `id` as Int32; declared overrides it to Int64 and non-nullable
+        let inferred = schema(vec![
+            ("id", DataType::Int32, true),
+            ("name", DataType::Utf8, true),
+        ]);
+        let declared = schema(vec![("id", DataType::Int64, false)]);
+        let result = merge_inferred_and_declared_schemas(inferred, Some(&declared));
+
+        let field = result.field_with_name("id").expect("field exists");
+        assert_eq!(field.data_type(), &DataType::Int64);
+        assert!(!field.is_nullable());
+        // `name` is still present from inferred
+        assert!(result.field_with_name("name").is_ok());
+    }
+
+    #[test]
+    fn test_merge_schemas_declared_only_field_appended() {
+        let inferred = schema(vec![("name", DataType::Utf8, true)]);
+        let declared = schema(vec![("score", DataType::Float64, true)]);
+        let result = merge_inferred_and_declared_schemas(inferred, Some(&declared));
+
+        assert_eq!(result.fields().len(), 2);
+        assert!(result.field_with_name("name").is_ok());
+        assert!(result.field_with_name("score").is_ok());
+    }
+
+    #[test]
+    fn test_merge_schemas_declared_only_fields_come_after_inferred() {
+        let inferred = schema(vec![
+            ("a", DataType::Utf8, true),
+            ("b", DataType::Utf8, true),
+        ]);
+        let declared = schema(vec![("c", DataType::Utf8, true)]);
+        let result = merge_inferred_and_declared_schemas(inferred, Some(&declared));
+
+        let names: Vec<&str> = result.fields().iter().map(|f| f.name().as_str()).collect();
+        assert_eq!(names, vec!["a", "b", "c"]);
+    }
+
+    #[test]
+    fn test_merge_schemas_empty_inferred() {
+        let inferred = Arc::new(Schema::empty());
+        let declared = schema(vec![("id", DataType::Int32, false)]);
+        let result = merge_inferred_and_declared_schemas(inferred, Some(&declared));
+
+        assert_eq!(result.fields().len(), 1);
+        assert_eq!(
+            result
+                .field_with_name("id")
+                .expect("field exists")
+                .data_type(),
+            &DataType::Int32
+        );
+    }
+
+    #[test]
+    fn test_merge_schemas_empty_declared() {
+        let inferred = schema(vec![("id", DataType::Int32, true)]);
+        let declared = Arc::new(Schema::empty());
+        let result = merge_inferred_and_declared_schemas(Arc::clone(&inferred), Some(&declared));
+
+        assert_eq!(result, inferred);
+    }
+}
+
+/// Merge an inferred schema with a declared schema.
+///
+/// Declared fields override inferred fields with the same name; fields that
+/// only appear in the inferred schema are kept; fields that only appear in
+/// the declared schema are appended after the inferred ones.
+#[must_use]
+pub fn merge_inferred_and_declared_schemas(inferred: SchemaRef, declared: Option<&SchemaRef>) -> SchemaRef {
+    let Some(declared) = declared else {
+        return inferred;
+    };
+
+    let declared_by_name: HashMap<&str, &Field> = declared
+        .fields()
+        .iter()
+        .map(|f| (f.name().as_str(), f.as_ref()))
+        .collect();
+    let inferred_names: HashSet<&str> = inferred
+        .fields()
+        .iter()
+        .map(|f| f.name().as_str())
+        .collect();
+
+    let mut merged: Vec<Field> = inferred
+        .fields()
+        .iter()
+        .map(|f| {
+            declared_by_name
+                .get(f.name().as_str())
+                .copied()
+                .cloned()
+                .unwrap_or_else(|| f.as_ref().clone())
+        })
+        .collect();
+
+    for f in declared.fields() {
+        if !inferred_names.contains(f.name().as_str()) {
+            merged.push(f.as_ref().clone());
+        }
+    }
+
+    Arc::new(Schema::new(merged))
+}
 
 pub trait SchemaValidator {
     type Error: std::error::Error + Send + Sync;

--- a/python/src/mongodb.rs
+++ b/python/src/mongodb.rs
@@ -41,8 +41,11 @@ impl RawMongoDBTableFactory {
     }
 
     pub fn get_table(&self, py: Python, table_reference: &str) -> PyResult<RawTableProvider> {
-        let table = wait_for_future(py, self.factory.table_provider(table_reference.into()))
-            .map_err(to_pyerr)?;
+        let table = wait_for_future(
+            py,
+            self.factory.table_provider(table_reference.into(), None),
+        )
+        .map_err(to_pyerr)?;
 
         Ok(RawTableProvider {
             table,


### PR DESCRIPTION
1. Pass `declared_schema: Option<SchemaRef` to `MongoDBTable::new` - which:
    * Will be used as is when collection is empty
    * Will be merged with inferred schema when collection is non-empty (declared schema takes precedence over inferred schema)

2. Return an error when collection is empty and `declared_schema` is `None`