### PR TITLE
Bump spiceai duckdb-rs fork to a33cc3c3 (statically-linked VSS / HNSW)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2483,7 +2483,7 @@ checksum = "d8b14ccef22fc6f5a8f4d7d768562a182c04ce9a3b3157b91390b52ddfdf1a76"
 [[package]]
 name = "duckdb"
 version = "1.10503.1"
-source = "git+https://github.com/spiceai/duckdb-rs.git?rev=b80672e038d1abe3d710f092a130661ea482940f#b80672e038d1abe3d710f092a130661ea482940f"
+source = "git+https://github.com/spiceai/duckdb-rs.git?rev=a33cc3c30b4b24b1fce702ae6f8e052232915c0a#a33cc3c30b4b24b1fce702ae6f8e052232915c0a"
 dependencies = [
  "arrow",
  "cast",
@@ -3720,7 +3720,7 @@ dependencies = [
 [[package]]
 name = "libduckdb-sys"
 version = "1.10503.1"
-source = "git+https://github.com/spiceai/duckdb-rs.git?rev=b80672e038d1abe3d710f092a130661ea482940f#b80672e038d1abe3d710f092a130661ea482940f"
+source = "git+https://github.com/spiceai/duckdb-rs.git?rev=a33cc3c30b4b24b1fce702ae6f8e052232915c0a#a33cc3c30b4b24b1fce702ae6f8e052232915c0a"
 dependencies = [
  "cc",
  "flate2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ datafusion-proto = { version = "52" }
 datafusion-physical-expr = { version = "52" }
 datafusion-physical-plan = { version = "52" }
 datafusion-table-providers = { path = "core" }
-duckdb = { git = "https://github.com/spiceai/duckdb-rs.git", rev = "b80672e038d1abe3d710f092a130661ea482940f" } # Forked to add support for duckdb_scan_arrow, pending: https://github.com/duckdb/duckdb-rs/pull/488
+duckdb = { git = "https://github.com/spiceai/duckdb-rs.git", rev = "a33cc3c30b4b24b1fce702ae6f8e052232915c0a" } # spiceai duckdb-rs fork: duckdb_scan_arrow (pending https://github.com/duckdb/duckdb-rs/pull/488) + statically-linked VSS (HNSW)
 adbc_core = { version = "0.23" }
 adbc_driver_manager = { version = "0.23" }
 parquet = "57"


### PR DESCRIPTION
## Summary

Bumps the `duckdb` (spiceai duckdb-rs fork) pin from `b80672e0` to **`a33cc3c3`** — the head of `spiceai/duckdb-rs` `spiceai-1.5.3` after [spiceai/duckdb-rs#37](https://github.com/spiceai/duckdb-rs/pull/37) (merged), which **statically links the VSS (vector similarity search / HNSW) extension** into the bundled DuckDB.

This lets the DuckDB vector engine create HNSW indexes without a runtime `INSTALL vss` (no network at runtime, works air-gapped, and doesn't 404 on custom DuckDB builds).

## Why this repo needs it

Consumers (e.g. spiceai) pin both their direct `duckdb` dependency **and** this crate's `duckdb` to the same git rev. If they diverge, cargo resolves two `libduckdb-sys` packages that both declare `links = "duckdb"` → a hard resolver error. Keeping table-providers on the same duckdb-rs rev avoids that.

## Change

- `Cargo.toml`: `duckdb` rev `b80672e0` → `a33cc3c3`.
- `Cargo.lock`: the two `duckdb` / `libduckdb-sys` git source entries updated to the new rev (source-string only — the DuckDB Rust API and dependency graph are unchanged between the two revs, so nothing else moves).

## Validation

`cargo metadata --locked` resolves cleanly against the new rev. There is no DuckDB Rust API change between `b80672e0` and `a33cc3c3` (the delta is bundled C++ source + build wiring), so table-providers compiles identically; CI covers the build.