### PR TITLE
Bump spiceai duckdb-rs fork to b1cf1723 (DuckDB version pinned to v1.5.3)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2483,7 +2483,7 @@ checksum = "d8b14ccef22fc6f5a8f4d7d768562a182c04ce9a3b3157b91390b52ddfdf1a76"
 [[package]]
 name = "duckdb"
 version = "1.10503.1"
-source = "git+https://github.com/spiceai/duckdb-rs.git?rev=a33cc3c30b4b24b1fce702ae6f8e052232915c0a#a33cc3c30b4b24b1fce702ae6f8e052232915c0a"
+source = "git+https://github.com/spiceai/duckdb-rs.git?rev=b1cf1723252204caf6262865255cd47e7435cbbe#b1cf1723252204caf6262865255cd47e7435cbbe"
 dependencies = [
  "arrow",
  "cast",
@@ -3720,7 +3720,7 @@ dependencies = [
 [[package]]
 name = "libduckdb-sys"
 version = "1.10503.1"
-source = "git+https://github.com/spiceai/duckdb-rs.git?rev=a33cc3c30b4b24b1fce702ae6f8e052232915c0a#a33cc3c30b4b24b1fce702ae6f8e052232915c0a"
+source = "git+https://github.com/spiceai/duckdb-rs.git?rev=b1cf1723252204caf6262865255cd47e7435cbbe#b1cf1723252204caf6262865255cd47e7435cbbe"
 dependencies = [
  "cc",
  "flate2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ datafusion-proto = { version = "52" }
 datafusion-physical-expr = { version = "52" }
 datafusion-physical-plan = { version = "52" }
 datafusion-table-providers = { path = "core" }
-duckdb = { git = "https://github.com/spiceai/duckdb-rs.git", rev = "a33cc3c30b4b24b1fce702ae6f8e052232915c0a" } # spiceai duckdb-rs fork: duckdb_scan_arrow (pending https://github.com/duckdb/duckdb-rs/pull/488) + statically-linked VSS (HNSW)
+duckdb = { git = "https://github.com/spiceai/duckdb-rs.git", rev = "b1cf1723252204caf6262865255cd47e7435cbbe" } # spiceai duckdb-rs fork: duckdb_scan_arrow (pending https://github.com/duckdb/duckdb-rs/pull/488) + statically-linked VSS (HNSW), DuckDB version pinned to v1.5.3
 adbc_core = { version = "0.23" }
 adbc_driver_manager = { version = "0.23" }
 parquet = "57"


### PR DESCRIPTION
## Summary

Bumps the `duckdb` (spiceai duckdb-rs fork) pin from `a33cc3c3` to **`b1cf1723`** — the head of `spiceai/duckdb-rs` `spiceai-1.5.3` after [spiceai/duckdb-rs#38](https://github.com/spiceai/duckdb-rs/pull/38) (merged).

#38 pins the **bundled DuckDB version to the release (`v1.5.3`)** during source generation. Without it, the duckdb-sources commit (which includes the vendored static `vss` extension) sits past the `v1.5.3` tag, so `git describe` reported a dev version (`v1.5.4-dev5`). A dev version makes DuckDB resolve **downloadable** extensions (tpch/tpcds/...) by commit hash, which **404**s — breaking consumers that load them.

Follow-up to #658 (which introduced the static-vss duckdb-rs).

## Change

- `Cargo.toml`: `duckdb` rev `a33cc3c3` -> `b1cf1723`.
- `Cargo.lock`: the two `duckdb` / `libduckdb-sys` git source entries updated to the new rev (source-string only; no DuckDB Rust API change between the revs).

## Validation

`cargo metadata --locked` resolves cleanly. Verified locally (in the downstream spiceai build) that the pinned `v1.5.3` build installs the `tpch` extension via `INSTALL tpch; LOAD tpch;` — it downloads `extensions.duckdb.org/v1.5.3/<platform>/tpch.duckdb_extension` (no 404) and generates data. Keeps table-providers' duckdb in sync with consumers that pin the same rev (avoids duplicate `libduckdb-sys` / `links = "duckdb"`).