### PR TITLE
Bump spiceai duckdb-rs fork to 7648ff8c (vendored vss; fix Windows build)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2483,7 +2483,7 @@ checksum = "d8b14ccef22fc6f5a8f4d7d768562a182c04ce9a3b3157b91390b52ddfdf1a76"
 [[package]]
 name = "duckdb"
 version = "1.10503.1"
-source = "git+https://github.com/spiceai/duckdb-rs.git?rev=b1cf1723252204caf6262865255cd47e7435cbbe#b1cf1723252204caf6262865255cd47e7435cbbe"
+source = "git+https://github.com/spiceai/duckdb-rs.git?rev=7648ff8c7d1ff06576478d518415e1ba0eac659c#7648ff8c7d1ff06576478d518415e1ba0eac659c"
 dependencies = [
  "arrow",
  "cast",
@@ -3720,7 +3720,7 @@ dependencies = [
 [[package]]
 name = "libduckdb-sys"
 version = "1.10503.1"
-source = "git+https://github.com/spiceai/duckdb-rs.git?rev=b1cf1723252204caf6262865255cd47e7435cbbe#b1cf1723252204caf6262865255cd47e7435cbbe"
+source = "git+https://github.com/spiceai/duckdb-rs.git?rev=7648ff8c7d1ff06576478d518415e1ba0eac659c#7648ff8c7d1ff06576478d518415e1ba0eac659c"
 dependencies = [
  "cc",
  "flate2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ datafusion-proto = { version = "52" }
 datafusion-physical-expr = { version = "52" }
 datafusion-physical-plan = { version = "52" }
 datafusion-table-providers = { path = "core" }
-duckdb = { git = "https://github.com/spiceai/duckdb-rs.git", rev = "b1cf1723252204caf6262865255cd47e7435cbbe" } # spiceai duckdb-rs fork: duckdb_scan_arrow (pending https://github.com/duckdb/duckdb-rs/pull/488) + statically-linked VSS (HNSW), DuckDB version pinned to v1.5.3
+duckdb = { git = "https://github.com/spiceai/duckdb-rs.git", rev = "7648ff8c7d1ff06576478d518415e1ba0eac659c" } # spiceai duckdb-rs fork: duckdb_scan_arrow (pending https://github.com/duckdb/duckdb-rs/pull/488) + statically-linked VSS (HNSW, vendored), DuckDB version pinned to v1.5.3
 adbc_core = { version = "0.23" }
 adbc_driver_manager = { version = "0.23" }
 parquet = "57"


### PR DESCRIPTION
## Summary

Bumps the `duckdb` (spiceai duckdb-rs fork) pin from `b1cf1723` to **`7648ff8c`** — the head of `spiceai/duckdb-rs` `spiceai-1.5.3` after [spiceai/duckdb-rs#39](https://github.com/spiceai/duckdb-rs/pull/39), which vendors the VSS extension as committed files instead of a git submodule.

## Why

Cargo recursively checks out **all** submodules of this git dependency. The previous vss *submodule* dragged in duckdb-vss's own nested `duckdb` submodule, whose deeply-nested Swift example path exceeds Windows' `MAX_PATH` — breaking the Windows build. Vendoring the vss source as files removes all submodules from the dependency.

## Change

- `Cargo.toml`: `duckdb` rev `b1cf1723` -> `7648ff8c`.
- `Cargo.lock`: the two `duckdb` / `libduckdb-sys` git source entries updated to the new rev (source-string only; no DuckDB Rust API change between the revs).

## Validation

`cargo metadata --locked` resolves cleanly. Keeps table-providers' duckdb in sync with consumers that pin the same rev (avoids duplicate `libduckdb-sys` / `links = "duckdb"`).