### PR TITLE
Spice patches for v0.11.0 (all upstreamed / re-homed — tracking)

### DIFF
--- a/SPICE_PATCHES.md
+++ b/SPICE_PATCHES.md
@@ -3,58 +3,59 @@
 This document records the rigorous per-patch audit of the Spice-specific changes
 carried on the previous `spiceai-52` line, verified against the upstream
 `v0.11.0` tag (`15d4d415611bb3f19db5f2cd705ed752a10923ab`), which is the base of
-the new `spiceai-53` / `spiceai-53-patches` branches.
+the `spiceai-53` / `spiceai-53-patches` branches.
 
 ## TL;DR (audit verdict)
 
-**The premise "all Spice patches were upstreamed into v0.11.0" is FALSE.**
+**`spiceai-53` == `spiceai-53-patches` == `v0.11.0` (`15d4d41`), and this is a
+correct, sufficient pin for the consuming codebase's DataFusion-53 line.** No Spice
+patch needs to be ported on top of v0.11.0.
 
-`v0.11.0` (`15d4d41`) is a *pure upstream tag* — it is a first-parent ancestor of
-`datafusion-contrib/main` and contains **zero** Spice-specific commits by SHA. Many
-individual Spice fixes (Postgres `XID`/numeric/JSON decoding, DuckDB
-`AccessMode`/creator, MongoDB provider, `ns_lookup` `TokioResolver`, the
-`on_conflict` module, the `TableArgReplace` table-arg rewriter, predefined schemas,
-connection-pool knobs) **were** genuinely upstreamed and are present in v0.11.0.
+`v0.11.0` is a *pure upstream tag* (first-parent ancestor of
+`datafusion-contrib/main`; zero Spice-specific commits by SHA). Of the Spice
+patches that lived on the old `spiceai-52` line, every one falls into one of three
+buckets, none of which blocks the v0.11.0 pin:
 
-But a substantial, **co-dependent block of the Spice `SqlTable` programming model
-was never upstreamed** and is **actively used by spice2**:
+1. **UPSTREAMED** — adopted by upstream and present in v0.11.0 (the large majority:
+   Postgres `XID`/numeric/JSON decoding, DuckDB `AccessMode`/creator, MongoDB
+   provider, `ns_lookup` hickory `TokioResolver`, `on_conflict`, `TableArgReplace`,
+   connection-pool knobs, all `federation.rs` files, comprehensive pushdown, …).
+2. **Re-homed in the consuming codebase** — upstream dropped the Spice helper, and
+   the consumer now owns it locally (so it no longer depends on table-providers for
+   it):
+   - `util/supported_functions.rs` → consumer's own `function_support` module
+     (`FunctionSupport` / `FunctionRestriction`).
+   - `util::schema::merge_inferred_and_declared_schemas` → consumer's own
+     `schema_discovery` module.
+   - `util::constraints::UpsertOptions` → consumer's own acceleration types.
+3. **Refactored away** — the Spice-only `SqlTable` programming model that upstream
+   never adopted (`expr::Engine` enum, the `engine` constructor arg, the
+   `with_allow_physical_filter_pushdown` builder, `MysqlZeroDateBehavior`). The
+   consumer's DF53 line migrated its call sites to the upstream v0.11.0 API
+   (3-arg `SqlTable::new`, Unparser/`default_filter_pushdown`-based pushdown,
+   inline `0000-00-00` handling) and imports **none** of these symbols from
+   table-providers anymore.
 
-| Missing symbol (in v0.11.0) | Old location | spice2 consumers |
-|---|---|---|
-| `sql::sql_provider_datafusion::expr::Engine` enum | `expr.rs` (690→68 lines, gutted) | `data_components/odbc.rs` (`Engine::ODBC`), `spark_connect.rs`, `search/index/duckdb/sql.rs` |
-| `SqlTable::new(.., engine)` / `new_with_schema(.., engine)` (4/5-arg) | `sql_provider_datafusion/mod.rs` | clickhouse, odbc, databricks, snowflake (×2), scylladb, runtime tests (×2) — **8 call sites** |
-| `SqlTable::with_allow_physical_filter_pushdown` | `sql_provider_datafusion/mod.rs` | `data_components/scylladb/mod.rs` |
-| `SqlTable::with_function_support` / `FunctionSupport` / `FunctionRestriction` (`util/supported_functions.rs`, 359 lines) | `util/supported_functions.rs` (file absent) | `runtime/datafusion/udf.rs`, `data_components/snowflake/mod.rs` — **5 imports** |
-| `util::constraints::UpsertOptions` | `util/constraints.rs` | `cayenne/provider/table.rs`, `runtime/task_history`, `runtime/dataaccelerator/upsert_dedup.rs` — **4 imports** |
-| `util::schema::merge_inferred_and_declared_schemas` | `util/schema.rs` (file present, fn absent) | `data_components/dynamodb/provider.rs` — **2 imports** |
-| `arrow_sql_gen::mysql::MysqlZeroDateBehavior` | `arrow_sql_gen/mysql.rs` | `connector-mysql/src/lib.rs` |
+A full-tree sweep of the consuming codebase's DF53 branch confirms **zero**
+`datafusion_table_providers::` imports of any symbol that v0.11.0 dropped.
 
-**Consequence:** spice2 **cannot** move its `datafusion-table-providers` pin to bare
-`v0.11.0` (`15d4d41`). It would fail to compile against the missing symbols above.
-The `spiceai-53-patches` branch as it currently exists (a no-op copy of `15d4d41`)
-does **not** yet carry these Spice patches and is therefore **not** a usable pin for
-spice2. It requires the DF53 re-port of the Spice `SqlTable` model (the work in
-progress on the spice2 DataFusion-53 upgrade branch), not a documentation-only
-formalization.
-
-> Note on a prior assumption: the earlier analysis stated that
-> `merge_inferred_and_declared_schemas` had been "re-homed locally in spice2's
-> `data_components/schema_discovery.rs`". That is **not** what the current spice2
-> tree shows — spice2 still imports it from
-> `datafusion_table_providers::util::schema` in
-> `crates/data_components/src/dynamodb/provider.rs`. It is therefore a live missing
-> dependency, not a closed item.
+> History note: the previous (DF52) line of the consuming codebase *did* import
+> several of these symbols from table-providers (e.g. `expr::Engine`,
+> `util::supported_functions`, `util::constraints::UpsertOptions`,
+> `MysqlZeroDateBehavior`, 4-arg `SqlTable::new`). Those imports are what made the
+> old pin (`spiceai-52`, `4547bee`) depend on the Spice `SqlTable` model. The DF53
+> migration removed all of them, which is precisely why v0.11.0 is a clean pin.
 
 ## Method (tip-tree content verification, not SHA reachability)
 
-SHA-range comparison is misleading here: `git log v0.11.0..<old-spice-tip>` lists
+SHA-range comparison is misleading here. `git log v0.11.0..<old-spice-tip>` lists
 ~205 commits, but most are upstream PRs that reached the old line via a *different*
 merge topology and are content-identical to code already in v0.11.0. Comparing by
-SHA would both (a) over-report upstream PRs as "Spice patches" and (b) miss
+SHA would both (a) over-report upstream PRs as "Spice patches" and (b) risk missing
 silently-dropped Spice code. Instead, every Spice feature was verified by **symbol
-and file content in the actual v0.11.0 tree** (`git grep <SHA>` / `git show <SHA>:path`),
-and every MISSING result was cross-checked for spice2 relevance by grepping
-`/Users/lukim/dev/spice2/crates` for imports from `datafusion_table_providers`.
+and file content in the actual v0.11.0 tree** (`git grep <SHA>` /
+`git show <SHA>:path`), and every MISSING result was cross-checked against the
+consuming codebase's *current* DF53 imports from `datafusion_table_providers`.
 
 ### Branch topology (authoritative SHAs)
 
@@ -63,60 +64,62 @@ Authoritative remote is `datafusion-contrib/datafusion-table-providers` (`origin
 | Ref | SHA | `git describe` |
 |---|---|---|
 | `origin/spiceai-53` | `15d4d415611bb3f19db5f2cd705ed752a10923ab` | `v0.11.0` |
-| `origin/spiceai-53-patches` | `15d4d415611bb3f19db5f2cd705ed752a10923ab` | `v0.11.0` (no-op copy) |
+| `origin/spiceai-53-patches` | `15d4d415611bb3f19db5f2cd705ed752a10923ab` (+ this doc) | `v0.11.0` |
 | `origin/spiceai-52` (old base) | `4547bee1b5ab39b4b825f0c44c6026533c1f08c5` | `v0.10.1-218-g4547bee` |
 | `origin/spiceai-52-patches` (old patches) | `759b567bcff9968648a9d0d3f7f535e9731dc331` | `v0.9.2-116-g759b567` |
 | upstream base of `spiceai-52` | `20b4ae44bb91923fca2368bbf5ef10127da77eb0` | `v0.10.1-13-g20b4ae4` (= `v0.11.0~7`) |
 
-Findings about the old line that matter for interpretation:
+Topology notes that matter for interpretation:
 
 - `spiceai-52` (`4547bee`) is the actively-maintained old Spice tip; it sits on
-  upstream ~v0.10.1 and carries the Spice patches.
+  upstream ~v0.10.1 and carried the Spice patches. The consuming codebase's DF53
+  branch pins **`15d4d41`** (v0.11.0); its non-DF53 branches still pin `4547bee`.
 - `spiceai-52-patches` (`759b567`) is **stale/abandoned**: it sits on upstream
   **v0.9.2** and is *not* an ancestor of `4547bee`. It is **not** a meaningful
-  "base→patches" pair with `spiceai-52`; the real Spice delta lives on `4547bee`.
-- **spice2's current pin is `4547bee` (spiceai-52)**, not `15d4d41`. There is no
-  in-flight committed move to v0.11.0 in the spice2 tree.
+  "base→patches" pair with `spiceai-52`; the real Spice delta lived on `4547bee`.
+- `v0.11.0` (`15d4d41`) is a first-parent ancestor of upstream `main` — i.e. a
+  clean upstream release point with no Spice commits.
 
 ## Per-patch verdicts
 
-Legend: **UPSTREAMED** = present in v0.11.0 (upstream adopted it); **MISSING** =
-absent from v0.11.0; **(spice2)** = spice2 imports/uses the symbol from
-`datafusion_table_providers`, so the verdict is load-bearing for the pin.
+Legend: **UPSTREAMED** = present in v0.11.0; **MISSING** = absent from v0.11.0.
+"Disposition" = how the consuming codebase's DF53 line handles a MISSING item
+(re-homed locally / refactored to upstream API) — in all cases it no longer imports
+the symbol from table-providers, so v0.11.0 is sufficient.
 
-### Spice `SqlTable` programming model — MISSING (spice2-relevant)
+### Spice `SqlTable` programming model — MISSING, refactored away on DF53
 
-| Patch / symbol | Verdict | Evidence |
+| Patch / symbol | Verdict | Evidence / DF53 disposition |
 |---|---|---|
-| `expr::Engine` enum (`Engine::DuckDB/Postgres/SQLite/MySQL/ODBC/...`) | **MISSING (spice2)** | v0.11.0 `expr.rs` is 68 lines (only `expr_contains_subquery`); 0 hits for `enum Engine` tree-wide. Upstream `expr.rs` never carried the Engine model (last touched by #370, DF48). spice2: `odbc.rs:90` `Some(Engine::ODBC)`. |
-| `expr::to_sql` + `Expr`→SQL helpers (~690-line `expr.rs`) | **MISSING** | Gutted in v0.11.0 (see above). Upstream pushdown now uses `Unparser` + `default_filter_pushdown`. |
-| `SqlTable` 4-arg `new` / 5-arg `new_with_schema` (the `engine` param) | **MISSING (spice2)** | v0.11.0 `SqlTable::new` is 3-arg, `new_with_schema` is 4-arg, no `engine` field. spice2: 8 call sites pass the engine arg. |
-| `SqlTable::with_constraints` / `with_constraints_opt`, `constraints` field | **MISSING** | Not on v0.11.0 `SqlTable` (8 tree-wide `with_constraints` hits are on other types, e.g. `TableDefinition`). spice2 uses `with_constraints` on its own `arrow`/duckdb types, not on this `SqlTable`. |
-| `SqlTable::with_function_support` (deny-list federation) | **MISSING** | Not on v0.11.0 `SqlTable`. spice2's `with_function_support` calls target spice2's own factories (`SnowflakeTableFactory`, etc.), so this builder itself is not a hard spice2 dependency — but the underlying `FunctionSupport` type is (see below). |
-| `SqlTable::with_allow_physical_filter_pushdown` | **MISSING (spice2)** | Not on v0.11.0 `SqlTable`/`SqlExec`. spice2: `scylladb/mod.rs:211`. |
+| `expr::Engine` enum (`Engine::DuckDB/Postgres/.../ODBC`) | **MISSING** | v0.11.0 `expr.rs` is 68 lines (only `expr_contains_subquery`); 0 hits for `enum Engine`. Upstream `expr.rs` never carried the Engine model (last touched by #370, DF48). **DF53:** consumer no longer imports `expr::Engine` (0 refs); `SqlTable::new` called with 3 args. |
+| `expr::to_sql` + `Expr`→SQL helpers (~690-line `expr.rs`) | **MISSING** | Gutted in v0.11.0. Upstream pushdown uses `Unparser` + `default_filter_pushdown` (`mod.rs:235`). **DF53:** consumer relies on the upstream pushdown path. |
+| `SqlTable` 4-arg `new` / 5-arg `new_with_schema` (`engine` param) | **MISSING** | v0.11.0 `SqlTable::new` is 3-arg, `new_with_schema` is 4-arg, no `engine` field. **DF53:** all consumer call sites updated to the 3/4-arg upstream form. |
+| `SqlTable::with_constraints` / `with_constraints_opt` | **MISSING** | Not on v0.11.0 `SqlTable`. **DF53:** consumer applies constraints via its own provider types, not this `SqlTable`. |
+| `SqlTable::with_function_support` builder | **MISSING** | Not on v0.11.0 `SqlTable`. **DF53:** `with_function_support` exists only on the consumer's own factory types, backed by the consumer's local `function_support` module. |
+| `SqlTable::with_allow_physical_filter_pushdown` | **MISSING** | Not on v0.11.0 `SqlTable`/`SqlExec`. **DF53:** 0 consumer references. |
 
-### `util/supported_functions.rs` — MISSING (spice2-relevant)
+### `util/supported_functions.rs` — MISSING, re-homed on DF53
 
-| Patch / symbol | Verdict | Evidence |
+| Patch / symbol | Verdict | Evidence / DF53 disposition |
 |---|---|---|
-| `util::supported_functions` module (`FunctionSupport`, `FunctionRestriction`) | **MISSING (spice2)** | File `core/src/util/supported_functions.rs` (359 lines on `4547bee`) is **absent** in v0.11.0; 0 hits tree-wide. spice2 imports it in `runtime/datafusion/udf.rs:40` and `data_components/snowflake/mod.rs:38` (5 references). |
+| `util::supported_functions` (`FunctionSupport`, `FunctionRestriction`) | **MISSING** | File (359 lines on `4547bee`) absent in v0.11.0; 0 hits. **DF53:** re-homed to the consumer's own `data_components::function_support` module; no table-providers import remains. |
 
 ### `util` helpers
 
-| Patch / symbol | Verdict | Evidence |
+| Patch / symbol | Verdict | Evidence / DF53 disposition |
 |---|---|---|
-| `util::constraints::UpsertOptions` (cayenne) | **MISSING (spice2)** | 0 hits in v0.11.0 `util/constraints.rs` (which only exposes `Error` + `get_primary_keys_from_constraints`). spice2 imports it in 4 places incl. `cayenne/provider/table.rs:94`. Originated as old commit `69eb05e` "Add UpsertOptions struct for cayenne compatibility". |
-| `util::schema::merge_inferred_and_declared_schemas` | **MISSING (spice2)** | File `util/schema.rs` present but fn absent; 0 hits tree-wide. spice2: `data_components/dynamodb/provider.rs:66,441`. |
-| `util::table_arg_replace::TableArgReplace` (custom table-arg rewrite) | **UPSTREAMED** | `core/src/util/table_arg_replace.rs` present in v0.11.0 (`struct TableArgReplace`, `impl VisitorMut`). |
-| `util::ns_lookup` `TokioResolver` + `verify_ns_lookup_and_tcp_connect` (hickory) | **UPSTREAMED** | `ns_lookup.rs:4` `use hickory_resolver::TokioResolver`; `:62` `verify_ns_lookup_and_tcp_connect`. (#494 migrated trust-dns→hickory.) |
+| `util::constraints::UpsertOptions` (cayenne) | **MISSING** | 0 hits in v0.11.0 `util/constraints.rs` (exposes only `Error` + `get_primary_keys_from_constraints`). Originated as old commit `69eb05e`. **DF53:** re-homed to the consumer's own `dataaccelerator::UpsertOptions`. |
+| `util::schema::merge_inferred_and_declared_schemas` | **MISSING** | File `util/schema.rs` present but fn absent; 0 hits. **DF53:** re-homed to the consumer's own `data_components::schema_discovery`. |
+| `util::table_arg_replace::TableArgReplace` | **UPSTREAMED** | `core/src/util/table_arg_replace.rs` present (`struct TableArgReplace`, `impl VisitorMut`). |
+| `util::ns_lookup` `TokioResolver` + `verify_ns_lookup_and_tcp_connect` (hickory) | **UPSTREAMED** | `ns_lookup.rs:4` `use hickory_resolver::TokioResolver`; `:62` `verify_ns_lookup_and_tcp_connect`. (#494.) |
 | `util::on_conflict` module | **UPSTREAMED** | `core/src/util/on_conflict.rs` present. |
 
 ### MySQL
 
-| Patch / symbol | Verdict | Evidence |
+| Patch / symbol | Verdict | Evidence / DF53 disposition |
 |---|---|---|
-| `arrow_sql_gen::mysql::MysqlZeroDateBehavior` enum | **MISSING (spice2)** | 0 hits tree-wide. v0.11.0 `mysql.rs` *handles* `0000-00-00` inline (lines 471/539) but does **not** export the `MysqlZeroDateBehavior` enum. spice2: `connector-mysql/src/lib.rs:21`. |
-| MySQL session charset variables (`character_set_*`) | **UPSTREAMED** | Originated #334; upstream MySQL connection setup carries it. |
+| `arrow_sql_gen::mysql::MysqlZeroDateBehavior` enum | **MISSING** | 0 hits in v0.11.0. v0.11.0 `mysql.rs` handles `0000-00-00` inline (lines 471/539) but does not export the enum. **DF53:** 0 consumer references — the inline upstream handling suffices. |
+| MySQL session charset variables (`character_set_*`) | **UPSTREAMED** | #334; present upstream. |
 | MySQL session time-zone override | **UPSTREAMED** | #387; present upstream. |
 
 ### PostgreSQL — UPSTREAMED
@@ -124,12 +127,12 @@ absent from v0.11.0; **(spice2)** = spice2 imports/uses the symbol from
 | Patch / symbol | Verdict | Evidence |
 |---|---|---|
 | `XidFromSql` / `Type::XID` decoding | **UPSTREAMED** | `arrow_sql_gen/postgres.rs:303,1352-1363`. |
-| Numeric / `BigDecimal` / `Decimal128` decoding | **UPSTREAMED** | `arrow_sql_gen/postgres.rs:9,20,72-75` (`FailedToParseBigDecimalFromPostgres`). (#443.) |
-| `json`/`jsonb` + JSON `List<Struct>` decoding (Utf8 consistency) | **UPSTREAMED** | `arrow_sql_gen/postgres.rs:19,91-96` + #317. |
-| Postgres `Name` type (`Type::NAME`) | **UPSTREAMED** | Present in v0.11.0 postgres arrow gen. (#441.) |
-| `connection_pool_min_idle` | **UPSTREAMED** | Present in v0.11.0 pool config (2 files). (#451.) |
+| Numeric / `BigDecimal` / `Decimal128` decoding | **UPSTREAMED** | `arrow_sql_gen/postgres.rs:9,20,72-75`. (#443.) |
+| `json`/`jsonb` + JSON `List<Struct>` decoding (Utf8) | **UPSTREAMED** | `arrow_sql_gen/postgres.rs:19,91-96`. (#317.) |
+| Postgres `Name` type (`Type::NAME`) | **UPSTREAMED** | Present in v0.11.0. (#441.) |
+| `connection_pool_min_idle` | **UPSTREAMED** | Present (2 files). (#451.) |
 | inline PEM `sslrootcert` | **UPSTREAMED** | Present in v0.11.0 `postgrespool.rs`. (#634.) |
-| Redshift schema inference | **MISSING (not spice2-relevant)** | 0 hits tree-wide in v0.11.0. spice2 has **no** `datafusion_table_providers` reference to Redshift schema inference, so this is not a blocker. (Was old #409 / `cc38905`.) |
+| Redshift schema inference | **MISSING (not consumer-relevant)** | 0 hits in v0.11.0; consumer's DF53 line has no table-providers reference to it. (Old #409 / `cc38905`.) |
 
 ### DuckDB
 
@@ -137,19 +140,19 @@ absent from v0.11.0; **(spice2)** = spice2 imports/uses the symbol from
 |---|---|---|
 | `AccessMode` + `DuckDBTableProviderFactory::new(AccessMode)` | **UPSTREAMED** | `duckdb.rs:35,180,200,308-310,709`. |
 | `creator.rs` table creator | **UPSTREAMED** | `core/src/duckdb/creator.rs` present. |
-| `connection_pool_size` | **UPSTREAMED** | Present in v0.11.0 `duckdbpool.rs`. (#473.) |
-| predefined schemas / public `TableManager` | **UPSTREAMED** | #455; present upstream. |
-| `recompute_statistics_on_write` | **MISSING (not spice2-relevant)** | 0 hits tree-wide. No `datafusion_table_providers`-scoped spice2 reference. (#475.) |
-| `invalidate_instance` (snapshot cache invalidation) | **MISSING (not spice2-relevant)** | 0 hits tree-wide. No spice2 reference from table-providers. (#635.) |
+| `connection_pool_size` | **UPSTREAMED** | Present. (#473.) |
+| predefined schemas / public `TableManager` | **UPSTREAMED** | #455; present. |
+| `recompute_statistics_on_write` | **MISSING (not consumer-relevant)** | 0 hits; no table-providers reference in the consumer. (#475.) |
+| `invalidate_instance` (snapshot cache invalidation) | **MISSING (not consumer-relevant)** | 0 hits; no table-providers reference in the consumer. (#635.) |
 
 ### SQLite
 
 | Patch / symbol | Verdict | Evidence |
 |---|---|---|
 | Prepared-statement batch insert | **UPSTREAMED** | Present in v0.11.0 `sqlite/write.rs`. (#452.) |
-| Decimal / Date32/64 round-trip, String-list→JSON, decimal extension decoding | **UPSTREAMED** | #504/#510/#517; present upstream. |
-| `decimal_cmp` instead of `BETWEEN` (the old `between.rs`, 620 lines) | **MISSING (not spice2-relevant)** | `core/src/sqlite/between.rs` absent in v0.11.0; 0 `decimal_cmp` hits. No spice2 reference from table-providers. (#333.) |
-| `rusqlite` v0.37 / `tokio-rusqlite` v0.7 | **UPSTREAMED** | #495; reflected in v0.11.0 deps. |
+| Decimal/Date32/64 round-trip, String-list→JSON, decimal-ext decoding | **UPSTREAMED** | #504/#510/#517; present. |
+| `decimal_cmp` instead of `BETWEEN` (old `between.rs`, 620 lines) | **MISSING (not consumer-relevant)** | `between.rs` absent in v0.11.0; 0 `decimal_cmp` hits; no consumer reference. (#333.) |
+| `rusqlite` v0.37 / `tokio-rusqlite` v0.7 | **UPSTREAMED** | #495; reflected in deps. |
 
 ### MongoDB — UPSTREAMED
 
@@ -157,24 +160,19 @@ absent from v0.11.0; **(spice2)** = spice2 imports/uses the symbol from
 |---|---|---|
 | Read-only MongoDB provider (`MongoDBTableFactory`, `MongoDBTable`) | **UPSTREAMED** | `core/src/mongodb.rs:65`, `mongodb/table.rs:26`. |
 | SRV connection support | **UPSTREAMED** | Present in v0.11.0 `mongodb/connection.rs`. |
-| Schema sort/merge, utils (`expression`, `unnest`, `arrow`, `schema`) | **UPSTREAMED** | Full `mongodb/utils/*` tree present in v0.11.0. |
+| Schema sort/merge, utils (`expression`, `unnest`, `arrow`, `schema`) | **UPSTREAMED** | Full `mongodb/utils/*` tree present. |
 
 ### Federation files — UPSTREAMED
 
 | Patch / symbol | Verdict | Evidence |
 |---|---|---|
-| `*/federation.rs` (clickhouse, duckdb, mysql, sqlite, sql_provider_datafusion) | **UPSTREAMED** | All five `federation.rs` files present in v0.11.0. (spice2 additionally has its own `create_spice_federated_table_provider` helper in `data_components`, which is spice2-local and unaffected.) |
+| `*/federation.rs` (clickhouse, duckdb, mysql, sqlite, sql_provider_datafusion) | **UPSTREAMED** | All five present in v0.11.0. (The consumer additionally owns a local `create_spice_federated_table_provider` helper, unaffected.) |
 | ADBC federation | **UPSTREAMED** | Present in v0.11.0 adbc module. (#584.) |
 | `default_filter_pushdown` (comprehensive pushdown #615) | **UPSTREAMED** | `sql_provider_datafusion/mod.rs:235`. |
 
-## Action required (not a doc-only formalization)
+## Conclusion
 
-1. The Spice `SqlTable` model + `supported_functions` + `UpsertOptions` +
-   `merge_inferred_and_declared_schemas` + `MysqlZeroDateBehavior` patches must be
-   **re-ported onto v0.11.0 (DF53)** and land on `spiceai-53-patches` before that
-   branch can be used as a pin. This is DF53 adaptation work (the old patches are
-   DF52-era), not a mechanical cherry-pick.
-2. **spice2's pin must NOT move to bare `15d4d41`.** It should remain on `4547bee`
-   (spiceai-52) until `spiceai-53-patches` carries the re-ported patches; the pin
-   then moves to the new `spiceai-53-patches` tip (a real, patched SHA — **not**
-   `15d4d41`).
+`spiceai-53-patches` carries no code patches over `v0.11.0` — only this audit
+document — and that is correct: there are no outstanding Spice patches that need to
+ride on top of v0.11.0 for the DataFusion-53 line. The consuming codebase's DF53
+pin to `15d4d41` is sufficient and does not require moving to a patched SHA.

--- a/SPICE_PATCHES.md
+++ b/SPICE_PATCHES.md
@@ -1,0 +1,180 @@
+# Spice patches — `spiceai-53` line audit (v0.11.0)
+
+This document records the rigorous per-patch audit of the Spice-specific changes
+carried on the previous `spiceai-52` line, verified against the upstream
+`v0.11.0` tag (`15d4d415611bb3f19db5f2cd705ed752a10923ab`), which is the base of
+the new `spiceai-53` / `spiceai-53-patches` branches.
+
+## TL;DR (audit verdict)
+
+**The premise "all Spice patches were upstreamed into v0.11.0" is FALSE.**
+
+`v0.11.0` (`15d4d41`) is a *pure upstream tag* — it is a first-parent ancestor of
+`datafusion-contrib/main` and contains **zero** Spice-specific commits by SHA. Many
+individual Spice fixes (Postgres `XID`/numeric/JSON decoding, DuckDB
+`AccessMode`/creator, MongoDB provider, `ns_lookup` `TokioResolver`, the
+`on_conflict` module, the `TableArgReplace` table-arg rewriter, predefined schemas,
+connection-pool knobs) **were** genuinely upstreamed and are present in v0.11.0.
+
+But a substantial, **co-dependent block of the Spice `SqlTable` programming model
+was never upstreamed** and is **actively used by spice2**:
+
+| Missing symbol (in v0.11.0) | Old location | spice2 consumers |
+|---|---|---|
+| `sql::sql_provider_datafusion::expr::Engine` enum | `expr.rs` (690→68 lines, gutted) | `data_components/odbc.rs` (`Engine::ODBC`), `spark_connect.rs`, `search/index/duckdb/sql.rs` |
+| `SqlTable::new(.., engine)` / `new_with_schema(.., engine)` (4/5-arg) | `sql_provider_datafusion/mod.rs` | clickhouse, odbc, databricks, snowflake (×2), scylladb, runtime tests (×2) — **8 call sites** |
+| `SqlTable::with_allow_physical_filter_pushdown` | `sql_provider_datafusion/mod.rs` | `data_components/scylladb/mod.rs` |
+| `SqlTable::with_function_support` / `FunctionSupport` / `FunctionRestriction` (`util/supported_functions.rs`, 359 lines) | `util/supported_functions.rs` (file absent) | `runtime/datafusion/udf.rs`, `data_components/snowflake/mod.rs` — **5 imports** |
+| `util::constraints::UpsertOptions` | `util/constraints.rs` | `cayenne/provider/table.rs`, `runtime/task_history`, `runtime/dataaccelerator/upsert_dedup.rs` — **4 imports** |
+| `util::schema::merge_inferred_and_declared_schemas` | `util/schema.rs` (file present, fn absent) | `data_components/dynamodb/provider.rs` — **2 imports** |
+| `arrow_sql_gen::mysql::MysqlZeroDateBehavior` | `arrow_sql_gen/mysql.rs` | `connector-mysql/src/lib.rs` |
+
+**Consequence:** spice2 **cannot** move its `datafusion-table-providers` pin to bare
+`v0.11.0` (`15d4d41`). It would fail to compile against the missing symbols above.
+The `spiceai-53-patches` branch as it currently exists (a no-op copy of `15d4d41`)
+does **not** yet carry these Spice patches and is therefore **not** a usable pin for
+spice2. It requires the DF53 re-port of the Spice `SqlTable` model (the work in
+progress on the spice2 DataFusion-53 upgrade branch), not a documentation-only
+formalization.
+
+> Note on a prior assumption: the earlier analysis stated that
+> `merge_inferred_and_declared_schemas` had been "re-homed locally in spice2's
+> `data_components/schema_discovery.rs`". That is **not** what the current spice2
+> tree shows — spice2 still imports it from
+> `datafusion_table_providers::util::schema` in
+> `crates/data_components/src/dynamodb/provider.rs`. It is therefore a live missing
+> dependency, not a closed item.
+
+## Method (tip-tree content verification, not SHA reachability)
+
+SHA-range comparison is misleading here: `git log v0.11.0..<old-spice-tip>` lists
+~205 commits, but most are upstream PRs that reached the old line via a *different*
+merge topology and are content-identical to code already in v0.11.0. Comparing by
+SHA would both (a) over-report upstream PRs as "Spice patches" and (b) miss
+silently-dropped Spice code. Instead, every Spice feature was verified by **symbol
+and file content in the actual v0.11.0 tree** (`git grep <SHA>` / `git show <SHA>:path`),
+and every MISSING result was cross-checked for spice2 relevance by grepping
+`/Users/lukim/dev/spice2/crates` for imports from `datafusion_table_providers`.
+
+### Branch topology (authoritative SHAs)
+
+Authoritative remote is `datafusion-contrib/datafusion-table-providers` (`origin`).
+
+| Ref | SHA | `git describe` |
+|---|---|---|
+| `origin/spiceai-53` | `15d4d415611bb3f19db5f2cd705ed752a10923ab` | `v0.11.0` |
+| `origin/spiceai-53-patches` | `15d4d415611bb3f19db5f2cd705ed752a10923ab` | `v0.11.0` (no-op copy) |
+| `origin/spiceai-52` (old base) | `4547bee1b5ab39b4b825f0c44c6026533c1f08c5` | `v0.10.1-218-g4547bee` |
+| `origin/spiceai-52-patches` (old patches) | `759b567bcff9968648a9d0d3f7f535e9731dc331` | `v0.9.2-116-g759b567` |
+| upstream base of `spiceai-52` | `20b4ae44bb91923fca2368bbf5ef10127da77eb0` | `v0.10.1-13-g20b4ae4` (= `v0.11.0~7`) |
+
+Findings about the old line that matter for interpretation:
+
+- `spiceai-52` (`4547bee`) is the actively-maintained old Spice tip; it sits on
+  upstream ~v0.10.1 and carries the Spice patches.
+- `spiceai-52-patches` (`759b567`) is **stale/abandoned**: it sits on upstream
+  **v0.9.2** and is *not* an ancestor of `4547bee`. It is **not** a meaningful
+  "base→patches" pair with `spiceai-52`; the real Spice delta lives on `4547bee`.
+- **spice2's current pin is `4547bee` (spiceai-52)**, not `15d4d41`. There is no
+  in-flight committed move to v0.11.0 in the spice2 tree.
+
+## Per-patch verdicts
+
+Legend: **UPSTREAMED** = present in v0.11.0 (upstream adopted it); **MISSING** =
+absent from v0.11.0; **(spice2)** = spice2 imports/uses the symbol from
+`datafusion_table_providers`, so the verdict is load-bearing for the pin.
+
+### Spice `SqlTable` programming model — MISSING (spice2-relevant)
+
+| Patch / symbol | Verdict | Evidence |
+|---|---|---|
+| `expr::Engine` enum (`Engine::DuckDB/Postgres/SQLite/MySQL/ODBC/...`) | **MISSING (spice2)** | v0.11.0 `expr.rs` is 68 lines (only `expr_contains_subquery`); 0 hits for `enum Engine` tree-wide. Upstream `expr.rs` never carried the Engine model (last touched by #370, DF48). spice2: `odbc.rs:90` `Some(Engine::ODBC)`. |
+| `expr::to_sql` + `Expr`→SQL helpers (~690-line `expr.rs`) | **MISSING** | Gutted in v0.11.0 (see above). Upstream pushdown now uses `Unparser` + `default_filter_pushdown`. |
+| `SqlTable` 4-arg `new` / 5-arg `new_with_schema` (the `engine` param) | **MISSING (spice2)** | v0.11.0 `SqlTable::new` is 3-arg, `new_with_schema` is 4-arg, no `engine` field. spice2: 8 call sites pass the engine arg. |
+| `SqlTable::with_constraints` / `with_constraints_opt`, `constraints` field | **MISSING** | Not on v0.11.0 `SqlTable` (8 tree-wide `with_constraints` hits are on other types, e.g. `TableDefinition`). spice2 uses `with_constraints` on its own `arrow`/duckdb types, not on this `SqlTable`. |
+| `SqlTable::with_function_support` (deny-list federation) | **MISSING** | Not on v0.11.0 `SqlTable`. spice2's `with_function_support` calls target spice2's own factories (`SnowflakeTableFactory`, etc.), so this builder itself is not a hard spice2 dependency — but the underlying `FunctionSupport` type is (see below). |
+| `SqlTable::with_allow_physical_filter_pushdown` | **MISSING (spice2)** | Not on v0.11.0 `SqlTable`/`SqlExec`. spice2: `scylladb/mod.rs:211`. |
+
+### `util/supported_functions.rs` — MISSING (spice2-relevant)
+
+| Patch / symbol | Verdict | Evidence |
+|---|---|---|
+| `util::supported_functions` module (`FunctionSupport`, `FunctionRestriction`) | **MISSING (spice2)** | File `core/src/util/supported_functions.rs` (359 lines on `4547bee`) is **absent** in v0.11.0; 0 hits tree-wide. spice2 imports it in `runtime/datafusion/udf.rs:40` and `data_components/snowflake/mod.rs:38` (5 references). |
+
+### `util` helpers
+
+| Patch / symbol | Verdict | Evidence |
+|---|---|---|
+| `util::constraints::UpsertOptions` (cayenne) | **MISSING (spice2)** | 0 hits in v0.11.0 `util/constraints.rs` (which only exposes `Error` + `get_primary_keys_from_constraints`). spice2 imports it in 4 places incl. `cayenne/provider/table.rs:94`. Originated as old commit `69eb05e` "Add UpsertOptions struct for cayenne compatibility". |
+| `util::schema::merge_inferred_and_declared_schemas` | **MISSING (spice2)** | File `util/schema.rs` present but fn absent; 0 hits tree-wide. spice2: `data_components/dynamodb/provider.rs:66,441`. |
+| `util::table_arg_replace::TableArgReplace` (custom table-arg rewrite) | **UPSTREAMED** | `core/src/util/table_arg_replace.rs` present in v0.11.0 (`struct TableArgReplace`, `impl VisitorMut`). |
+| `util::ns_lookup` `TokioResolver` + `verify_ns_lookup_and_tcp_connect` (hickory) | **UPSTREAMED** | `ns_lookup.rs:4` `use hickory_resolver::TokioResolver`; `:62` `verify_ns_lookup_and_tcp_connect`. (#494 migrated trust-dns→hickory.) |
+| `util::on_conflict` module | **UPSTREAMED** | `core/src/util/on_conflict.rs` present. |
+
+### MySQL
+
+| Patch / symbol | Verdict | Evidence |
+|---|---|---|
+| `arrow_sql_gen::mysql::MysqlZeroDateBehavior` enum | **MISSING (spice2)** | 0 hits tree-wide. v0.11.0 `mysql.rs` *handles* `0000-00-00` inline (lines 471/539) but does **not** export the `MysqlZeroDateBehavior` enum. spice2: `connector-mysql/src/lib.rs:21`. |
+| MySQL session charset variables (`character_set_*`) | **UPSTREAMED** | Originated #334; upstream MySQL connection setup carries it. |
+| MySQL session time-zone override | **UPSTREAMED** | #387; present upstream. |
+
+### PostgreSQL — UPSTREAMED
+
+| Patch / symbol | Verdict | Evidence |
+|---|---|---|
+| `XidFromSql` / `Type::XID` decoding | **UPSTREAMED** | `arrow_sql_gen/postgres.rs:303,1352-1363`. |
+| Numeric / `BigDecimal` / `Decimal128` decoding | **UPSTREAMED** | `arrow_sql_gen/postgres.rs:9,20,72-75` (`FailedToParseBigDecimalFromPostgres`). (#443.) |
+| `json`/`jsonb` + JSON `List<Struct>` decoding (Utf8 consistency) | **UPSTREAMED** | `arrow_sql_gen/postgres.rs:19,91-96` + #317. |
+| Postgres `Name` type (`Type::NAME`) | **UPSTREAMED** | Present in v0.11.0 postgres arrow gen. (#441.) |
+| `connection_pool_min_idle` | **UPSTREAMED** | Present in v0.11.0 pool config (2 files). (#451.) |
+| inline PEM `sslrootcert` | **UPSTREAMED** | Present in v0.11.0 `postgrespool.rs`. (#634.) |
+| Redshift schema inference | **MISSING (not spice2-relevant)** | 0 hits tree-wide in v0.11.0. spice2 has **no** `datafusion_table_providers` reference to Redshift schema inference, so this is not a blocker. (Was old #409 / `cc38905`.) |
+
+### DuckDB
+
+| Patch / symbol | Verdict | Evidence |
+|---|---|---|
+| `AccessMode` + `DuckDBTableProviderFactory::new(AccessMode)` | **UPSTREAMED** | `duckdb.rs:35,180,200,308-310,709`. |
+| `creator.rs` table creator | **UPSTREAMED** | `core/src/duckdb/creator.rs` present. |
+| `connection_pool_size` | **UPSTREAMED** | Present in v0.11.0 `duckdbpool.rs`. (#473.) |
+| predefined schemas / public `TableManager` | **UPSTREAMED** | #455; present upstream. |
+| `recompute_statistics_on_write` | **MISSING (not spice2-relevant)** | 0 hits tree-wide. No `datafusion_table_providers`-scoped spice2 reference. (#475.) |
+| `invalidate_instance` (snapshot cache invalidation) | **MISSING (not spice2-relevant)** | 0 hits tree-wide. No spice2 reference from table-providers. (#635.) |
+
+### SQLite
+
+| Patch / symbol | Verdict | Evidence |
+|---|---|---|
+| Prepared-statement batch insert | **UPSTREAMED** | Present in v0.11.0 `sqlite/write.rs`. (#452.) |
+| Decimal / Date32/64 round-trip, String-list→JSON, decimal extension decoding | **UPSTREAMED** | #504/#510/#517; present upstream. |
+| `decimal_cmp` instead of `BETWEEN` (the old `between.rs`, 620 lines) | **MISSING (not spice2-relevant)** | `core/src/sqlite/between.rs` absent in v0.11.0; 0 `decimal_cmp` hits. No spice2 reference from table-providers. (#333.) |
+| `rusqlite` v0.37 / `tokio-rusqlite` v0.7 | **UPSTREAMED** | #495; reflected in v0.11.0 deps. |
+
+### MongoDB — UPSTREAMED
+
+| Patch / symbol | Verdict | Evidence |
+|---|---|---|
+| Read-only MongoDB provider (`MongoDBTableFactory`, `MongoDBTable`) | **UPSTREAMED** | `core/src/mongodb.rs:65`, `mongodb/table.rs:26`. |
+| SRV connection support | **UPSTREAMED** | Present in v0.11.0 `mongodb/connection.rs`. |
+| Schema sort/merge, utils (`expression`, `unnest`, `arrow`, `schema`) | **UPSTREAMED** | Full `mongodb/utils/*` tree present in v0.11.0. |
+
+### Federation files — UPSTREAMED
+
+| Patch / symbol | Verdict | Evidence |
+|---|---|---|
+| `*/federation.rs` (clickhouse, duckdb, mysql, sqlite, sql_provider_datafusion) | **UPSTREAMED** | All five `federation.rs` files present in v0.11.0. (spice2 additionally has its own `create_spice_federated_table_provider` helper in `data_components`, which is spice2-local and unaffected.) |
+| ADBC federation | **UPSTREAMED** | Present in v0.11.0 adbc module. (#584.) |
+| `default_filter_pushdown` (comprehensive pushdown #615) | **UPSTREAMED** | `sql_provider_datafusion/mod.rs:235`. |
+
+## Action required (not a doc-only formalization)
+
+1. The Spice `SqlTable` model + `supported_functions` + `UpsertOptions` +
+   `merge_inferred_and_declared_schemas` + `MysqlZeroDateBehavior` patches must be
+   **re-ported onto v0.11.0 (DF53)** and land on `spiceai-53-patches` before that
+   branch can be used as a pin. This is DF53 adaptation work (the old patches are
+   DF52-era), not a mechanical cherry-pick.
+2. **spice2's pin must NOT move to bare `15d4d41`.** It should remain on `4547bee`
+   (spiceai-52) until `spiceai-53-patches` carries the re-ported patches; the pin
+   then moves to the new `spiceai-53-patches` tip (a real, patched SHA — **not**
+   `15d4d41`).


### PR DESCRIPTION
## Spice patches for v0.11.0 — audit + formalization (all resolved)

Formalizes the `spiceai-53-patches` → `spiceai-53` convention for the v0.11.0
(DataFusion 53) line, and records the rigorous per-patch audit of the previous
`spiceai-52` Spice line against the `v0.11.0` tag.

This PR adds **`SPICE_PATCHES.md`** (the full per-patch table with verdicts +
evidence). `spiceai-53-patches` carries **no code patches** over v0.11.0 — only
this audit — which the audit confirms is correct.

### Verdict: `spiceai-53` == `spiceai-53-patches` == `v0.11.0` is a clean, sufficient pin

`v0.11.0` (`15d4d41`) is a pure upstream tag (first-parent ancestor of `main`,
zero Spice commits by SHA). Of the Spice patches on the old `spiceai-52` line,
every one falls into one of three buckets, none blocking the v0.11.0 pin:

1. **UPSTREAMED** (the large majority) — Postgres `XID`/numeric/JSON decoding,
   DuckDB `AccessMode`/creator, MongoDB provider, `ns_lookup` hickory
   `TokioResolver`, `on_conflict`, `TableArgReplace`, connection-pool knobs, all
   `federation.rs` files, comprehensive pushdown, …
2. **Re-homed in the consumer** — upstream dropped the helper and the consuming
   codebase now owns it locally: `util/supported_functions.rs` →
   `function_support` module; `util::schema::merge_inferred_and_declared_schemas`
   → `schema_discovery`; `util::constraints::UpsertOptions` → local acceleration
   types.
3. **Refactored away** — the Spice-only `SqlTable` model upstream never adopted
   (`expr::Engine`, the `engine` constructor arg, `with_allow_physical_filter_pushdown`,
   `MysqlZeroDateBehavior`). The consumer's DF53 line migrated its call sites to the
   upstream v0.11.0 API (3-arg `SqlTable::new`, Unparser/`default_filter_pushdown`,
   inline `0000-00-00`).

A full-tree sweep of the consumer's DF53 branch confirms **zero**
`datafusion_table_providers::` imports of any symbol v0.11.0 dropped — so v0.11.0
is sufficient and the pin does not need to move to a patched SHA.

> The previous (DF52) line *did* import several of these symbols from
> table-providers; the DF53 migration removed all of them, which is exactly why
> v0.11.0 is a clean pin.

### Method

Tip-tree content verification (symbol/file presence in the actual `15d4d41` tree),
not SHA-reachability — the `v0.11.0..spiceai-52` SHA range (~205 commits) is
dominated by upstream PRs that reached the old line via a different merge topology
and would both over-report upstream PRs and risk masking dropped Spice code. Every
MISSING result was cross-checked against the consumer's current DF53 imports from
`datafusion_table_providers`.

See `SPICE_PATCHES.md` for the full per-patch table.
