### PR TITLE
Properly handle denied function list in ADBC Connection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1864,7 +1864,7 @@ dependencies = [
 [[package]]
 name = "datafusion-federation"
 version = "0.4.2"
-source = "git+https://github.com/spiceai/datafusion-federation.git?rev=ce834ccf676a73c8c8356daadb9bed1ba28ba1da#ce834ccf676a73c8c8356daadb9bed1ba28ba1da"
+source = "git+https://github.com/spiceai/datafusion-federation.git?rev=cc539c74781e1d0e01245302002b1fbeddf8e015#cc539c74781e1d0e01245302002b1fbeddf8e015"
 dependencies = [
  "arrow-json",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1864,7 +1864,7 @@ dependencies = [
 [[package]]
 name = "datafusion-federation"
 version = "0.4.2"
-source = "git+https://github.com/spiceai/datafusion-federation.git?rev=490d3a2f8fb535b1ec76b823abb240e648668a74#490d3a2f8fb535b1ec76b823abb240e648668a74"
+source = "git+https://github.com/spiceai/datafusion-federation.git?rev=ce834ccf676a73c8c8356daadb9bed1ba28ba1da#ce834ccf676a73c8c8356daadb9bed1ba28ba1da"
 dependencies = [
  "arrow-json",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ arrow-json = "58.0"
 arrow-odbc = { version = "23.1" }
 datafusion = { version = "53.0", default-features = false }
 datafusion-expr = { version = "53.0" }
-datafusion-federation = { git = "https://github.com/spiceai/datafusion-federation.git", rev = "ce834ccf676a73c8c8356daadb9bed1ba28ba1da" } # branch: spiceai-53
+datafusion-federation = { git = "https://github.com/spiceai/datafusion-federation.git", rev = "cc539c74781e1d0e01245302002b1fbeddf8e015" } # branch: sgrebonv/spiceai-53
 datafusion-ffi = { version = "53.0" }
 datafusion-proto = { version = "53.0" }
 datafusion-physical-expr = { version = "53.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ arrow-json = "58.0"
 arrow-odbc = { version = "23.1" }
 datafusion = { version = "53.0", default-features = false }
 datafusion-expr = { version = "53.0" }
-datafusion-federation = { git = "https://github.com/spiceai/datafusion-federation.git", rev = "490d3a2f8fb535b1ec76b823abb240e648668a74" } # branch: spiceai-53
+datafusion-federation = { git = "https://github.com/spiceai/datafusion-federation.git", rev = "ce834ccf676a73c8c8356daadb9bed1ba28ba1da" } # branch: spiceai-53
 datafusion-ffi = { version = "53.0" }
 datafusion-proto = { version = "53.0" }
 datafusion-physical-expr = { version = "53.0" }

--- a/core/src/adbc.rs
+++ b/core/src/adbc.rs
@@ -22,6 +22,8 @@ use crate::{
 
 use adbc_core::{Connection, Database};
 use arrow::array::RecordBatch;
+#[cfg(feature = "adbc-federation")]
+use crate::util::supported_functions::FunctionSupport;
 use datafusion::sql::unparser::dialect::Dialect;
 use datafusion::{
     catalog::Session,
@@ -78,6 +80,8 @@ where
     pool: Arc<ADBCPool<D>>,
     #[cfg(feature = "adbc-federation")]
     federation_enabled: bool,
+    #[cfg(feature = "adbc-federation")]
+    function_support: Option<FunctionSupport>,
 }
 
 impl<D> AdbcTableFactory<D>
@@ -91,6 +95,8 @@ where
             pool,
             #[cfg(feature = "adbc-federation")]
             federation_enabled: true, // enabled by default when the feature is available
+            #[cfg(feature = "adbc-federation")]
+            function_support: None,
         }
     }
 
@@ -98,6 +104,13 @@ where
     #[must_use]
     pub fn with_federation_enabled(mut self, enabled: bool) -> Self {
         self.federation_enabled = enabled;
+        self
+    }
+
+    #[cfg(feature = "adbc-federation")]
+    #[must_use]
+    pub fn with_function_support(mut self, function_support: FunctionSupport) -> Self {
+        self.function_support = Some(function_support);
         self
     }
 
@@ -135,6 +148,8 @@ where
             Arc::clone(&schema),
             table_reference.clone(),
             dialect,
+            #[cfg(feature = "adbc-federation")]
+            self.function_support.clone(),
         ));
 
         #[cfg(feature = "adbc-federation")]

--- a/core/src/adbc/federation.rs
+++ b/core/src/adbc/federation.rs
@@ -12,8 +12,10 @@
 
 use crate::sql::db_connection_pool::dbconnection::{get_schema, Error as DbError};
 use crate::sql::sql_provider_datafusion::{get_stream, to_execution_error};
+use crate::util::supported_functions::contains_unsupported_functions;
 use arrow::datatypes::SchemaRef;
 use async_trait::async_trait;
+use datafusion::logical_expr::LogicalPlan;
 use datafusion::sql::unparser::dialect::Dialect;
 use datafusion_federation::sql::{
     RemoteTableRef, SQLExecutor, SQLFederationProvider, SQLTableSource,
@@ -69,6 +71,12 @@ impl<T, P> SQLExecutor for AdbcDBTable<T, P> {
 
     fn dialect(&self) -> Arc<dyn Dialect> {
         self.base_table.dialect()
+    }
+
+    fn can_execute_plan(&self, plan: &LogicalPlan) -> bool {
+        self.function_support.as_ref().is_none_or(|func_supp| {
+            !contains_unsupported_functions(plan, func_supp).unwrap_or(false)
+        })
     }
 
     fn execute(

--- a/core/src/adbc/sql_table.rs
+++ b/core/src/adbc/sql_table.rs
@@ -11,6 +11,8 @@
 // limitations under the License.
 
 use crate::sql::db_connection_pool::DbConnectionPool;
+#[cfg(feature = "adbc-federation")]
+use crate::util::supported_functions::FunctionSupport;
 
 use async_trait::async_trait;
 use futures::TryStreamExt;
@@ -41,6 +43,8 @@ use datafusion::{
 
 pub struct AdbcDBTable<T: 'static, P: 'static> {
     pub(crate) base_table: SqlTable<T, P>,
+    #[cfg(feature = "adbc-federation")]
+    pub(crate) function_support: Option<FunctionSupport>,
 }
 
 impl<T, P> std::fmt::Debug for AdbcDBTable<T, P> {
@@ -57,13 +61,18 @@ impl<T, P> AdbcDBTable<T, P> {
         schema: impl Into<SchemaRef>,
         table_reference: impl Into<TableReference>,
         dialect: Option<Arc<dyn Dialect + Send + Sync>>,
+        #[cfg(feature = "adbc-federation")] function_support: Option<FunctionSupport>,
     ) -> Self {
         let mut base_table = SqlTable::new_with_schema("adbc", pool, schema, table_reference, None);
 
         if let Some(d) = dialect {
             base_table = base_table.with_dialect(d);
         }
-        Self { base_table }
+        Self {
+            base_table,
+            #[cfg(feature = "adbc-federation")]
+            function_support,
+        }
     }
 
     fn create_physical_plan(
@@ -100,7 +109,22 @@ impl<T, P> TableProvider for AdbcDBTable<T, P> {
         &self,
         filters: &[&Expr],
     ) -> DataFusionResult<Vec<TableProviderFilterPushDown>> {
-        self.base_table.supports_filters_pushdown(filters)
+        let base_results = self.base_table.supports_filters_pushdown(filters)?;
+        #[cfg(feature = "adbc-federation")]
+        if let Some(func_support) = &self.function_support {
+            return Ok(filters
+                .iter()
+                .zip(base_results)
+                .map(|(filter, base_result)| {
+                    if func_support.supports(filter) {
+                        base_result
+                    } else {
+                        TableProviderFilterPushDown::Unsupported
+                    }
+                })
+                .collect());
+        }
+        Ok(base_results)
     }
 
     async fn scan(


### PR DESCRIPTION
Wires `with_function_support` into `AdbcTableFactory` so that Spice-specific UDFs (json functions, bucket, embedding functions, etc.) are never pushed down to remote ADBC sources that cannot execute them. Depends on upstream changes in datafusion-table-providers and datafusion-federation.