### PR TITLE
fix: Improve Postgres schema parsing for Redshift, support arrays of structs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2510,6 +2510,7 @@ dependencies = [
  "insta",
  "itertools",
  "libduckdb-sys",
+ "logos",
  "mongodb",
  "mysql_async",
  "native-tls",
@@ -4113,6 +4114,38 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "logos"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb2c55a318a87600ea870ff8c2012148b44bf18b74fad48d0f835c38c7d07c5f"
+dependencies = [
+ "logos-derive",
+]
+
+[[package]]
+name = "logos-codegen"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58b3ffaa284e1350d017a57d04ada118c4583cf260c8fb01e0fe28a2e9cf8970"
+dependencies = [
+ "fnv",
+ "proc-macro2",
+ "quote",
+ "regex-automata",
+ "regex-syntax",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "logos-derive"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52d3a9855747c17eaf4383823f135220716ab49bea5fbea7dd42cc9a92f8aa31"
+dependencies = [
+ "logos-codegen",
+]
 
 [[package]]
 name = "lru"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -19,7 +19,7 @@ arrow-schema = { workspace = true, optional = true, features = ["serde"] }
 arrow-json = { workspace = true }
 arrow-odbc = { workspace = true, optional = true }
 
-datafusion = { workspace = true, default-features = false, features = ["sql"]}
+datafusion = { workspace = true, default-features = false, features = ["sql"] }
 datafusion-expr = { workspace = true, optional = true }
 datafusion-federation = { workspace = true, features = [
   "sql",
@@ -57,6 +57,7 @@ futures = "0.3"
 geo-types = "0.7"
 itertools = "0.14"
 mongodb = { version = "3.6.0", features = ["openssl-tls"], optional = true }
+logos = { version = "0.16", optional = true }
 mysql_async = { version = "0.36", features = [
   "native-tls-tls",
   "chrono",
@@ -166,16 +167,17 @@ postgres = [
   "dep:pem",
   "dep:async-stream",
   "dep:arrow-schema",
+  "dep:logos",
 ]
 postgres-federation = ["postgres", "federation"]
 sqlite = ["dep:rusqlite", "dep:tokio-rusqlite", "dep:arrow-schema"]
 sqlite-federation = ["sqlite", "federation"]
 sqlite-bundled = ["sqlite", "rusqlite/bundled"]
 adbc = [
-  "dep:adbc_driver_manager", 
-  "dep:adbc_core", 
-  "dep:r2d2_adbc", 
-  "dep:async-stream", 
+  "dep:adbc_driver_manager",
+  "dep:adbc_core",
+  "dep:r2d2_adbc",
+  "dep:async-stream",
   "dep:arrow-schema",
   "dep:r2d2",
 ]

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -7,6 +7,9 @@ pub mod common;
 pub mod sql;
 pub mod util;
 
+/// Canonical Arrow metadata key for user-facing table and column descriptions.
+pub const DESCRIPTION_METADATA_KEY: &str = "description";
+
 #[cfg(feature = "adbc")]
 pub mod adbc;
 #[cfg(feature = "clickhouse")]

--- a/core/src/sql/arrow_sql_gen/arrow.rs
+++ b/core/src/sql/arrow_sql_gen/arrow.rs
@@ -107,6 +107,21 @@ pub fn map_data_type_to_array_builder(data_type: &DataType) -> Box<dyn ArrayBuil
                 DataType::Utf8 => Box::new(ListBuilder::new(StringBuilder::new())),
                 DataType::Boolean => Box::new(ListBuilder::new(BooleanBuilder::new())),
                 DataType::Binary => Box::new(ListBuilder::new(BinaryBuilder::new())),
+                // List of struct (e.g. PostgreSQL composite arrays). The list values
+                // builder must be a concrete `StructBuilder` (not a boxed `dyn
+                // ArrayBuilder`) so callers can downcast to `ListBuilder<StructBuilder>`;
+                // its inner field builders are themselves boxed, which `StructBuilder`
+                // expects.
+                DataType::Struct(struct_fields) => {
+                    let field_builders = struct_fields
+                        .iter()
+                        .map(|f| map_data_type_to_array_builder(f.data_type()))
+                        .collect();
+                    Box::new(ListBuilder::new(StructBuilder::new(
+                        struct_fields.clone(),
+                        field_builders,
+                    )))
+                }
                 _ => unimplemented!("Unsupported list value data type {:?}", data_type),
             }
         }

--- a/core/src/sql/arrow_sql_gen/postgres.rs
+++ b/core/src/sql/arrow_sql_gen/postgres.rs
@@ -32,6 +32,7 @@ use tokio_postgres::{types::Type, Row};
 
 pub mod builder;
 pub mod composite;
+pub mod hive_schema;
 pub mod schema;
 
 #[derive(Debug, Snafu)]
@@ -195,6 +196,47 @@ macro_rules! handle_composite_types {
     }
 }
 
+/// Appends every field of a `CompositeType` value into `$struct_builder`'s field builders
+/// (a single struct row). The caller is responsible for the matching
+/// `$struct_builder.append(...)` validity call. Shared by the top-level composite column
+/// path and the composite-array (`List<Struct>`) element path.
+macro_rules! append_composite_fields_to_struct {
+    ($composite_type:expr, $struct_builder:expr) => {{
+        let fields = $composite_type.fields();
+        for (idx, field) in fields.iter().enumerate() {
+            let field_name = field.name();
+            let Some(field_type) = map_column_type_to_data_type(field.type_(), field_name)? else {
+                return UnsupportedDataTypeSnafu {
+                    data_type: field.type_().to_string(),
+                    field_name: field_name.to_string(),
+                }
+                .fail();
+            };
+
+            handle_composite_types!(
+                field_type,
+                field.type_(),
+                $composite_type,
+                $struct_builder,
+                idx,
+                field_name,
+                Boolean => (BooleanBuilder, bool),
+                Int8 => (Int8Builder, i8),
+                Int16 => (Int16Builder, i16),
+                Int32 => (Int32Builder, i32),
+                Int64 => (Int64Builder, i64),
+                UInt32 => (UInt32Builder, u32),
+                Float32 => (Float32Builder, f32),
+                Float64 => (Float64Builder, f64),
+                Binary => (BinaryBuilder, Vec<u8>),
+                LargeBinary => (LargeBinaryBuilder, Vec<u8>),
+                Utf8 => (StringBuilder, String),
+                LargeUtf8 => (LargeStringBuilder, String)
+            );
+        }
+    }};
+}
+
 /// Converts Postgres `Row`s to an Arrow `RecordBatch`. Assumes that all rows have the same schema and
 /// sets the schema based on the first row.
 ///
@@ -208,15 +250,15 @@ pub fn rows_to_arrow(rows: &[Row], projected_schema: &Option<SchemaRef>) -> Resu
     let mut postgres_types: Vec<Type> = Vec::new();
     let mut postgres_numeric_scales: Vec<Option<u32>> = Vec::new();
     let mut column_names: Vec<String> = Vec::new();
-    let mut projected_json_list_struct_fields: Vec<Option<Arc<Field>>> = Vec::new();
+    let mut projected_json_complex_fields: Vec<Option<Arc<Field>>> = Vec::new();
 
     if !rows.is_empty() {
         let row = &rows[0];
         for column in row.columns() {
             let column_name = column.name();
             let column_type = column.type_();
-            let projected_json_list_struct_field =
-                projected_list_struct_field(projected_schema, column_name, column_type);
+            let projected_json_complex_field =
+                projected_json_complex_field(projected_schema, column_name, column_type);
 
             let mut numeric_scale: Option<u32> = None;
 
@@ -252,15 +294,23 @@ pub fn rows_to_arrow(rows: &[Row], projected_schema: &Option<SchemaRef>) -> Resu
                 map_column_type_to_data_type(column_type, column_name)?
             };
 
-            if projected_json_list_struct_field.is_some() {
-                // Keep JSON/JSONB collection in a temporary Utf8 builder and
-                // decode into typed List<Struct> after row collection.
+            let projected_field = projected_schema
+                .as_ref()
+                .and_then(|schema| schema.field_with_name(column_name).ok());
+
+            let nullable = projected_field
+                .map(|field| field.is_nullable())
+                .unwrap_or(true);
+
+            if projected_json_complex_field.is_some() {
+                // Collect the JSON text in a temporary Utf8 builder and decode it into
+                // the projected complex Arrow type after row collection.
                 data_type = Some(DataType::Utf8);
             }
 
             match &data_type {
                 Some(data_type) => {
-                    arrow_fields.push(Some(Field::new(column_name, data_type.clone(), true)));
+                    arrow_fields.push(Some(Field::new(column_name, data_type.clone(), nullable)));
                 }
                 None => arrow_fields.push(None),
             }
@@ -269,7 +319,7 @@ pub fn rows_to_arrow(rows: &[Row], projected_schema: &Option<SchemaRef>) -> Resu
                 .push(map_data_type_to_array_builder_optional(data_type.as_ref()));
             postgres_types.push(column_type.clone());
             column_names.push(column_name.to_string());
-            projected_json_list_struct_fields.push(projected_json_list_struct_field);
+            projected_json_complex_fields.push(projected_json_complex_field);
         }
     }
 
@@ -865,7 +915,69 @@ pub fn rows_to_arrow(rows: &[Row], projected_schema: &Option<SchemaRef>) -> Resu
                         None => builder.append_null(),
                     }
                 }
+                // Redshift `SUPER` (and Spectrum `ARRAY`/`STRUCT`/`MAP` external columns
+                // surfaced as `SUPER`) arrive as JSON text. Collect that text into a
+                // `Utf8` builder; if the column is projected as a complex Arrow type it is
+                // decoded into that type after row collection (see
+                // `projected_json_complex_field`), otherwise it stays a JSON string.
+                _ if postgres_type.name() == "super" => {
+                    let Some(builder) = builder else {
+                        return NoBuilderForIndexSnafu { index: i }.fail();
+                    };
+                    let Some(builder) = builder.as_any_mut().downcast_mut::<StringBuilder>() else {
+                        return FailedToDowncastBuilderSnafu {
+                            postgres_type: format!("{postgres_type}"),
+                        }
+                        .fail();
+                    };
+                    let v = row.try_get::<usize, Option<SuperRawString>>(i).context(
+                        FailedToGetRowValueSnafu {
+                            pg_type: postgres_type.clone(),
+                        },
+                    )?;
+
+                    match v {
+                        Some(v) => builder.append_value(v.0),
+                        None => builder.append_null(),
+                    }
+                }
                 _ => match *postgres_type.kind() {
+                    // Array of a composite type (`my_struct[]`) → List<Struct>. Each array
+                    // element is a `CompositeType`; append it as a struct row in the list.
+                    Kind::Array(ref element_type)
+                        if matches!(*element_type.kind(), Kind::Composite(_)) =>
+                    {
+                        let Some(builder) = builder else {
+                            return NoBuilderForIndexSnafu { index: i }.fail();
+                        };
+                        let Some(list_builder) = builder
+                            .as_any_mut()
+                            .downcast_mut::<ListBuilder<StructBuilder>>()
+                        else {
+                            return FailedToDowncastBuilderSnafu {
+                                postgres_type: format!("{postgres_type}"),
+                            }
+                            .fail();
+                        };
+
+                        let v = row
+                            .try_get::<usize, Option<Vec<CompositeType>>>(i)
+                            .context(FailedToGetRowValueSnafu {
+                                pg_type: postgres_type.clone(),
+                            })?;
+
+                        let Some(composites) = v else {
+                            list_builder.append_null();
+                            continue;
+                        };
+
+                        let struct_builder = list_builder.values();
+                        for composite_type in &composites {
+                            append_composite_fields_to_struct!(composite_type, struct_builder);
+                            struct_builder.append(true);
+                        }
+                        list_builder.append(true);
+                    }
                     Kind::Composite(_) => {
                         let Some(builder) = builder else {
                             return NoBuilderForIndexSnafu { index: i }.fail();
@@ -891,39 +1003,7 @@ pub fn rows_to_arrow(rows: &[Row], projected_schema: &Option<SchemaRef>) -> Resu
 
                         builder.append(true);
 
-                        let fields = composite_type.fields();
-                        for (idx, field) in fields.iter().enumerate() {
-                            let field_name = field.name();
-                            let Some(field_type) =
-                                map_column_type_to_data_type(field.type_(), field_name)?
-                            else {
-                                return FailedToDowncastBuilderSnafu {
-                                    postgres_type: format!("{}", field.type_()),
-                                }
-                                .fail();
-                            };
-
-                            handle_composite_types!(
-                                field_type,
-                                field.type_(),
-                                composite_type,
-                                builder,
-                                idx,
-                                field_name,
-                                Boolean => (BooleanBuilder, bool),
-                                Int8 => (Int8Builder, i8),
-                                Int16 => (Int16Builder, i16),
-                                Int32 => (Int32Builder, i32),
-                                Int64 => (Int64Builder, i64),
-                                UInt32 => (UInt32Builder, u32),
-                                Float32 => (Float32Builder, f32),
-                                Float64 => (Float64Builder, f64),
-                                Binary => (BinaryBuilder, Vec<u8>),
-                                LargeBinary => (LargeBinaryBuilder, Vec<u8>),
-                                Utf8 => (StringBuilder, String),
-                                LargeUtf8 => (LargeStringBuilder, String)
-                            );
-                        }
+                        append_composite_fields_to_struct!(composite_type, builder);
                     }
                     Kind::Enum(_) => {
                         let Some(builder) = builder else {
@@ -974,7 +1054,7 @@ pub fn rows_to_arrow(rows: &[Row], projected_schema: &Option<SchemaRef>) -> Resu
             return NoArrowFieldForIndexSnafu { index: i }.fail();
         };
 
-        if let Some(projected_field) = projected_json_list_struct_fields.get(i).cloned().flatten() {
+        if let Some(projected_field) = projected_json_complex_fields.get(i).cloned().flatten() {
             let Some(string_array) = array.as_any().downcast_ref::<StringArray>() else {
                 return InvalidJsonListStructIntermediateArraySnafu {
                     column_name: projected_field.name().to_string(),
@@ -982,18 +1062,7 @@ pub fn rows_to_arrow(rows: &[Row], projected_schema: &Option<SchemaRef>) -> Resu
                 .fail();
             };
 
-            let list_item_field = match projected_field.data_type() {
-                DataType::List(list_item_field) => list_item_field.as_ref(),
-                _ => {
-                    return UnsupportedDataTypeSnafu {
-                        data_type: projected_field.data_type().to_string(),
-                        field_name: projected_field.name().to_string(),
-                    }
-                    .fail();
-                }
-            };
-
-            array = decode_json_list_of_struct(string_array, list_item_field).context(
+            array = decode_json_complex_column(string_array, projected_field.as_ref()).context(
                 FailedToDecodeJsonListStructSnafu {
                     column_name: projected_field.name().to_string(),
                 },
@@ -1016,52 +1085,71 @@ pub fn rows_to_arrow(rows: &[Row], projected_schema: &Option<SchemaRef>) -> Resu
     }
 }
 
-fn projected_list_struct_field(
+/// Identifies columns whose values arrive as a JSON text serialization of a complex
+/// Arrow type and should be decoded post-collection rather than read as a scalar.
+///
+/// Two sources produce these:
+/// - PostgreSQL `JSON`/`JSONB` columns projected as a complex Arrow type.
+/// - Redshift Spectrum external `ARRAY`/`STRUCT`/`MAP` columns, which Redshift serializes
+///   to `VARCHAR(65535)` JSON text over the wire (see `json_serialization_enable`).
+///
+/// Returns the projected field when the wire column is text-like *and* the projected
+/// Arrow type is a complex type (`List`/`LargeList`/`Struct`/`Map`). Such a pairing only
+/// occurs for these JSON-text cases — ordinary text columns project as `Utf8`, and native
+/// composite/array columns carry their own wire OIDs handled elsewhere — so this is safe
+/// to apply regardless of the source database variant.
+fn projected_json_complex_field(
     projected_schema: &Option<SchemaRef>,
     column_name: &str,
     column_type: &Type,
 ) -> Option<Arc<Field>> {
-    if !matches!(*column_type, Type::JSON | Type::JSONB) {
+    // Only text-bearing wire types can carry a JSON serialization. These all have a
+    // string-producing row arm above, so forcing the collection builder to `Utf8` is safe.
+    // Redshift's `super` (matched by name — it has no stable built-in OID) is how Spectrum
+    // surfaces serialized `ARRAY`/`STRUCT`/`MAP` external columns.
+    let is_text_like = matches!(
+        *column_type,
+        Type::JSON | Type::JSONB | Type::TEXT | Type::VARCHAR | Type::BPCHAR | Type::NAME
+    ) || column_type.name() == "super";
+    if !is_text_like {
         return None;
     }
 
     let schema = projected_schema.as_ref()?;
     let field = Arc::new(schema.field_with_name(column_name).ok()?.clone());
     match field.data_type() {
-        DataType::List(item_field) if matches!(item_field.data_type(), DataType::Struct(_)) => {
+        DataType::List(_) | DataType::LargeList(_) | DataType::Struct(_) | DataType::Map(_, _) => {
             Some(field)
         }
         _ => None,
     }
 }
 
-/// Decodes a `StringArray` of JSON list-of-struct values into a typed
-/// `List<Struct>` Arrow array using a single batch NDJSON decode.
+/// Decodes a `StringArray` of JSON values into a typed complex Arrow array (`List`,
+/// `Struct`, `Map`, …) using a single batch NDJSON decode against `field`'s data type.
 ///
-/// Null entries in `string_array` are emitted as the JSON literal `null` in the
-/// NDJSON buffer, which the `arrow_json` decoder interprets as a null list
-/// element — no post-hoc `take` reindexing required.
-fn decode_json_list_of_struct(
+/// `arrow_json`'s field decoder treats each JSON line as a value of `field.data_type()`
+/// (arrays decode `[...]`, structs/maps decode `{...}`), producing a single-column batch
+/// whose `column(0)` is the decoded array. Null entries in `string_array` are emitted as
+/// the JSON literal `null`, which the decoder interprets as a null element — no post-hoc
+/// `take` reindexing required.
+fn decode_json_complex_column(
     string_array: &StringArray,
-    list_item_field: &Field,
+    field: &Field,
 ) -> std::result::Result<ArrayRef, arrow::error::ArrowError> {
-    // The list field name is unused — the caller overwrites the field from the
+    // The field name is unused for decoding — the caller overwrites the field from the
     // projected schema.  We only need the data type for the decoder.
-    let list_field = Arc::new(Field::new_list(
-        "_",
-        Arc::new(list_item_field.clone()),
-        true,
-    ));
+    let decode_field = Arc::new(field.clone());
 
     if string_array.is_empty() {
-        return Ok(new_null_array(list_field.data_type(), 0));
+        return Ok(new_null_array(decode_field.data_type(), 0));
     }
 
     if string_array.null_count() == string_array.len() {
-        return Ok(new_null_array(list_field.data_type(), string_array.len()));
+        return Ok(new_null_array(decode_field.data_type(), string_array.len()));
     }
 
-    let mut decoder = ReaderBuilder::new_with_field(list_field)
+    let mut decoder = ReaderBuilder::new_with_field(decode_field)
         .with_batch_size(string_array.len())
         .build_decoder()
         .map_err(|e| {
@@ -1186,6 +1274,10 @@ fn map_column_type_to_data_type(column_type: &Type, field_name: &str) -> Result<
         _ if matches!(column_type.name(), "_geometry" | "_geography") => Ok(Some(DataType::List(
             Arc::new(Field::new("item", DataType::Binary, true)),
         ))),
+        // Redshift `SUPER` (and Spectrum complex external columns surfaced as `SUPER`)
+        // arrive as JSON text. Default to `Utf8`; a complex projected schema upgrades it
+        // to the decoded type via `projected_json_complex_field`.
+        _ if column_type.name() == "super" => Ok(Some(DataType::Utf8)),
         _ => match *column_type.kind() {
             Kind::Composite(ref fields) => {
                 let mut arrow_fields = Vec::new();
@@ -1211,6 +1303,21 @@ fn map_column_type_to_data_type(column_type: &Type, field_name: &str) -> Result<
                 Box::new(DataType::Int8),
                 Box::new(DataType::Utf8),
             ))),
+            // Array of a composite type (e.g. `my_struct[]`) → List<Struct>. The common
+            // scalar arrays (`int[]`, `text[]`, …) are matched by their explicit
+            // `Type::*_ARRAY` arms above; this catches user-defined composite arrays.
+            Kind::Array(ref element_type) if matches!(*element_type.kind(), Kind::Composite(_)) => {
+                let Some(element) = map_column_type_to_data_type(element_type, field_name)? else {
+                    return UnsupportedDataTypeSnafu {
+                        data_type: element_type.to_string(),
+                        field_name: field_name.to_string(),
+                    }
+                    .fail();
+                };
+                Ok(Some(DataType::List(Arc::new(Field::new(
+                    "item", element, true,
+                )))))
+            }
             _ => UnsupportedDataTypeSnafu {
                 data_type: column_type.to_string(),
                 field_name: field_name.to_string(),
@@ -1262,6 +1369,29 @@ impl<'a> FromSql<'a> for JsonbRawString {
 
     fn accepts(ty: &Type) -> bool {
         matches!(*ty, Type::JSON | Type::JSONB)
+    }
+}
+
+/// Reads a Redshift `SUPER` value as its raw UTF-8 JSON text.
+///
+/// Redshift serializes `SUPER` — and the `ARRAY`/`STRUCT`/`MAP` columns of Spectrum
+/// external tables, which surface over the wire as `SUPER` — to a JSON text
+/// representation. `SUPER` has no stable built-in OID, so this matches by type name and
+/// interprets the value bytes as UTF-8. (Requires `json_serialization_enable` on the
+/// session for Spectrum complex columns to serialize rather than error server-side.)
+#[derive(Debug)]
+struct SuperRawString(String);
+
+impl<'a> FromSql<'a> for SuperRawString {
+    fn from_sql(
+        _ty: &Type,
+        raw: &'a [u8],
+    ) -> std::result::Result<Self, Box<dyn std::error::Error + Sync + Send>> {
+        Ok(SuperRawString(String::from_utf8(raw.to_vec())?))
+    }
+
+    fn accepts(ty: &Type) -> bool {
+        ty.name() == "super"
     }
 }
 
@@ -1601,8 +1731,11 @@ mod tests {
             true,
         ));
 
-        let array =
-            decode_json_list_of_struct(&string_array, &list_item_field).expect("cast succeeds");
+        let array = decode_json_complex_column(
+            &string_array,
+            &Field::new_list("item", Arc::clone(&list_item_field), true),
+        )
+        .expect("cast succeeds");
         let list = array
             .as_any()
             .downcast_ref::<ListArray>()
@@ -1644,8 +1777,11 @@ mod tests {
             true,
         ));
 
-        let array =
-            decode_json_list_of_struct(&string_array, &list_item_field).expect("cast succeeds");
+        let array = decode_json_complex_column(
+            &string_array,
+            &Field::new_list("item", Arc::clone(&list_item_field), true),
+        )
+        .expect("cast succeeds");
         let list = array
             .as_any()
             .downcast_ref::<ListArray>()
@@ -1675,8 +1811,11 @@ mod tests {
             true,
         ));
 
-        let error = decode_json_list_of_struct(&string_array, &list_item_field)
-            .expect_err("malformed json should error");
+        let error = decode_json_complex_column(
+            &string_array,
+            &Field::new_list("item", Arc::clone(&list_item_field), true),
+        )
+        .expect_err("malformed json should error");
         assert!(error.to_string().contains("Failed to decode value"));
     }
 
@@ -1690,8 +1829,11 @@ mod tests {
             true,
         ));
 
-        let array =
-            decode_json_list_of_struct(&string_array, &list_item_field).expect("cast succeeds");
+        let array = decode_json_complex_column(
+            &string_array,
+            &Field::new_list("item", Arc::clone(&list_item_field), true),
+        )
+        .expect("cast succeeds");
         let list = array
             .as_any()
             .downcast_ref::<ListArray>()
@@ -1729,8 +1871,11 @@ mod tests {
             true,
         ));
 
-        let array =
-            decode_json_list_of_struct(&string_array, &list_item_field).expect("decode succeeds");
+        let array = decode_json_complex_column(
+            &string_array,
+            &Field::new_list("item", Arc::clone(&list_item_field), true),
+        )
+        .expect("decode succeeds");
         let list = array
             .as_any()
             .downcast_ref::<ListArray>()
@@ -1773,8 +1918,251 @@ mod tests {
         assert_eq!(floats.value(0), 2.0);
     }
 
+    /// Redshift Spectrum serializes a top-level STRUCT column to a JSON object
+    /// (`{"given":"John","family":"Smith"}`); the row path must decode it into a
+    /// `StructArray`, not flatten it into separate columns.
     #[test]
-    fn test_projected_list_struct_field_matches_by_name() {
+    fn test_decode_json_complex_column_struct() {
+        let string_array = StringArray::from(vec![
+            Some(r#"{"given":"John","family":"Smith"}"#),
+            None,
+            Some(r#"{"given":"Ada","family":"Lovelace"}"#),
+        ]);
+
+        let struct_field = Field::new(
+            "name",
+            DataType::Struct(
+                vec![
+                    Field::new("given", DataType::Utf8, true),
+                    Field::new("family", DataType::Utf8, true),
+                ]
+                .into(),
+            ),
+            true,
+        );
+
+        let array =
+            decode_json_complex_column(&string_array, &struct_field).expect("struct decode");
+        let structs = array
+            .as_any()
+            .downcast_ref::<StructArray>()
+            .expect("array should be StructArray");
+
+        assert_eq!(structs.len(), 3);
+        assert!(structs.is_null(1));
+        let given = structs
+            .column(0)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .expect("given should be Utf8");
+        assert_eq!(given.value(0), "John");
+        assert_eq!(given.value(2), "Ada");
+    }
+
+    /// Redshift Spectrum serializes a MAP column to a JSON object with string keys;
+    /// the row path must decode it into a `MapArray`.
+    #[test]
+    fn test_decode_json_complex_column_map() {
+        let string_array = StringArray::from(vec![Some(r#"{"a":1,"b":2}"#), Some("{}")]);
+
+        let entries = Arc::new(Field::new_struct(
+            "entries",
+            vec![
+                Arc::new(Field::new("key", DataType::Utf8, false)),
+                Arc::new(Field::new("value", DataType::Int32, true)),
+            ],
+            false,
+        ));
+        let map_field = Field::new("attrs", DataType::Map(entries, false), true);
+
+        let array = decode_json_complex_column(&string_array, &map_field).expect("map decode");
+        let map = array
+            .as_any()
+            .downcast_ref::<arrow::array::MapArray>()
+            .expect("array should be MapArray");
+
+        assert_eq!(map.len(), 2);
+        assert_eq!(map.value_length(0), 2);
+        assert_eq!(map.value_length(1), 0);
+    }
+
+    /// The headline case: an array of structs (`[{...},{...}]`) decodes into
+    /// `List<Struct>`, mirroring how Spectrum serializes collection columns.
+    #[test]
+    fn test_decode_json_complex_column_array_of_struct() {
+        let string_array = StringArray::from(vec![Some(
+            r#"[{"shipdate":"2018-03-01","price":100.5},{"shipdate":"2018-03-02","price":7.0}]"#,
+        )]);
+
+        let list_field = Field::new_list(
+            "lines",
+            Field::new(
+                "item",
+                DataType::Struct(
+                    vec![
+                        Field::new("shipdate", DataType::Utf8, true),
+                        Field::new("price", DataType::Float64, true),
+                    ]
+                    .into(),
+                ),
+                true,
+            ),
+            true,
+        );
+
+        let array =
+            decode_json_complex_column(&string_array, &list_field).expect("array<struct> decode");
+        let list = array
+            .as_any()
+            .downcast_ref::<ListArray>()
+            .expect("array should be ListArray");
+        assert_eq!(list.value_length(0), 2);
+
+        let structs = list
+            .value(0)
+            .as_any()
+            .downcast_ref::<StructArray>()
+            .expect("list values should be StructArray")
+            .clone();
+        let prices = structs
+            .column(1)
+            .as_any()
+            .downcast_ref::<arrow::array::Float64Array>()
+            .expect("price should be Float64");
+        assert_eq!(prices.value(0), 100.5);
+        assert_eq!(prices.value(1), 7.0);
+    }
+
+    /// A text-like wire column (Redshift serializes Spectrum complex types to
+    /// `VARCHAR`) projected as a complex Arrow type must be routed through the JSON
+    /// decode path, not read as a scalar string.
+    #[test]
+    fn test_projected_json_complex_field_triggers_for_varchar_struct() {
+        let payload_field = Field::new(
+            "payload",
+            DataType::Struct(vec![Field::new("a", DataType::Int32, true)].into()),
+            true,
+        );
+        let schema = Arc::new(Schema::new(vec![payload_field]));
+        let projected_schema = Some(schema);
+
+        assert!(
+            projected_json_complex_field(&projected_schema, "payload", &Type::VARCHAR).is_some(),
+            "VARCHAR column projected as Struct should decode as JSON"
+        );
+
+        // A plain scalar projection over the same wire column is left as a scalar.
+        let scalar_schema = Some(Arc::new(Schema::new(vec![Field::new(
+            "payload",
+            DataType::Utf8,
+            true,
+        )])));
+        assert!(
+            projected_json_complex_field(&scalar_schema, "payload", &Type::VARCHAR).is_none(),
+            "VARCHAR column projected as Utf8 must stay a scalar string"
+        );
+    }
+
+    /// A Redshift `super` wire column (how Spectrum serializes `ARRAY`/`STRUCT`/`MAP`
+    /// external columns) is matched by type name and routed through the JSON decode path.
+    #[test]
+    fn test_super_type_routes_through_json_decode() {
+        let super_type = Type::new(
+            "super".to_owned(),
+            4000,
+            Kind::Simple,
+            "pg_catalog".to_owned(),
+        );
+
+        // Without a projected schema it resolves to a plain Utf8 JSON string column.
+        assert_eq!(
+            map_column_type_to_data_type(&super_type, "c").expect("super maps"),
+            Some(DataType::Utf8)
+        );
+
+        // Projected as a complex type, it is picked up for JSON decoding.
+        let schema = Some(Arc::new(Schema::new(vec![Field::new(
+            "payload",
+            DataType::List(Arc::new(Field::new(
+                "item",
+                DataType::Struct(vec![Field::new("a", DataType::Int32, true)].into()),
+                true,
+            ))),
+            true,
+        )])));
+        assert!(
+            projected_json_complex_field(&schema, "payload", &super_type).is_some(),
+            "super column projected as List<Struct> should decode as JSON"
+        );
+    }
+
+    /// A native PostgreSQL array-of-composite wire type (`composite[]`) maps to
+    /// `List<Struct>`, and that Arrow type produces a `ListBuilder<StructBuilder>`.
+    #[test]
+    fn test_composite_array_maps_to_list_struct() {
+        use tokio_postgres::types::Field as PgField;
+
+        let composite = Type::new(
+            "line_item".to_owned(),
+            20_000,
+            Kind::Composite(vec![
+                PgField::new("sku".to_owned(), Type::TEXT),
+                PgField::new("qty".to_owned(), Type::INT4),
+                PgField::new("price".to_owned(), Type::FLOAT8),
+            ]),
+            "public".to_owned(),
+        );
+        let array_type = Type::new(
+            "_line_item".to_owned(),
+            20_001,
+            Kind::Array(composite),
+            "public".to_owned(),
+        );
+
+        let dt = map_column_type_to_data_type(&array_type, "items")
+            .expect("maps")
+            .expect("some data type");
+        let expected_item = DataType::Struct(
+            vec![
+                Field::new("sku", DataType::Utf8, true),
+                Field::new("qty", DataType::Int32, true),
+                Field::new("price", DataType::Float64, true),
+            ]
+            .into(),
+        );
+        assert_eq!(
+            dt,
+            DataType::List(Arc::new(Field::new("item", expected_item, true)))
+        );
+
+        // The builder for this Arrow type must downcast to ListBuilder<StructBuilder>.
+        let mut builder = crate::sql::arrow_sql_gen::arrow::map_data_type_to_array_builder(&dt);
+        assert!(
+            builder
+                .as_any_mut()
+                .downcast_mut::<ListBuilder<StructBuilder>>()
+                .is_some(),
+            "List<Struct> must build a ListBuilder<StructBuilder>"
+        );
+    }
+
+    #[test]
+    fn test_super_raw_string_reads_utf8() {
+        let super_type = Type::new(
+            "super".to_owned(),
+            4000,
+            Kind::Simple,
+            "pg_catalog".to_owned(),
+        );
+        let raw = br#"[{"a":1},{"a":2}]"#;
+        let parsed = SuperRawString::from_sql(&super_type, raw).expect("super decodes");
+        assert_eq!(parsed.0, r#"[{"a":1},{"a":2}]"#);
+        assert!(SuperRawString::accepts(&super_type));
+        assert!(!SuperRawString::accepts(&Type::VARCHAR));
+    }
+
+    #[test]
+    fn test_projected_json_complex_field_matches_by_name() {
         let other_field = Field::new("other", DataType::Int32, true);
         let payload_field = Field::new(
             "payload",
@@ -1790,7 +2178,7 @@ mod tests {
         let projected_schema = Some(schema);
 
         // Name match succeeds regardless of positional index.
-        let resolved = projected_list_struct_field(&projected_schema, "payload", &Type::JSONB)
+        let resolved = projected_json_complex_field(&projected_schema, "payload", &Type::JSONB)
             .expect("field should resolve from projected schema");
         assert_eq!(resolved.name(), "payload");
 
@@ -1804,7 +2192,7 @@ mod tests {
 
         // Name miss returns None — no positional fallback.
         assert!(
-            projected_list_struct_field(&projected_schema, "no_such_column", &Type::JSONB)
+            projected_json_complex_field(&projected_schema, "no_such_column", &Type::JSONB)
                 .is_none()
         );
     }

--- a/core/src/sql/arrow_sql_gen/postgres/hive_schema.rs
+++ b/core/src/sql/arrow_sql_gen/postgres/hive_schema.rs
@@ -1,0 +1,893 @@
+/*
+Copyright 2024-2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+use arrow::datatypes::{DataType as ArrowDataType, Field as ArrowField, TimeUnit};
+use logos::{Lexer, Logos};
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use crate::DESCRIPTION_METADATA_KEY;
+
+const MAX_RECURSION_DEPTH: usize = 100;
+
+#[derive(Logos, Debug, PartialEq, Clone)]
+#[logos(skip r"[ \t\n\f]+")] // Skip whitespace
+pub enum Token<'input> {
+    #[regex("(?i)BIGINT")]
+    BigInt,
+    #[regex("(?i)BINARY")]
+    Binary,
+    #[regex("(?i)BOOLEAN")]
+    Boolean,
+    #[regex("(?i)DATE")]
+    Date,
+    #[regex("(?i)DECIMAL")]
+    Decimal,
+    #[regex("(?i)DOUBLE")]
+    Double,
+    #[regex("(?i)FLOAT")]
+    Float,
+    #[regex("(?i)INT")]
+    Int,
+    #[regex("(?i)LONG")]
+    Long,
+    #[regex("(?i)VOID")]
+    Void,
+    #[regex("(?i)SMALLINT")]
+    SmallInt,
+    #[regex("(?i)STRING")]
+    String,
+    #[regex("(?i)TIMESTAMP")]
+    Timestamp,
+    #[regex("(?i)TIMESTAMP_NTZ")]
+    TimestampNtz,
+    #[regex("(?i)TINYINT")]
+    TinyInt,
+    #[regex("(?i)ARRAY")]
+    Array,
+    #[regex("(?i)MAP")]
+    Map,
+    #[regex("(?i)STRUCT")]
+    Struct,
+    #[regex("(?i)VARIANT")]
+    Variant,
+    #[regex("(?i)NOT")]
+    Not,
+    #[regex("(?i)NULL")]
+    Null,
+    #[regex("(?i)COMMENT")]
+    Comment,
+    #[token("<")]
+    LAngle,
+    #[token(">")]
+    RAngle,
+    #[token("(")]
+    LParen,
+    #[token(")")]
+    RParen,
+    #[token(",")]
+    Comma,
+    #[token(":")]
+    Colon,
+    #[regex(r"[a-zA-Z_][a-zA-Z0-9_]*", |lex| lex.slice())]
+    Identifier(&'input str),
+    #[regex(r"[0-9]+", |lex| lex.slice().parse().ok())]
+    Number(u32),
+    #[regex(r"'[^']*'", |lex| lex.slice().trim_matches('\'').to_string())]
+    QuotedString(String),
+}
+
+pub struct Parser<'input> {
+    lexer: Lexer<'input, Token<'input>>,
+    current: Option<Result<Token<'input>, ()>>,
+}
+
+impl<'input> Parser<'input> {
+    pub fn new(input: &'input str) -> Self {
+        let mut lexer = Token::lexer(input);
+        let current = lexer.next();
+        Parser { lexer, current }
+    }
+
+    fn advance(&mut self) {
+        self.current = self.lexer.next();
+    }
+
+    fn expect(&mut self, token: &Token<'input>) -> Result<(), String> {
+        match &self.current {
+            Some(Ok(current_token)) if current_token == token => {
+                self.advance();
+                Ok(())
+            }
+            _ => Err(format!("Expected {token:?}, found {:?}", self.current)),
+        }
+    }
+
+    /// Expects the current token to be an `Identifier` matching `name`
+    /// (case-insensitive). Advances past it on success.
+    fn expect_identifier(&mut self, name: &str, context: &str) -> Result<(), String> {
+        match &self.current {
+            Some(Ok(Token::Identifier(id))) if id.eq_ignore_ascii_case(name) => {
+                self.advance();
+                Ok(())
+            }
+            _ => Err(format!(
+                "Expected '{name}' after {context}, found {:?}",
+                self.current
+            )),
+        }
+    }
+
+    pub fn parse(&mut self) -> Result<ArrowDataType, String> {
+        self.parse_data_type_with_depth(0)
+    }
+
+    fn parse_decimal(&mut self) -> Result<ArrowDataType, String> {
+        self.advance();
+        let params = if self.current == Some(Ok(Token::LParen)) {
+            self.advance();
+            let precision = if let Some(Ok(Token::Number(p))) = self.current {
+                self.advance();
+                p
+            } else {
+                return Err("Expected number for DECIMAL precision".to_string());
+            };
+            self.expect(&Token::Comma)?;
+            let scale = if let Some(Ok(Token::Number(s))) = self.current {
+                self.advance();
+                s
+            } else {
+                return Err("Expected number for DECIMAL scale".to_string());
+            };
+            self.expect(&Token::RParen)?;
+            Some((precision, scale))
+        } else {
+            None
+        };
+        Ok(match params {
+            Some((p, s)) => {
+                let precision =
+                    u8::try_from(p).map_err(|e| format!("truncated Decimal precision: {e}"))?;
+                let scale = i8::try_from(s).map_err(|e| format!("truncated Decimal scale: {e}"))?;
+                if precision > 38 {
+                    return Err(format!(
+                        "DECIMAL precision {precision} exceeds maximum of 38"
+                    ));
+                }
+                if u8::try_from(s).is_ok_and(|su| su > precision) {
+                    return Err(format!(
+                        "DECIMAL scale {scale} out of range for precision {precision}"
+                    ));
+                }
+                ArrowDataType::Decimal128(precision, scale)
+            }
+            None => ArrowDataType::Decimal128(38, 10), // Default precision and scale
+        })
+    }
+
+    fn parse_data_type_with_depth(&mut self, depth: usize) -> Result<ArrowDataType, String> {
+        if depth > MAX_RECURSION_DEPTH {
+            return Err(format!(
+                "Maximum schema recursion depth exceeded ({MAX_RECURSION_DEPTH})"
+            ));
+        }
+
+        match self.current.clone() {
+            Some(Ok(Token::BigInt | Token::Long)) => {
+                self.advance();
+                Ok(ArrowDataType::Int64)
+            }
+            Some(Ok(Token::Binary)) => {
+                self.advance();
+                Ok(ArrowDataType::Binary)
+            }
+            Some(Ok(Token::Boolean)) => {
+                self.advance();
+                Ok(ArrowDataType::Boolean)
+            }
+            Some(Ok(Token::Date)) => {
+                self.advance();
+                Ok(ArrowDataType::Date32)
+            }
+            Some(Ok(Token::Decimal)) => self.parse_decimal(),
+            Some(Ok(Token::Double)) => {
+                self.advance();
+                // Consume optional trailing "precision" from source-native
+                // type name (e.g. PostgreSQL "double precision").
+                if matches!(&self.current, Some(Ok(Token::Identifier(id))) if id.eq_ignore_ascii_case("precision"))
+                {
+                    self.advance();
+                }
+                Ok(ArrowDataType::Float64)
+            }
+            Some(Ok(Token::Float)) => {
+                self.advance();
+                Ok(ArrowDataType::Float32)
+            }
+            Some(Ok(Token::Int)) => {
+                self.advance();
+                Ok(ArrowDataType::Int32)
+            }
+            Some(Ok(Token::Void)) => {
+                self.advance();
+                Ok(ArrowDataType::Null)
+            }
+            Some(Ok(Token::SmallInt)) => {
+                self.advance();
+                Ok(ArrowDataType::Int16)
+            }
+            Some(Ok(Token::String | Token::Variant)) => {
+                self.advance();
+                Ok(ArrowDataType::Utf8)
+            }
+            Some(Ok(Token::Timestamp)) => {
+                self.advance();
+                // Handle source-native multi-word timestamp types from
+                // Lakehouse Federation (e.g. PostgreSQL).
+                if matches!(&self.current, Some(Ok(Token::Identifier(id))) if id.eq_ignore_ascii_case("without"))
+                {
+                    // "timestamp without time zone" → TimestampNtz
+                    self.advance(); // consume "without"
+                    self.expect_identifier("time", "'timestamp without'")?;
+                    self.expect_identifier("zone", "'timestamp without time'")?;
+                    return Ok(ArrowDataType::Timestamp(TimeUnit::Microsecond, None));
+                }
+                if matches!(&self.current, Some(Ok(Token::Identifier(id))) if id.eq_ignore_ascii_case("with"))
+                {
+                    // "timestamp with time zone" → Timestamp(UTC)
+                    self.advance(); // consume "with"
+                    self.expect_identifier("time", "'timestamp with'")?;
+                    self.expect_identifier("zone", "'timestamp with time'")?;
+                    return Ok(ArrowDataType::Timestamp(
+                        TimeUnit::Microsecond,
+                        Some("UTC".into()),
+                    ));
+                }
+                Ok(ArrowDataType::Timestamp(
+                    TimeUnit::Microsecond,
+                    Some("UTC".into()),
+                ))
+            }
+            Some(Ok(Token::TimestampNtz)) => {
+                self.advance();
+                Ok(ArrowDataType::Timestamp(TimeUnit::Microsecond, None))
+            }
+            Some(Ok(Token::TinyInt)) => {
+                self.advance();
+                Ok(ArrowDataType::Int8)
+            }
+            Some(Ok(Token::Array)) => {
+                self.advance();
+                if self.current == Some(Ok(Token::LAngle)) {
+                    self.advance();
+                    let inner_type = self.parse_data_type_with_depth(depth + 1)?;
+                    self.expect(&Token::RAngle)?;
+                    let field = ArrowField::new("item", inner_type, true);
+                    Ok(ArrowDataType::List(Arc::new(field)))
+                } else {
+                    // Fallback: no element type specified (e.g. from data_type column)
+                    let field = ArrowField::new("item", ArrowDataType::Utf8, true);
+                    Ok(ArrowDataType::List(Arc::new(field)))
+                }
+            }
+            Some(Ok(Token::Map)) => self.parse_map_with_depth(depth),
+            Some(Ok(Token::Struct)) => self.parse_struct_with_depth(depth),
+            // GEOMETRY is not a first-class Arrow type; treat as Binary (WKB).
+            // The lexer emits it as Identifier("GEOMETRY") since it has no
+            // dedicated token. Consume any trailing `(SRID)` if present.
+            Some(Ok(Token::Identifier(id))) if id.eq_ignore_ascii_case("GEOMETRY") => {
+                self.advance();
+                // Skip optional parenthesized SRID, e.g. `geometry(5070)`
+                if self.current == Some(Ok(Token::LParen)) {
+                    self.advance(); // skip `(`
+                    self.advance(); // skip SRID number
+                    self.expect(&Token::RParen)?;
+                }
+                Ok(ArrowDataType::Binary)
+            }
+            // Source-native type names from Lakehouse Federation. These
+            // appear in `information_schema.columns.data_type` for foreign
+            // tables backed by PostgreSQL, MySQL, SQL Server, etc.
+            Some(Ok(Token::Identifier(id))) if id.eq_ignore_ascii_case("INTEGER") => {
+                self.advance();
+                Ok(ArrowDataType::Int32)
+            }
+            Some(Ok(Token::Identifier(id))) if id.eq_ignore_ascii_case("TEXT") => {
+                self.advance();
+                Ok(ArrowDataType::Utf8)
+            }
+            Some(Ok(Token::Identifier(id))) if id.eq_ignore_ascii_case("NUMERIC") => {
+                self.advance();
+                // Accept optional (precision, scale) like DECIMAL.
+                if self.current == Some(Ok(Token::LParen)) {
+                    // Re-use the DECIMAL parser by faking a rewind.
+                    // We already advanced past "NUMERIC", and parse_decimal
+                    // also starts after advancing past "DECIMAL". However,
+                    // parse_decimal expects to be called with current = LParen
+                    // after its own advance. We need to inline the param
+                    // parsing here.
+                    self.advance(); // skip `(`
+                    let precision = if let Some(Ok(Token::Number(p))) = self.current {
+                        self.advance();
+                        p
+                    } else {
+                        return Err("Expected number for NUMERIC precision".to_string());
+                    };
+                    self.expect(&Token::Comma)?;
+                    let scale = if let Some(Ok(Token::Number(s))) = self.current {
+                        self.advance();
+                        s
+                    } else {
+                        return Err("Expected number for NUMERIC scale".to_string());
+                    };
+                    self.expect(&Token::RParen)?;
+                    let p = u8::try_from(precision)
+                        .map_err(|e| format!("truncated NUMERIC precision: {e}"))?;
+                    let s =
+                        i8::try_from(scale).map_err(|e| format!("truncated NUMERIC scale: {e}"))?;
+                    if p > 38 {
+                        return Err(format!("NUMERIC precision {p} exceeds maximum of 38"));
+                    }
+                    // scale (originally u32, now i8) must not exceed precision
+                    if u8::try_from(scale).is_ok_and(|su| su > p) {
+                        return Err(format!("NUMERIC scale {s} out of range for precision {p}"));
+                    }
+                    Ok(ArrowDataType::Decimal128(p, s))
+                } else {
+                    Ok(ArrowDataType::Decimal128(38, 10))
+                }
+            }
+            Some(Ok(Token::Identifier(id))) if id.eq_ignore_ascii_case("REAL") => {
+                self.advance();
+                Ok(ArrowDataType::Float32)
+            }
+            Some(Ok(Token::Identifier(id)))
+                if id.eq_ignore_ascii_case("CHARACTER") || id.eq_ignore_ascii_case("VARCHAR") =>
+            {
+                self.advance();
+                // Consume optional trailing "varying" from "character varying"
+                if matches!(&self.current, Some(Ok(Token::Identifier(id))) if id.eq_ignore_ascii_case("varying"))
+                {
+                    self.advance();
+                }
+                // Consume optional (length) from "varchar(255)"
+                if self.current == Some(Ok(Token::LParen)) {
+                    self.advance(); // skip `(`
+                    if !matches!(self.current, Some(Ok(Token::Number(_)))) {
+                        return Err("Expected number for CHARACTER/VARCHAR length".to_string());
+                    }
+                    self.advance(); // skip length
+                    self.expect(&Token::RParen)?;
+                }
+                Ok(ArrowDataType::Utf8)
+            }
+            _ => Err(format!("Unexpected token: {:?}", self.current)),
+        }
+    }
+
+    fn parse_map_with_depth(&mut self, depth: usize) -> Result<ArrowDataType, String> {
+        self.advance();
+        if self.current != Some(Ok(Token::LAngle)) {
+            // Fallback: no type parameters (e.g. from data_type column)
+            let key_field = Arc::new(ArrowField::new("key", ArrowDataType::Utf8, false));
+            let value_field = Arc::new(ArrowField::new("value", ArrowDataType::Utf8, true));
+            let entry_struct = Arc::new(ArrowField::new_struct(
+                "entries",
+                vec![key_field, value_field],
+                false,
+            ));
+            return Ok(ArrowDataType::Map(entry_struct, false));
+        }
+        self.advance();
+        let key_type = self.parse_data_type_with_depth(depth + 1)?;
+        self.expect(&Token::Comma)?;
+        let value_type = self.parse_data_type_with_depth(depth + 1)?;
+        self.expect(&Token::RAngle)?;
+        let key_field = Arc::new(ArrowField::new("key", key_type, false));
+        let value_field = Arc::new(ArrowField::new("value", value_type, true));
+        let entry_struct = Arc::new(ArrowField::new_struct(
+            "entries",
+            vec![key_field, value_field],
+            false,
+        ));
+        Ok(ArrowDataType::Map(entry_struct, false))
+    }
+
+    fn parse_struct_with_depth(&mut self, depth: usize) -> Result<ArrowDataType, String> {
+        self.advance();
+        if self.current != Some(Ok(Token::LAngle)) {
+            // Fallback: no field definitions (e.g. from data_type column)
+            return Ok(ArrowDataType::Utf8);
+        }
+        self.expect(&Token::LAngle)?;
+        let mut fields = Vec::new();
+        if self.current != Some(Ok(Token::RAngle)) {
+            loop {
+                let field = self.parse_field_with_depth(depth + 1)?;
+                fields.push(field);
+                if self.current == Some(Ok(Token::Comma)) {
+                    self.advance();
+                    if self.current == Some(Ok(Token::RAngle)) {
+                        break;
+                    }
+                } else {
+                    break;
+                }
+            }
+        }
+        self.expect(&Token::RAngle)?;
+        Ok(ArrowDataType::Struct(fields.into()))
+    }
+
+    fn token_is_identifier(token: &Token<'input>) -> bool {
+        matches!(
+            token,
+            Token::BigInt
+                | Token::Binary
+                | Token::Boolean
+                | Token::Date
+                | Token::Decimal
+                | Token::Double
+                | Token::Float
+                | Token::Int
+                | Token::Long
+                | Token::Void
+                | Token::SmallInt
+                | Token::String
+                | Token::Timestamp
+                | Token::TimestampNtz
+                | Token::TinyInt
+                | Token::Array
+                | Token::Map
+                | Token::Struct
+                | Token::Variant
+                | Token::Not
+                | Token::Null
+                | Token::Comment
+        )
+    }
+
+    fn parse_field_with_depth(&mut self, depth: usize) -> Result<ArrowField, String> {
+        let name = match self.current.clone() {
+            Some(Ok(Token::Identifier(name))) => {
+                self.advance();
+                name.to_string()
+            }
+            Some(Ok(token)) if Self::token_is_identifier(&token) => {
+                let name = self.lexer.slice().to_string();
+                self.advance();
+                name
+            }
+            _ => return Err("Expected identifier for field name".to_string()),
+        };
+        self.expect(&Token::Colon)?;
+        let data_type = self.parse_data_type_with_depth(depth)?;
+        let nullable = if self.current == Some(Ok(Token::Not)) {
+            self.advance();
+            self.expect(&Token::Null)?;
+            false
+        } else {
+            true
+        };
+        let metadata = if self.current == Some(Ok(Token::Comment)) {
+            self.advance();
+            if let Some(Ok(Token::QuotedString(s))) = self.current.clone() {
+                self.advance();
+                let mut metadata = HashMap::new();
+                metadata.insert(DESCRIPTION_METADATA_KEY.to_string(), s);
+                metadata
+            } else {
+                return Err("Expected quoted string for COMMENT".to_string());
+            }
+        } else {
+            HashMap::new()
+        };
+        Ok(ArrowField::new(name, data_type, nullable).with_metadata(metadata))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow::datatypes::{DataType as ArrowDataType, Field as ArrowField, TimeUnit};
+
+    #[test]
+    fn test_scalar_types() {
+        let inputs = vec![
+            "BIGINT",
+            "bigint",
+            "BiGiNt",
+            "BINARY",
+            "binary",
+            "BOOLEAN",
+            "boolEAN",
+            "DATE",
+            "date",
+            "DOUBLE",
+            "double",
+            "FLOAT",
+            "float",
+            "INT",
+            "int",
+            "SMALLINT",
+            "smallint",
+            "STRING",
+            "string",
+            "TIMESTAMP",
+            "timestamp",
+            "TIMESTAMP_NTZ",
+            "timestamp_ntz",
+            "TINYINT",
+            "tinyint",
+            "VOID",
+            "void",
+            "VARIANT",
+            "variant",
+        ];
+        let expected = vec![
+            ArrowDataType::Int64,
+            ArrowDataType::Int64,
+            ArrowDataType::Int64,
+            ArrowDataType::Binary,
+            ArrowDataType::Binary,
+            ArrowDataType::Boolean,
+            ArrowDataType::Boolean,
+            ArrowDataType::Date32,
+            ArrowDataType::Date32,
+            ArrowDataType::Float64,
+            ArrowDataType::Float64,
+            ArrowDataType::Float32,
+            ArrowDataType::Float32,
+            ArrowDataType::Int32,
+            ArrowDataType::Int32,
+            ArrowDataType::Int16,
+            ArrowDataType::Int16,
+            ArrowDataType::Utf8,
+            ArrowDataType::Utf8,
+            ArrowDataType::Timestamp(TimeUnit::Microsecond, Some("UTC".into())),
+            ArrowDataType::Timestamp(TimeUnit::Microsecond, Some("UTC".into())),
+            ArrowDataType::Timestamp(TimeUnit::Microsecond, None),
+            ArrowDataType::Timestamp(TimeUnit::Microsecond, None),
+            ArrowDataType::Int8,
+            ArrowDataType::Int8,
+            ArrowDataType::Null,
+            ArrowDataType::Null,
+            ArrowDataType::Utf8,
+            ArrowDataType::Utf8,
+        ];
+
+        for (input, expected) in inputs.iter().zip(expected.iter()) {
+            let mut parser = Parser::new(input);
+            let result = parser.parse().expect("parse success");
+            assert_eq!(result, *expected, "Failed for input: {input}");
+        }
+    }
+
+    #[test]
+    fn test_struct_mixed_case() {
+        let inputs = vec![
+            "STRUCT<field1: INT NOT NULL COMMENT 'id field', field2: STRING>",
+            "struct<field1: int NOT NULL COMMENT 'id field', field2: string>",
+        ];
+        let expected = ArrowDataType::Struct(
+            vec![
+                ArrowField::new("field1", ArrowDataType::Int32, false).with_metadata(
+                    HashMap::from([(DESCRIPTION_METADATA_KEY.to_string(), "id field".to_string())]),
+                ),
+                ArrowField::new("field2", ArrowDataType::Utf8, true),
+            ]
+            .into(),
+        );
+
+        for input in inputs {
+            let mut parser = Parser::new(input);
+            let result = parser.parse().expect("parse success");
+            assert_eq!(result, expected, "Failed for input: {input}");
+        }
+    }
+
+    #[test]
+    fn test_parse_rejects_excessive_recursion_depth() {
+        let input = format!(
+            "{}INT{}",
+            "ARRAY<".repeat(MAX_RECURSION_DEPTH + 1),
+            ">".repeat(MAX_RECURSION_DEPTH + 1)
+        );
+
+        let mut parser = Parser::new(&input);
+        let err = parser.parse().expect_err("must reject excessive recursion");
+
+        assert!(err.contains("Maximum schema recursion depth exceeded"));
+    }
+
+    #[test]
+    fn test_struct_reserved_field_names() {
+        let input = "STRUCT<date: STRING, value: INT>";
+
+        let expected = ArrowDataType::Struct(
+            vec![
+                ArrowField::new("date", ArrowDataType::Utf8, true),
+                ArrowField::new("value", ArrowDataType::Int32, true),
+            ]
+            .into(),
+        );
+
+        let mut parser = Parser::new(input);
+        let result = parser.parse().expect("parse success");
+        assert_eq!(result, expected, "Failed for input: {input}");
+    }
+
+    #[test]
+    fn test_nested_type() {
+        let input = "ARRAY<STRUCT<field1: INT, field2: MAP<STRING, DECIMAL(10,2)>>>";
+
+        let expected = ArrowDataType::List(Arc::new(ArrowField::new(
+            "item",
+            ArrowDataType::Struct(
+                vec![
+                    ArrowField::new("field1", ArrowDataType::Int32, true),
+                    ArrowField::new(
+                        "field2",
+                        {
+                            let key_field =
+                                Arc::new(ArrowField::new("key", ArrowDataType::Utf8, false));
+                            let value_field = Arc::new(ArrowField::new(
+                                "value",
+                                ArrowDataType::Decimal128(10, 2),
+                                true,
+                            ));
+                            let entry_struct = Arc::new(ArrowField::new_struct(
+                                "entries",
+                                vec![key_field, value_field],
+                                false,
+                            ));
+                            ArrowDataType::Map(entry_struct, false)
+                        },
+                        true,
+                    ),
+                ]
+                .into(),
+            ),
+            true,
+        )));
+
+        let mut parser = Parser::new(input);
+        let result = parser.parse().expect("parse success");
+        assert_eq!(result, expected, "Failed for input: {input}");
+    }
+
+    #[test]
+    fn test_parameterless_complex_types() {
+        // When using `data_type` column instead of `full_data_type`, complex types
+        // come without type parameters (e.g. just "ARRAY" instead of "ARRAY<STRING>").
+        let mut parser = Parser::new("ARRAY");
+        let result = parser.parse().expect("parse ARRAY without params");
+        let expected_array =
+            ArrowDataType::List(Arc::new(ArrowField::new("item", ArrowDataType::Utf8, true)));
+        assert_eq!(result, expected_array);
+
+        let mut parser = Parser::new("MAP");
+        let result = parser.parse().expect("parse MAP without params");
+        let key = Arc::new(ArrowField::new("key", ArrowDataType::Utf8, false));
+        let val = Arc::new(ArrowField::new("value", ArrowDataType::Utf8, true));
+        let entries = Arc::new(ArrowField::new_struct("entries", vec![key, val], false));
+        let expected_map = ArrowDataType::Map(entries, false);
+        assert_eq!(result, expected_map);
+
+        let mut parser = Parser::new("STRUCT");
+        let result = parser.parse().expect("parse STRUCT without params");
+        assert_eq!(result, ArrowDataType::Utf8);
+
+        let mut parser = Parser::new("DECIMAL");
+        let result = parser.parse().expect("parse DECIMAL without params");
+        assert_eq!(result, ArrowDataType::Decimal128(38, 10));
+
+        // GEOMETRY with SRID → Binary
+        let mut parser = Parser::new("geometry(5070)");
+        let result = parser.parse().expect("parse GEOMETRY with SRID");
+        assert_eq!(result, ArrowDataType::Binary);
+
+        // GEOMETRY without SRID → Binary
+        let mut parser = Parser::new("GEOMETRY");
+        let result = parser.parse().expect("parse GEOMETRY without SRID");
+        assert_eq!(result, ArrowDataType::Binary);
+    }
+
+    /// Databricks sends Arrow IPC data with `Timestamp(Microsecond, ...)` but
+    /// the schema parser previously declared `Timestamp(Nanosecond, ...)`,
+    /// causing arithmetic overflow when casting far-future sentinel values
+    /// (e.g. year 9999: 253402300799999000 µs × 1000 > `i64::MAX`).
+    ///
+    /// This test ensures the parser declares Microsecond to match the wire format.
+    #[test]
+    fn test_timestamp_uses_microsecond_to_prevent_overflow() {
+        let mut parser = Parser::new("TIMESTAMP");
+        let result = parser.parse().expect("parse TIMESTAMP");
+        assert_eq!(
+            result,
+            ArrowDataType::Timestamp(TimeUnit::Microsecond, Some("UTC".into())),
+            "TIMESTAMP must use Microsecond to match Databricks Arrow IPC format"
+        );
+
+        let mut parser = Parser::new("TIMESTAMP_NTZ");
+        let result = parser.parse().expect("parse TIMESTAMP_NTZ");
+        assert_eq!(
+            result,
+            ArrowDataType::Timestamp(TimeUnit::Microsecond, None),
+            "TIMESTAMP_NTZ must use Microsecond to match Databricks Arrow IPC format"
+        );
+
+        // Verify the sentinel value 9999-12-31T23:59:59.999 fits in i64 microseconds
+        // but would overflow in nanoseconds (253402300799999000 * 1000 > i64::MAX).
+        let sentinel_us: i64 = 253_402_300_799_999_000;
+        assert!(
+            sentinel_us.checked_mul(1000).is_none(),
+            "year-9999 sentinel must overflow when converting µs→ns"
+        );
+    }
+
+    /// Databricks `data_type` column returns `LONG` for what `full_data_type`
+    /// calls `bigint`. Both must parse to `Int64`.
+    #[test]
+    fn test_long_maps_to_int64() {
+        for input in ["LONG", "long", "Long"] {
+            let mut parser = Parser::new(input);
+            let result = parser.parse().expect("should parse LONG variant");
+            assert_eq!(result, ArrowDataType::Int64, "Failed for input: {input}");
+        }
+    }
+
+    /// Covers the exact `full_data_type` values from a real Databricks
+    /// `information_schema.columns` dump: bigint, string, timestamp,
+    /// boolean, double.
+    #[test]
+    fn test_full_data_type_column_values() {
+        let cases = vec![
+            ("bigint", ArrowDataType::Int64),
+            ("string", ArrowDataType::Utf8),
+            (
+                "timestamp",
+                ArrowDataType::Timestamp(TimeUnit::Microsecond, Some("UTC".into())),
+            ),
+            ("boolean", ArrowDataType::Boolean),
+            ("double", ArrowDataType::Float64),
+        ];
+        for (input, expected) in &cases {
+            let mut parser = Parser::new(input);
+            let result = parser.parse().expect("should parse full_data_type value");
+            assert_eq!(
+                result, *expected,
+                "Failed for full_data_type input: {input}"
+            );
+        }
+    }
+
+    /// Covers the exact `data_type` column values from a real Databricks
+    /// `information_schema.columns` dump: LONG, STRING, TIMESTAMP,
+    /// BOOLEAN, DOUBLE. These are what the fallback path receives.
+    #[test]
+    fn test_data_type_column_values() {
+        let cases = vec![
+            ("LONG", ArrowDataType::Int64),
+            ("STRING", ArrowDataType::Utf8),
+            (
+                "TIMESTAMP",
+                ArrowDataType::Timestamp(TimeUnit::Microsecond, Some("UTC".into())),
+            ),
+            ("BOOLEAN", ArrowDataType::Boolean),
+            ("DOUBLE", ArrowDataType::Float64),
+        ];
+        for (input, expected) in &cases {
+            let mut parser = Parser::new(input);
+            let result = parser.parse().expect("should parse data_type value");
+            assert_eq!(result, *expected, "Failed for data_type input: {input}");
+        }
+    }
+
+    /// Source-native type names from Lakehouse Federation foreign tables
+    /// (e.g. `PostgreSQL`). These appear in `information_schema.columns.data_type`
+    /// when querying federated tables.
+    #[test]
+    fn test_source_native_types() {
+        let cases = vec![
+            ("integer", ArrowDataType::Int32),
+            ("INTEGER", ArrowDataType::Int32),
+            ("text", ArrowDataType::Utf8),
+            ("TEXT", ArrowDataType::Utf8),
+            ("numeric", ArrowDataType::Decimal128(38, 10)),
+            ("NUMERIC", ArrowDataType::Decimal128(38, 10)),
+            ("numeric(10,2)", ArrowDataType::Decimal128(10, 2)),
+            ("NUMERIC(18,4)", ArrowDataType::Decimal128(18, 4)),
+            ("real", ArrowDataType::Float32),
+            ("REAL", ArrowDataType::Float32),
+            ("double precision", ArrowDataType::Float64),
+            ("DOUBLE PRECISION", ArrowDataType::Float64),
+            ("character varying", ArrowDataType::Utf8),
+            ("CHARACTER VARYING", ArrowDataType::Utf8),
+            ("varchar", ArrowDataType::Utf8),
+            ("varchar(255)", ArrowDataType::Utf8),
+            ("VARCHAR(100)", ArrowDataType::Utf8),
+            (
+                "timestamp without time zone",
+                ArrowDataType::Timestamp(TimeUnit::Microsecond, None),
+            ),
+            (
+                "TIMESTAMP WITHOUT TIME ZONE",
+                ArrowDataType::Timestamp(TimeUnit::Microsecond, None),
+            ),
+            (
+                "timestamp with time zone",
+                ArrowDataType::Timestamp(TimeUnit::Microsecond, Some("UTC".into())),
+            ),
+            (
+                "TIMESTAMP WITH TIME ZONE",
+                ArrowDataType::Timestamp(TimeUnit::Microsecond, Some("UTC".into())),
+            ),
+        ];
+        for (input, expected) in &cases {
+            let mut parser = Parser::new(input);
+            let result = parser
+                .parse()
+                .unwrap_or_else(|e| panic!("should parse native type '{input}': {e}"));
+            assert_eq!(result, *expected, "Failed for source-native type: {input}");
+        }
+    }
+
+    /// Schema test for the Neon `PostgreSQL` foreign table from a real
+    /// DESCRIBE TABLE response (Spark SQL types).
+    #[test]
+    fn test_neon_pg_describe_table_types() {
+        let cases = vec![
+            ("int", ArrowDataType::Int32),
+            ("string", ArrowDataType::Utf8),
+            ("decimal(10,2)", ArrowDataType::Decimal128(10, 2)),
+            (
+                "timestamp",
+                ArrowDataType::Timestamp(TimeUnit::Microsecond, Some("UTC".into())),
+            ),
+            ("boolean", ArrowDataType::Boolean),
+        ];
+        for (input, expected) in &cases {
+            let mut parser = Parser::new(input);
+            let result = parser.parse().expect("should parse DESCRIBE TABLE type");
+            assert_eq!(result, *expected, "Failed for DESCRIBE TABLE type: {input}");
+        }
+    }
+
+    /// Schema test for the Neon `PostgreSQL` foreign table from
+    /// `information_schema.columns.data_type` (source-native types).
+    #[test]
+    fn test_neon_pg_information_schema_native_types() {
+        let cases = vec![
+            ("integer", ArrowDataType::Int32),
+            ("text", ArrowDataType::Utf8),
+            ("numeric", ArrowDataType::Decimal128(38, 10)),
+            (
+                "timestamp without time zone",
+                ArrowDataType::Timestamp(TimeUnit::Microsecond, None),
+            ),
+            ("boolean", ArrowDataType::Boolean),
+        ];
+        for (input, expected) in &cases {
+            let mut parser = Parser::new(input);
+            let result = parser.parse().expect("should parse native type");
+            assert_eq!(
+                result, *expected,
+                "Failed for information_schema native type: {input}"
+            );
+        }
+    }
+}

--- a/core/src/sql/arrow_sql_gen/postgres/schema.rs
+++ b/core/src/sql/arrow_sql_gen/postgres/schema.rs
@@ -4,6 +4,7 @@ use serde_json::json;
 use serde_json::Value;
 use std::sync::Arc;
 
+use crate::sql::db_connection_pool::dbconnection::postgresconn::PostgresVariant;
 use crate::UnsupportedTypeAction;
 
 #[derive(Debug, Clone)]
@@ -43,6 +44,7 @@ impl Default for ParseContext {
 pub(crate) fn pg_data_type_to_arrow_type(
     pg_type: &str,
     context: &ParseContext,
+    variant: Option<PostgresVariant>,
 ) -> Result<DataType, ArrowError> {
     let base_type = pg_type.split('(').next().unwrap_or(pg_type).trim();
 
@@ -86,7 +88,7 @@ pub(crate) fn pg_data_type_to_arrow_type(
         "tsvector" | "tsquery" => Ok(DataType::LargeUtf8),
         "xml" | "json" => Ok(DataType::Utf8),
         "aclitem" | "pg_node_tree" => Ok(DataType::Utf8),
-        "array" => parse_array_type(context),
+        "array" => parse_array_type(context, variant),
         "anyarray" => Ok(DataType::List(Arc::new(Field::new(
             "item",
             DataType::Binary,
@@ -96,12 +98,19 @@ pub(crate) fn pg_data_type_to_arrow_type(
             Field::new("lower", DataType::Int32, true),
             Field::new("upper", DataType::Int32, true),
         ]))),
-        "composite" => parse_composite_type(context),
+        "composite" => parse_composite_type(context, variant),
         "geometry" | "geography" => Ok(DataType::Binary),
 
         // `jsonb` is currently not supported, but if the user has set the `UnsupportedTypeAction` to `String` we'll return `Utf8`.
         "jsonb" if context.unsupported_type_action == UnsupportedTypeAction::String => {
             Ok(DataType::Utf8)
+        }
+        // Redshift external tables (`CREATE EXTERNAL TABLE`, Redshift Spectrum) report
+        // column types from the backing catalog (e.g. AWS Glue / Hive Metastore), which
+        // use simplified Hive type names like `string`, `int`, or `double`. When the
+        // variant is Redshift, fall back to lenient Hive-type resolution before erroring.
+        _ if variant == Some(PostgresVariant::Redshift) => {
+            redshift_external_type_to_arrow_type(pg_type)
         }
         _ => Err(ArrowError::ParseError(format!(
             "Unsupported PostgreSQL type: {}",
@@ -110,7 +119,58 @@ pub(crate) fn pg_data_type_to_arrow_type(
     }
 }
 
-fn parse_array_type(context: &ParseContext) -> Result<DataType, ArrowError> {
+/// Lenient resolution of Redshift external-table column types into Arrow types.
+///
+/// External tables (Redshift Spectrum) surface column types via `external_type` in
+/// `svv_external_columns`. These originate from the external catalog (commonly AWS
+/// Glue, which is backed by Hive types), so they may use simplified Hive type names
+/// that the standard PostgreSQL type mapping does not recognise — most notably
+/// `string`, but also `tinyint`, bare `float`/`double`, and `binary`.
+///
+/// Matching is case-insensitive (catalogs are inconsistent about casing) and covers
+/// the basic Hive types: integers, floats, decimals, strings, booleans, and the
+/// common date/time/binary types. See
+/// <https://cwiki.apache.org/confluence/display/hive/languagemanual+types>.
+fn redshift_external_type_to_arrow_type(external_type: &str) -> Result<DataType, ArrowError> {
+    // Lowercase the full type so parameterised types (e.g. `DECIMAL(10,2)`,
+    // `VARCHAR(256)`) are handled consistently regardless of catalog casing.
+    let lowered = external_type.to_lowercase();
+    let base_type = lowered.split('(').next().unwrap_or(&lowered).trim();
+
+    match base_type {
+        // String types — Hive `string` is unbounded text; `varchar`/`char` carry an
+        // optional length that does not affect the Arrow type.
+        "string" | "varchar" | "char" | "character" | "character varying" => Ok(DataType::Utf8),
+        // Integer types.
+        "tinyint" => Ok(DataType::Int8),
+        "smallint" | "int2" => Ok(DataType::Int16),
+        "int" | "integer" | "int4" => Ok(DataType::Int32),
+        "bigint" | "int8" => Ok(DataType::Int64),
+        // Floating-point types — Hive `float` is single precision, `double` is double.
+        "float" | "real" | "float4" => Ok(DataType::Float32),
+        "double" | "double precision" | "float8" => Ok(DataType::Float64),
+        // Fixed-point decimal types.
+        "decimal" | "numeric" => {
+            let (precision, scale) = parse_numeric_type(&lowered)?;
+            Ok(DataType::Decimal128(precision, scale))
+        }
+        // Boolean type.
+        "boolean" | "bool" => Ok(DataType::Boolean),
+        // Binary type.
+        "binary" => Ok(DataType::Binary),
+        // Date/time types.
+        "date" => Ok(DataType::Date32),
+        "timestamp" => Ok(DataType::Timestamp(TimeUnit::Nanosecond, None)),
+        _ => Err(ArrowError::ParseError(format!(
+            "Unsupported Redshift type: {external_type}"
+        ))),
+    }
+}
+
+fn parse_array_type(
+    context: &ParseContext,
+    variant: Option<PostgresVariant>,
+) -> Result<DataType, ArrowError> {
     let details = context
         .type_details
         .as_ref()
@@ -130,9 +190,9 @@ fn parse_array_type(context: &ParseContext) -> Result<DataType, ArrowError> {
             "type": "array",
             "element_type": element_type.trim_end_matches("[]"),
         }));
-        parse_array_type(&inner_context)?
+        parse_array_type(&inner_context, variant)?
     } else {
-        pg_data_type_to_arrow_type(element_type, context)?
+        pg_data_type_to_arrow_type(element_type, context, variant)?
     };
 
     Ok(DataType::List(Arc::new(Field::new(
@@ -140,7 +200,10 @@ fn parse_array_type(context: &ParseContext) -> Result<DataType, ArrowError> {
     ))))
 }
 
-fn parse_composite_type(context: &ParseContext) -> Result<DataType, ArrowError> {
+fn parse_composite_type(
+    context: &ParseContext,
+    variant: Option<PostgresVariant>,
+) -> Result<DataType, ArrowError> {
     let details = context.type_details.as_ref().ok_or_else(|| {
         ArrowError::ParseError("Missing type details for composite type".to_string())
     })?;
@@ -178,9 +241,9 @@ fn parse_composite_type(context: &ParseContext) -> Result<DataType, ArrowError> 
                 })?;
             let field_type = if attr_type == "composite" {
                 let inner_context = context.clone().with_type_details(attr.clone());
-                parse_composite_type(&inner_context)?
+                parse_composite_type(&inner_context, variant)?
             } else {
-                pg_data_type_to_arrow_type(attr_type, context)?
+                pg_data_type_to_arrow_type(attr_type, context, variant)?
             };
             Ok(Field::new(name, field_type, true))
         })
@@ -239,91 +302,98 @@ mod tests {
         let context = ParseContext::new();
         // Test basic types
         assert_eq!(
-            pg_data_type_to_arrow_type("smallint", &context).expect("Failed to convert smallint"),
+            pg_data_type_to_arrow_type("smallint", &context, None)
+                .expect("Failed to convert smallint"),
             DataType::Int16
         );
         assert_eq!(
-            pg_data_type_to_arrow_type("integer", &context).expect("Failed to convert integer"),
+            pg_data_type_to_arrow_type("integer", &context, None)
+                .expect("Failed to convert integer"),
             DataType::Int32
         );
         assert_eq!(
-            pg_data_type_to_arrow_type("bigint", &context).expect("Failed to convert bigint"),
+            pg_data_type_to_arrow_type("bigint", &context, None).expect("Failed to convert bigint"),
             DataType::Int64
         );
         assert_eq!(
-            pg_data_type_to_arrow_type("real", &context).expect("Failed to convert real"),
+            pg_data_type_to_arrow_type("real", &context, None).expect("Failed to convert real"),
             DataType::Float32
         );
         assert_eq!(
-            pg_data_type_to_arrow_type("double precision", &context)
+            pg_data_type_to_arrow_type("double precision", &context, None)
                 .expect("Failed to convert double precision"),
             DataType::Float64
         );
         assert_eq!(
-            pg_data_type_to_arrow_type("boolean", &context).expect("Failed to convert boolean"),
+            pg_data_type_to_arrow_type("boolean", &context, None)
+                .expect("Failed to convert boolean"),
             DataType::Boolean
         );
         assert_eq!(
-            pg_data_type_to_arrow_type("\"char\"", &context)
+            pg_data_type_to_arrow_type("\"char\"", &context, None)
                 .expect("Failed to convert single character"),
             DataType::Int8
         );
 
         // Test string types
         assert_eq!(
-            pg_data_type_to_arrow_type("character", &context).expect("Failed to convert character"),
+            pg_data_type_to_arrow_type("character", &context, None)
+                .expect("Failed to convert character"),
             DataType::Utf8
         );
         assert_eq!(
-            pg_data_type_to_arrow_type("character varying", &context)
+            pg_data_type_to_arrow_type("character varying", &context, None)
                 .expect("Failed to convert character varying"),
             DataType::Utf8
         );
         assert_eq!(
-            pg_data_type_to_arrow_type("name", &context).expect("Failed to convert name"),
+            pg_data_type_to_arrow_type("name", &context, None).expect("Failed to convert name"),
             DataType::Utf8
         );
         assert_eq!(
-            pg_data_type_to_arrow_type("text", &context).expect("Failed to convert text"),
+            pg_data_type_to_arrow_type("text", &context, None).expect("Failed to convert text"),
             DataType::Utf8
         );
 
         // Test date/time types
         assert_eq!(
-            pg_data_type_to_arrow_type("date", &context).expect("Failed to convert date"),
+            pg_data_type_to_arrow_type("date", &context, None).expect("Failed to convert date"),
             DataType::Date32
         );
         assert_eq!(
-            pg_data_type_to_arrow_type("time without time zone", &context)
+            pg_data_type_to_arrow_type("time without time zone", &context, None)
                 .expect("Failed to convert time without time zone"),
             DataType::Time64(TimeUnit::Nanosecond)
         );
         assert_eq!(
-            pg_data_type_to_arrow_type("timestamp without time zone", &context)
+            pg_data_type_to_arrow_type("timestamp without time zone", &context, None)
                 .expect("Failed to convert timestamp without time zone"),
             DataType::Timestamp(TimeUnit::Nanosecond, None)
         );
         assert_eq!(
-            pg_data_type_to_arrow_type("timestamp with time zone", &context)
+            pg_data_type_to_arrow_type("timestamp with time zone", &context, None)
                 .expect("Failed to convert timestamp with time zone"),
             DataType::Timestamp(TimeUnit::Nanosecond, Some("UTC".into()))
         );
         assert_eq!(
-            pg_data_type_to_arrow_type("interval", &context).expect("Failed to convert interval"),
+            pg_data_type_to_arrow_type("interval", &context, None)
+                .expect("Failed to convert interval"),
             DataType::Interval(IntervalUnit::MonthDayNano)
         );
 
         // Test numeric types
         assert_eq!(
-            pg_data_type_to_arrow_type("numeric", &context).expect("Failed to convert numeric"),
+            pg_data_type_to_arrow_type("numeric", &context, None)
+                .expect("Failed to convert numeric"),
             DataType::Decimal128(38, 20)
         );
         assert_eq!(
-            pg_data_type_to_arrow_type("numeric()", &context).expect("Failed to convert numeric()"),
+            pg_data_type_to_arrow_type("numeric()", &context, None)
+                .expect("Failed to convert numeric()"),
             DataType::Decimal128(38, 20)
         );
         assert_eq!(
-            pg_data_type_to_arrow_type("numeric(10,2)", &context)
+            pg_data_type_to_arrow_type("numeric(10,2)", &context, None)
                 .expect("Failed to convert numeric(10,2)"),
             DataType::Decimal128(10, 2)
         );
@@ -334,7 +404,7 @@ mod tests {
             "element_type": "integer",
         }));
         assert_eq!(
-            pg_data_type_to_arrow_type("array", &array_type_context)
+            pg_data_type_to_arrow_type("array", &array_type_context, None)
                 .expect("Failed to convert array"),
             DataType::List(Arc::new(Field::new("item", DataType::Int32, true)))
         );
@@ -348,7 +418,7 @@ mod tests {
             ]
         }));
         assert_eq!(
-            pg_data_type_to_arrow_type("composite", &composite_type_context)
+            pg_data_type_to_arrow_type("composite", &composite_type_context, None)
                 .expect("Failed to convert composite"),
             DataType::Struct(Fields::from(vec![
                 Field::new("x", DataType::Int32, true),
@@ -357,7 +427,7 @@ mod tests {
         );
 
         // Test unsupported type
-        assert!(pg_data_type_to_arrow_type("unsupported_type", &context).is_err());
+        assert!(pg_data_type_to_arrow_type("unsupported_type", &context, None).is_err());
     }
 
     #[test]
@@ -405,26 +475,26 @@ mod tests {
     fn test_pg_data_type_to_arrow_type_with_size() {
         let context = ParseContext::new();
         assert_eq!(
-            pg_data_type_to_arrow_type("character(10)", &context)
+            pg_data_type_to_arrow_type("character(10)", &context, None)
                 .expect("Failed to convert character(10)"),
             DataType::Utf8
         );
         assert_eq!(
-            pg_data_type_to_arrow_type("character varying(255)", &context)
+            pg_data_type_to_arrow_type("character varying(255)", &context, None)
                 .expect("Failed to convert character varying(255)"),
             DataType::Utf8
         );
         assert_eq!(
-            pg_data_type_to_arrow_type("bit(8)", &context).expect("Failed to convert bit(8)"),
+            pg_data_type_to_arrow_type("bit(8)", &context, None).expect("Failed to convert bit(8)"),
             DataType::Binary
         );
         assert_eq!(
-            pg_data_type_to_arrow_type("bit varying(64)", &context)
+            pg_data_type_to_arrow_type("bit varying(64)", &context, None)
                 .expect("Failed to convert bit varying(64)"),
             DataType::Binary
         );
         assert_eq!(
-            pg_data_type_to_arrow_type("numeric(10,2)", &context)
+            pg_data_type_to_arrow_type("numeric(10,2)", &context, None)
                 .expect("Failed to convert numeric(10,2)"),
             DataType::Decimal128(10, 2)
         );
@@ -435,19 +505,19 @@ mod tests {
         let context = ParseContext::new();
         // Test additional numeric types
         assert_eq!(
-            pg_data_type_to_arrow_type("numeric(38,10)", &context)
+            pg_data_type_to_arrow_type("numeric(38,10)", &context, None)
                 .expect("Failed to convert numeric(38,10)"),
             DataType::Decimal128(38, 10)
         );
         assert_eq!(
-            pg_data_type_to_arrow_type("decimal(5,0)", &context)
+            pg_data_type_to_arrow_type("decimal(5,0)", &context, None)
                 .expect("Failed to convert decimal(5,0)"),
             DataType::Decimal128(5, 0)
         );
 
         // Test time types with precision
         assert_eq!(
-            pg_data_type_to_arrow_type("time(6) without time zone", &context)
+            pg_data_type_to_arrow_type("time(6) without time zone", &context, None)
                 .expect("Failed to convert time(6) without time zone"),
             DataType::Time64(TimeUnit::Nanosecond)
         );
@@ -458,7 +528,7 @@ mod tests {
             "element_type": "integer[]",
         }));
         assert_eq!(
-            pg_data_type_to_arrow_type("array", &nested_array_type_details)
+            pg_data_type_to_arrow_type("array", &nested_array_type_details, None)
                 .expect("Failed to convert nested array"),
             DataType::List(Arc::new(Field::new(
                 "item",
@@ -473,33 +543,35 @@ mod tests {
             "values": ["small", "medium", "large"]
         }));
         assert_eq!(
-            pg_data_type_to_arrow_type("enum", &enum_type_details).expect("Failed to convert enum"),
+            pg_data_type_to_arrow_type("enum", &enum_type_details, None)
+                .expect("Failed to convert enum"),
             DataType::Dictionary(Box::new(DataType::Int8), Box::new(DataType::Utf8))
         );
 
         // Test geometric types
         assert_eq!(
-            pg_data_type_to_arrow_type("point", &context).expect("Failed to convert point"),
+            pg_data_type_to_arrow_type("point", &context, None).expect("Failed to convert point"),
             DataType::FixedSizeList(Arc::new(Field::new("item", DataType::Float64, true)), 2)
         );
         assert_eq!(
-            pg_data_type_to_arrow_type("line", &context).expect("Failed to convert line"),
+            pg_data_type_to_arrow_type("line", &context, None).expect("Failed to convert line"),
             DataType::Binary
         );
 
         // Test network address types
         assert_eq!(
-            pg_data_type_to_arrow_type("inet", &context).expect("Failed to convert inet"),
+            pg_data_type_to_arrow_type("inet", &context, None).expect("Failed to convert inet"),
             DataType::Utf8
         );
         assert_eq!(
-            pg_data_type_to_arrow_type("cidr", &context).expect("Failed to convert cidr"),
+            pg_data_type_to_arrow_type("cidr", &context, None).expect("Failed to convert cidr"),
             DataType::Utf8
         );
 
         // Test range types
         assert_eq!(
-            pg_data_type_to_arrow_type("int4range", &context).expect("Failed to convert int4range"),
+            pg_data_type_to_arrow_type("int4range", &context, None)
+                .expect("Failed to convert int4range"),
             DataType::Struct(Fields::from(vec![
                 Field::new("lower", DataType::Int32, true),
                 Field::new("upper", DataType::Int32, true),
@@ -508,7 +580,7 @@ mod tests {
 
         // Test JSON types
         assert_eq!(
-            pg_data_type_to_arrow_type("json", &context).expect("Failed to convert json"),
+            pg_data_type_to_arrow_type("json", &context, None).expect("Failed to convert json"),
             DataType::Utf8
         );
 
@@ -516,35 +588,38 @@ mod tests {
             .clone()
             .with_unsupported_type_action(UnsupportedTypeAction::String);
         assert_eq!(
-            pg_data_type_to_arrow_type("jsonb", &jsonb_context).expect("Failed to convert jsonb"),
+            pg_data_type_to_arrow_type("jsonb", &jsonb_context, None)
+                .expect("Failed to convert jsonb"),
             DataType::Utf8
         );
 
         // Test UUID type
         assert_eq!(
-            pg_data_type_to_arrow_type("uuid", &context).expect("Failed to convert uuid"),
+            pg_data_type_to_arrow_type("uuid", &context, None).expect("Failed to convert uuid"),
             DataType::Utf8
         );
 
         // Test text search types
         assert_eq!(
-            pg_data_type_to_arrow_type("tsvector", &context).expect("Failed to convert tsvector"),
+            pg_data_type_to_arrow_type("tsvector", &context, None)
+                .expect("Failed to convert tsvector"),
             DataType::LargeUtf8
         );
         assert_eq!(
-            pg_data_type_to_arrow_type("tsquery", &context).expect("Failed to convert tsquery"),
+            pg_data_type_to_arrow_type("tsquery", &context, None)
+                .expect("Failed to convert tsquery"),
             DataType::LargeUtf8
         );
 
         // Test bpchar type
         assert_eq!(
-            pg_data_type_to_arrow_type("bpchar", &context).expect("Failed to convert bpchar"),
+            pg_data_type_to_arrow_type("bpchar", &context, None).expect("Failed to convert bpchar"),
             DataType::Utf8
         );
 
         // Test bpchar with length specification
         assert_eq!(
-            pg_data_type_to_arrow_type("bpchar(10)", &context)
+            pg_data_type_to_arrow_type("bpchar(10)", &context, None)
                 .expect("Failed to convert bpchar(10)"),
             DataType::Utf8
         );
@@ -558,7 +633,8 @@ mod tests {
             "element_type": "integer",
         }));
         assert_eq!(
-            parse_array_type(&single_dim_array).expect("Failed to parse single dimension array"),
+            parse_array_type(&single_dim_array, None)
+                .expect("Failed to parse single dimension array"),
             DataType::List(Arc::new(Field::new("item", DataType::Int32, true)))
         );
 
@@ -567,7 +643,8 @@ mod tests {
             "element_type": "text[]",
         }));
         assert_eq!(
-            parse_array_type(&multi_dim_array).expect("Failed to parse multi-dimension array"),
+            parse_array_type(&multi_dim_array, None)
+                .expect("Failed to parse multi-dimension array"),
             DataType::List(Arc::new(Field::new(
                 "item",
                 DataType::List(Arc::new(Field::new("item", DataType::Utf8, true))),
@@ -576,7 +653,7 @@ mod tests {
         );
 
         let invalid_array = context.clone().with_type_details(json!({"type": "array"}));
-        assert!(parse_array_type(&invalid_array).is_err());
+        assert!(parse_array_type(&invalid_array, None).is_err());
     }
 
     #[test]
@@ -591,7 +668,8 @@ mod tests {
             ]
         }));
         assert_eq!(
-            parse_composite_type(&simple_composite).expect("Failed to parse simple composite type"),
+            parse_composite_type(&simple_composite, None)
+                .expect("Failed to parse simple composite type"),
             DataType::Struct(Fields::from(vec![
                 Field::new("id", DataType::Int32, true),
                 Field::new("name", DataType::Utf8, true),
@@ -610,7 +688,8 @@ mod tests {
             ]
         }));
         assert_eq!(
-            parse_composite_type(&nested_composite).expect("Failed to parse nested composite type"),
+            parse_composite_type(&nested_composite, None)
+                .expect("Failed to parse nested composite type"),
             DataType::Struct(Fields::from(vec![
                 Field::new("id", DataType::Int32, true),
                 Field::new(
@@ -627,6 +706,135 @@ mod tests {
         let invalid_composite = context.clone().with_type_details(json!({
             "type": "composite",
         }));
-        assert!(parse_composite_type(&invalid_composite).is_err());
+        assert!(parse_composite_type(&invalid_composite, None).is_err());
+    }
+
+    /// Convenience wrapper that resolves a type as a Redshift column would.
+    fn redshift(pg_type: &str) -> Result<DataType, ArrowError> {
+        pg_data_type_to_arrow_type(
+            pg_type,
+            &ParseContext::new(),
+            Some(PostgresVariant::Redshift),
+        )
+    }
+
+    #[test]
+    fn test_redshift_external_simplified_hive_types() {
+        // The headline case from AWS Glue / Hive catalogs: `string` must map to Utf8.
+        assert_eq!(redshift("string").expect("string"), DataType::Utf8);
+
+        // Integer family, including Hive `tinyint` which has no PostgreSQL spelling.
+        assert_eq!(redshift("tinyint").expect("tinyint"), DataType::Int8);
+        assert_eq!(redshift("smallint").expect("smallint"), DataType::Int16);
+        assert_eq!(redshift("int").expect("int"), DataType::Int32);
+        assert_eq!(redshift("integer").expect("integer"), DataType::Int32);
+        assert_eq!(redshift("bigint").expect("bigint"), DataType::Int64);
+
+        // Floating-point: Hive `float` is single precision, `double` is double precision.
+        assert_eq!(redshift("float").expect("float"), DataType::Float32);
+        assert_eq!(redshift("double").expect("double"), DataType::Float64);
+        assert_eq!(
+            redshift("double precision").expect("double precision"),
+            DataType::Float64
+        );
+
+        // Booleans.
+        assert_eq!(redshift("boolean").expect("boolean"), DataType::Boolean);
+
+        // Binary.
+        assert_eq!(redshift("binary").expect("binary"), DataType::Binary);
+
+        // Date/time.
+        assert_eq!(redshift("date").expect("date"), DataType::Date32);
+        assert_eq!(
+            redshift("timestamp").expect("timestamp"),
+            DataType::Timestamp(TimeUnit::Nanosecond, None)
+        );
+    }
+
+    #[test]
+    fn test_redshift_external_string_variants() {
+        // Hive `string` and the length-qualified character types all collapse to Utf8.
+        assert_eq!(redshift("string").expect("string"), DataType::Utf8);
+        assert_eq!(redshift("varchar").expect("varchar"), DataType::Utf8);
+        assert_eq!(
+            redshift("varchar(256)").expect("varchar(256)"),
+            DataType::Utf8
+        );
+        assert_eq!(redshift("char(10)").expect("char(10)"), DataType::Utf8);
+    }
+
+    #[test]
+    fn test_redshift_external_decimal_types() {
+        // Hive `decimal` carries precision/scale that must be parsed through.
+        assert_eq!(
+            redshift("decimal(10,2)").expect("decimal(10,2)"),
+            DataType::Decimal128(10, 2)
+        );
+        assert_eq!(
+            redshift("decimal(38,0)").expect("decimal(38,0)"),
+            DataType::Decimal128(38, 0)
+        );
+        // Bare `decimal` falls back to the default precision/scale.
+        assert_eq!(
+            redshift("decimal").expect("decimal"),
+            DataType::Decimal128(38, 20)
+        );
+    }
+
+    #[test]
+    fn test_redshift_external_types_are_case_insensitive() {
+        // External catalogs are inconsistent about casing, so resolution must not care.
+        assert_eq!(redshift("STRING").expect("STRING"), DataType::Utf8);
+        assert_eq!(redshift("Int").expect("Int"), DataType::Int32);
+        assert_eq!(redshift("BIGINT").expect("BIGINT"), DataType::Int64);
+        assert_eq!(redshift("Double").expect("Double"), DataType::Float64);
+        assert_eq!(
+            redshift("DECIMAL(12,4)").expect("DECIMAL(12,4)"),
+            DataType::Decimal128(12, 4)
+        );
+        assert_eq!(redshift("Boolean").expect("Boolean"), DataType::Boolean);
+    }
+
+    #[test]
+    fn test_redshift_variant_still_handles_native_pg_types() {
+        // Standard Redshift (svv_redshift_columns) emits formatted PostgreSQL type
+        // strings; the Redshift variant must keep resolving those unchanged.
+        assert_eq!(
+            redshift("character varying(256)").expect("character varying(256)"),
+            DataType::Utf8
+        );
+        assert_eq!(
+            redshift("numeric(10,2)").expect("numeric(10,2)"),
+            DataType::Decimal128(10, 2)
+        );
+        assert_eq!(
+            redshift("timestamp without time zone").expect("timestamp without time zone"),
+            DataType::Timestamp(TimeUnit::Nanosecond, None)
+        );
+    }
+
+    #[test]
+    fn test_simplified_hive_types_require_redshift_variant() {
+        // The lenient Hive mapping is gated on the Redshift variant: `string` is not a
+        // PostgreSQL type, so it must error for the default variant and when unset.
+        let context = ParseContext::new();
+        assert!(pg_data_type_to_arrow_type("string", &context, None).is_err());
+        assert!(
+            pg_data_type_to_arrow_type("string", &context, Some(PostgresVariant::Default)).is_err()
+        );
+        // `tinyint` is likewise Hive-only.
+        assert!(pg_data_type_to_arrow_type("tinyint", &context, None).is_err());
+    }
+
+    #[test]
+    fn test_redshift_external_unsupported_type_errors() {
+        // Complex Hive types (and genuinely unknown types) are still unsupported even
+        // under the Redshift variant, so they surface as errors rather than silently
+        // mapping to the wrong Arrow type.
+        assert!(redshift("array<int>").is_err());
+        assert!(redshift("map<string,int>").is_err());
+        assert!(redshift("struct<a:int>").is_err());
+        assert!(redshift("totally_unknown_type").is_err());
     }
 }

--- a/core/src/sql/arrow_sql_gen/postgres/schema.rs
+++ b/core/src/sql/arrow_sql_gen/postgres/schema.rs
@@ -4,6 +4,7 @@ use serde_json::json;
 use serde_json::Value;
 use std::sync::Arc;
 
+use super::hive_schema;
 use crate::sql::db_connection_pool::dbconnection::postgresconn::PostgresVariant;
 use crate::UnsupportedTypeAction;
 
@@ -107,8 +108,9 @@ pub(crate) fn pg_data_type_to_arrow_type(
         }
         // Redshift external tables (`CREATE EXTERNAL TABLE`, Redshift Spectrum) report
         // column types from the backing catalog (e.g. AWS Glue / Hive Metastore), which
-        // use simplified Hive type names like `string`, `int`, or `double`. When the
-        // variant is Redshift, fall back to lenient Hive-type resolution before erroring.
+        // use Hive type names — including complex types like `array<struct<...>>`,
+        // `map<...>`, and `struct<...>`. When the variant is Redshift, fall back to the
+        // shared Hive type-string parser before erroring.
         _ if variant == Some(PostgresVariant::Redshift) => {
             redshift_external_type_to_arrow_type(pg_type)
         }
@@ -119,52 +121,25 @@ pub(crate) fn pg_data_type_to_arrow_type(
     }
 }
 
-/// Lenient resolution of Redshift external-table column types into Arrow types.
+/// Resolves a Redshift external-table column type into an Arrow type.
 ///
-/// External tables (Redshift Spectrum) surface column types via `external_type` in
-/// `svv_external_columns`. These originate from the external catalog (commonly AWS
-/// Glue, which is backed by Hive types), so they may use simplified Hive type names
-/// that the standard PostgreSQL type mapping does not recognise — most notably
-/// `string`, but also `tinyint`, bare `float`/`double`, and `binary`.
+/// External tables (Redshift Spectrum) surface column types from the backing catalog
+/// (commonly AWS Glue, which is backed by Hive types). These use Hive type names that
+/// the standard PostgreSQL type mapping does not recognise — simple scalars like
+/// `string`, `tinyint`, or bare `float`/`double`, but also the complex types
+/// `array<...>`, `map<...>`, and `struct<...>` that Spectrum serializes to JSON text.
 ///
-/// Matching is case-insensitive (catalogs are inconsistent about casing) and covers
-/// the basic Hive types: integers, floats, decimals, strings, booleans, and the
-/// common date/time/binary types. See
+/// Resolution is delegated to the shared [`hive_schema::Parser`] so that Redshift and
+/// Databricks share one Hive type-string grammar. Parsing is case-insensitive (catalogs
+/// are inconsistent about casing) and handles parameterised types (e.g. `DECIMAL(10,2)`,
+/// `VARCHAR(256)`). See
 /// <https://cwiki.apache.org/confluence/display/hive/languagemanual+types>.
 fn redshift_external_type_to_arrow_type(external_type: &str) -> Result<DataType, ArrowError> {
-    // Lowercase the full type so parameterised types (e.g. `DECIMAL(10,2)`,
-    // `VARCHAR(256)`) are handled consistently regardless of catalog casing.
-    let lowered = external_type.to_lowercase();
-    let base_type = lowered.split('(').next().unwrap_or(&lowered).trim();
-
-    match base_type {
-        // String types — Hive `string` is unbounded text; `varchar`/`char` carry an
-        // optional length that does not affect the Arrow type.
-        "string" | "varchar" | "char" | "character" | "character varying" => Ok(DataType::Utf8),
-        // Integer types.
-        "tinyint" => Ok(DataType::Int8),
-        "smallint" | "int2" => Ok(DataType::Int16),
-        "int" | "integer" | "int4" => Ok(DataType::Int32),
-        "bigint" | "int8" => Ok(DataType::Int64),
-        // Floating-point types — Hive `float` is single precision, `double` is double.
-        "float" | "real" | "float4" => Ok(DataType::Float32),
-        "double" | "double precision" | "float8" => Ok(DataType::Float64),
-        // Fixed-point decimal types.
-        "decimal" | "numeric" => {
-            let (precision, scale) = parse_numeric_type(&lowered)?;
-            Ok(DataType::Decimal128(precision, scale))
-        }
-        // Boolean type.
-        "boolean" | "bool" => Ok(DataType::Boolean),
-        // Binary type.
-        "binary" => Ok(DataType::Binary),
-        // Date/time types.
-        "date" => Ok(DataType::Date32),
-        "timestamp" => Ok(DataType::Timestamp(TimeUnit::Nanosecond, None)),
-        _ => Err(ArrowError::ParseError(format!(
-            "Unsupported Redshift type: {external_type}"
-        ))),
-    }
+    hive_schema::Parser::new(external_type)
+        .parse()
+        .map_err(|e| {
+            ArrowError::ParseError(format!("Unsupported Redshift type: {external_type} ({e})"))
+        })
 }
 
 fn parse_array_type(
@@ -178,6 +153,19 @@ fn parse_array_type(
     let details = details
         .as_object()
         .ok_or_else(|| ArrowError::ParseError("Invalid array type details format".to_string()))?;
+    // When the array element is a composite type (`my_struct[]`), the schema query
+    // emits the element's attribute details so we can build a `Struct` here, rather
+    // than trying to resolve the bare composite type name.
+    if let Some(element_details) = details.get("element_details") {
+        if element_details.get("type").and_then(Value::as_str) == Some("composite") {
+            let inner_context = context.clone().with_type_details(element_details.clone());
+            let inner_type = parse_composite_type(&inner_context, variant)?;
+            return Ok(DataType::List(Arc::new(Field::new(
+                "item", inner_type, true,
+            ))));
+        }
+    }
+
     let element_type = details
         .get("element_type")
         .and_then(Value::as_str)
@@ -657,6 +645,64 @@ mod tests {
     }
 
     #[test]
+    fn test_parse_array_of_composite_type() {
+        // An array whose element is a composite type carries `element_details`
+        // describing the struct fields; the array resolves to List<Struct>.
+        let context = ParseContext::new();
+        let composite_array = context.clone().with_type_details(json!({
+            "type": "array",
+            "element_type": "line_item",
+            "element_details": {
+                "type": "composite",
+                "attributes": [
+                    {"name": "sku", "type": "text"},
+                    {"name": "qty", "type": "integer"},
+                    {"name": "price", "type": "double precision"},
+                ]
+            }
+        }));
+
+        let expected = DataType::List(Arc::new(Field::new(
+            "item",
+            DataType::Struct(Fields::from(vec![
+                Field::new("sku", DataType::Utf8, true),
+                Field::new("qty", DataType::Int32, true),
+                Field::new("price", DataType::Float64, true),
+            ])),
+            true,
+        )));
+
+        assert_eq!(
+            parse_array_type(&composite_array, None).expect("composite array parses"),
+            expected
+        );
+
+        // Resolving through the top-level entry point (data_type == "array") must
+        // yield the same List<Struct>.
+        assert_eq!(
+            pg_data_type_to_arrow_type("array", &composite_array, None)
+                .expect("array data_type resolves"),
+            expected
+        );
+    }
+
+    #[test]
+    fn test_parse_array_with_null_element_details_falls_back() {
+        // Non-composite element arrays emit `element_details` as JSON null; resolution
+        // must fall through to the scalar `element_type` path.
+        let context = ParseContext::new();
+        let scalar_array = context.clone().with_type_details(json!({
+            "type": "array",
+            "element_type": "integer",
+            "element_details": serde_json::Value::Null,
+        }));
+        assert_eq!(
+            parse_array_type(&scalar_array, None).expect("scalar array parses"),
+            DataType::List(Arc::new(Field::new("item", DataType::Int32, true)))
+        );
+    }
+
+    #[test]
     fn test_parse_composite_type_extended() {
         let context = ParseContext::new();
         let simple_composite = context.clone().with_type_details(json!({
@@ -828,13 +874,56 @@ mod tests {
     }
 
     #[test]
+    fn test_redshift_external_complex_types_resolve() {
+        // Complex Hive types from the external catalog now resolve through the shared
+        // Hive parser (Redshift Spectrum serializes their values to JSON text, which the
+        // row path decodes into these Arrow types).
+        assert_eq!(
+            redshift("array<int>").expect("array<int>"),
+            DataType::List(Arc::new(Field::new("item", DataType::Int32, true)))
+        );
+
+        let map_entries = Arc::new(Field::new_struct(
+            "entries",
+            vec![
+                Arc::new(Field::new("key", DataType::Utf8, false)),
+                Arc::new(Field::new("value", DataType::Int32, true)),
+            ],
+            false,
+        ));
+        assert_eq!(
+            redshift("map<string,int>").expect("map<string,int>"),
+            DataType::Map(map_entries, false)
+        );
+
+        assert_eq!(
+            redshift("struct<a:int>").expect("struct<a:int>"),
+            DataType::Struct(Fields::from(vec![Field::new("a", DataType::Int32, true)]))
+        );
+
+        // The headline case: an array of structs (e.g. Spectrum line-item collections).
+        assert_eq!(
+            redshift("array<struct<shipdate:timestamp,price:decimal(10,2)>>")
+                .expect("array<struct<...>>"),
+            DataType::List(Arc::new(Field::new(
+                "item",
+                DataType::Struct(Fields::from(vec![
+                    Field::new(
+                        "shipdate",
+                        DataType::Timestamp(TimeUnit::Microsecond, Some("UTC".into())),
+                        true,
+                    ),
+                    Field::new("price", DataType::Decimal128(10, 2), true),
+                ])),
+                true,
+            )))
+        );
+    }
+
+    #[test]
     fn test_redshift_external_unsupported_type_errors() {
-        // Complex Hive types (and genuinely unknown types) are still unsupported even
-        // under the Redshift variant, so they surface as errors rather than silently
+        // Genuinely unknown type names still surface as errors rather than silently
         // mapping to the wrong Arrow type.
-        assert!(redshift("array<int>").is_err());
-        assert!(redshift("map<string,int>").is_err());
-        assert!(redshift("struct<a:int>").is_err());
         assert!(redshift("totally_unknown_type").is_err());
     }
 }

--- a/core/src/sql/db_connection_pool/dbconnection/postgresconn.rs
+++ b/core/src/sql/db_connection_pool/dbconnection/postgresconn.rs
@@ -94,6 +94,30 @@ SELECT
             FROM pg_type t2
             JOIN pg_type et ON t2.typelem = et.oid
             WHERE t2.oid = a.atttypid
+        ),
+        -- When the array element is a composite type, carry its attributes so the
+        -- array can be resolved to a List<Struct>. Null for non-composite elements.
+        'element_details', (
+            SELECT jsonb_build_object(
+                'type', 'composite',
+                'attributes', (
+                    SELECT jsonb_agg(
+                        jsonb_build_object(
+                            'name', a2.attname,
+                            'type', pg_catalog.format_type(a2.atttypid, a2.atttypmod)
+                        )
+                        ORDER BY a2.attnum
+                    )
+                    FROM pg_attribute a2
+                    WHERE a2.attrelid = et.typrelid
+                    AND a2.attnum > 0
+                    AND NOT a2.attisdropped
+                )
+            )
+            FROM pg_type t2
+            JOIN pg_type et ON t2.typelem = et.oid
+            WHERE t2.oid = a.atttypid
+            AND et.typtype = 'c'
         )
         )
     ELSE custom.type_details

--- a/core/src/sql/db_connection_pool/dbconnection/postgresconn.rs
+++ b/core/src/sql/db_connection_pool/dbconnection/postgresconn.rs
@@ -111,31 +111,31 @@ WHERE ns.nspname = $1
 ORDER BY a.attnum;
 ";
 
+// Redshift does not materialize datashare objects into the local `pg_catalog`
+// (pg_class/pg_attribute return zero rows for tables consumed from a datashare),
+// so we read column metadata from `svv_redshift_columns`, which covers both local
+// and datashare tables. The view exposes no type OIDs, so the array/enum/composite
+// `type_details` path is unavailable — that is acceptable because Redshift has no
+// PostgreSQL arrays/enums/composites (semi-structured data uses SUPER).
+//
+// Notes:
+// - `data_type` is already a formatted type string (e.g. `character varying(256)`,
+//   `numeric(10,2)`), matching what `format_type` produced before.
+// - `is_nullable` is normalized to the literal `YES`/`NO` expected by `get_schema`.
+// - `database_name = current_database()` scopes to the connected database (which is
+//   the datashare consumer DB) so a schema/table that exists in multiple accessible
+//   databases doesn't yield duplicated columns.
 const REDSHIFT_SCHEMA_QUERY: &str = r#"
 SELECT
-    a.attname AS column_name,
-    CASE
-        WHEN t.typelem != 0 AND et.typname IS NOT NULL THEN 'array'
-        ELSE pg_catalog.format_type(a.atttypid, a.atttypmod)
-    END AS data_type,
-    CASE WHEN a.attnotnull THEN 'NO' ELSE 'YES' END AS is_nullable,
-    CASE
-        WHEN t.typelem != 0 AND et.typname IS NOT NULL THEN
-            -- JSON_PARSE returns a super type tokio-postgres does not understand, so cast to text
-            JSON_PARSE('{"type": "array", "element_type": "' || et.typname || '"}')::text
-        ELSE NULL
-    END AS type_details
-FROM pg_class cls
-JOIN pg_namespace ns ON cls.relnamespace = ns.oid
-JOIN pg_attribute a ON a.attrelid = cls.oid
-LEFT JOIN pg_type t ON t.oid = a.atttypid
-LEFT JOIN pg_type et ON t.typelem = et.oid
-WHERE ns.nspname = $1
-    AND cls.relname = $2
-    AND cls.relkind IN ('r','v','m')
-    AND a.attnum > 0
-    AND NOT a.attisdropped
-ORDER BY a.attnum;
+    column_name,
+    data_type,
+    CASE WHEN lower(is_nullable) IN ('yes', 'true') THEN 'YES' ELSE 'NO' END AS is_nullable,
+    CAST(NULL AS VARCHAR) AS type_details
+FROM svv_redshift_columns
+WHERE schema_name = $1
+    AND table_name = $2
+    AND database_name = current_database()
+ORDER BY ordinal_position;
 "#;
 
 pub enum PostgresVariant {
@@ -154,6 +154,26 @@ const TABLES_QUERY: &str = "
 SELECT tablename
 FROM pg_tables
 WHERE schemaname = $1;
+";
+
+// Like `REDSHIFT_SCHEMA_QUERY`, these read from the `svv_redshift_*` system views so
+// that schemas/tables consumed from a datashare (absent from the local `pg_catalog`)
+// are listed alongside the connected database's own schemas/tables. `current_database()`
+// scopes results to the connected (datashare consumer) database.
+const REDSHIFT_SCHEMAS_QUERY: &str = "
+SELECT schema_name
+FROM svv_redshift_schemas
+WHERE database_name = current_database()
+  AND schema_name NOT IN ('pg_catalog', 'information_schema')
+  AND schema_name NOT LIKE 'pg_temp_%'
+  AND schema_name NOT LIKE 'pg_toast%';
+";
+
+const REDSHIFT_TABLES_QUERY: &str = "
+SELECT table_name
+FROM svv_redshift_tables
+WHERE database_name = current_database()
+  AND schema_name = $1;
 ";
 
 #[derive(Debug, Snafu)]
@@ -244,23 +264,33 @@ impl<'a> AsyncDbConnection<PostgresPooledConnection, &'a (dyn ToSql + Sync)>
     }
 
     async fn tables(&self, schema: &str) -> Result<Vec<String>, super::Error> {
-        let rows = self
-            .conn
-            .query(TABLES_QUERY, &[&schema])
-            .await
-            .map_err(|e| super::Error::UnableToGetTables {
+        let query = match self.get_variant().await? {
+            PostgresVariant::Default => TABLES_QUERY,
+            PostgresVariant::Redshift => REDSHIFT_TABLES_QUERY,
+        };
+
+        let rows = self.conn.query(query, &[&schema]).await.map_err(|e| {
+            super::Error::UnableToGetTables {
                 source: Box::new(e),
-            })?;
+            }
+        })?;
 
         Ok(rows.iter().map(|r| r.get::<usize, String>(0)).collect())
     }
 
     async fn schemas(&self) -> Result<Vec<String>, super::Error> {
-        let rows = self.conn.query(SCHEMAS_QUERY, &[]).await.map_err(|e| {
-            super::Error::UnableToGetSchemas {
-                source: Box::new(e),
-            }
-        })?;
+        let query = match self.get_variant().await? {
+            PostgresVariant::Default => SCHEMAS_QUERY,
+            PostgresVariant::Redshift => REDSHIFT_SCHEMAS_QUERY,
+        };
+
+        let rows =
+            self.conn
+                .query(query, &[])
+                .await
+                .map_err(|e| super::Error::UnableToGetSchemas {
+                    source: Box::new(e),
+                })?;
 
         Ok(rows.iter().map(|r| r.get::<usize, String>(0)).collect())
     }
@@ -270,6 +300,16 @@ impl<'a> AsyncDbConnection<PostgresPooledConnection, &'a (dyn ToSql + Sync)>
         table_reference: &TableReference,
     ) -> Result<SchemaRef, super::Error> {
         let (variant, rows) = self.query_variant_and_schema(table_reference).await?;
+
+        // Native inference can return zero rows even though the table exists and is
+        // queryable — e.g. Redshift datashare objects that aren't represented in the
+        // catalog views we query. Fall back to inferring the schema from a sample row.
+        if rows.is_empty() {
+            tracing::warn!(
+                "Native PostgreSQL schema inference returned no data. Inferring schema from table data rows."
+            );
+            return self.infer_schema_from_data(table_reference).await;
+        }
 
         let mut fields = Vec::new();
         for row in rows {
@@ -440,5 +480,52 @@ impl PostgresConnection {
             });
 
         Ok((variant, rows?))
+    }
+
+    /// Fallback schema inference used when native (catalog-based) inference returns no
+    /// rows for a table that is nonetheless queryable. Reads a single row and derives the
+    /// Arrow schema from its column metadata via `rows_to_arrow`.
+    ///
+    /// Note: an empty table yields an empty schema, since `rows_to_arrow` reads column
+    /// types from the first returned row.
+    async fn infer_schema_from_data(
+        &self,
+        table_reference: &TableReference,
+    ) -> Result<SchemaRef, super::Error> {
+        let rows = self
+            .conn
+            .query(&format!("SELECT * FROM {table_reference} LIMIT 1"), &[])
+            .await
+            .map_err(|e| {
+                if let Some(error_source) = e.source() {
+                    if let Some(pg_error) =
+                        error_source.downcast_ref::<tokio_postgres::error::DbError>()
+                    {
+                        if pg_error.code() == &tokio_postgres::error::SqlState::UNDEFINED_TABLE {
+                            return super::Error::UndefinedTable {
+                                source: Box::new(pg_error.clone()),
+                                table_name: table_reference.to_string(),
+                            };
+                        }
+                    }
+                }
+                super::Error::UnableToGetSchema {
+                    source: Box::new(e),
+                }
+            })?;
+
+        if rows.is_empty() {
+            tracing::warn!(
+                "Schema inference from table data rows returned no rows. The schema for table '{table_reference}' is empty.",
+            );
+            return Ok(Arc::new(Schema::empty()));
+        }
+
+        let rec =
+            rows_to_arrow(rows.as_slice(), &None).map_err(|e| super::Error::UnableToGetSchema {
+                source: Box::new(PostgresError::ConversionError { source: e }),
+            })?;
+
+        Ok(rec.schema())
     }
 }

--- a/core/src/sql/db_connection_pool/dbconnection/postgresconn.rs
+++ b/core/src/sql/db_connection_pool/dbconnection/postgresconn.rs
@@ -8,6 +8,7 @@ use crate::sql::arrow_sql_gen::postgres::schema::ParseContext;
 use crate::sql::db_connection_pool::postgrespool::ConnectionManager;
 use crate::util::handle_unsupported_type_error;
 use crate::util::schema::SchemaValidator;
+use crate::UnsupportedTypeAction;
 use arrow::datatypes::Field;
 use arrow::datatypes::Schema;
 use arrow::datatypes::SchemaRef;
@@ -30,8 +31,7 @@ use futures::stream;
 use futures::StreamExt;
 
 use snafu::prelude::*;
-
-use crate::UnsupportedTypeAction;
+use tokio_postgres::Row;
 
 use super::AsyncDbConnection;
 use super::DbConnection;
@@ -110,6 +110,38 @@ WHERE ns.nspname = $1
     AND NOT a.attisdropped
 ORDER BY a.attnum;
 ";
+
+const REDSHIFT_SCHEMA_QUERY: &str = r#"
+SELECT
+    a.attname AS column_name,
+    CASE
+        WHEN t.typelem != 0 AND et.typname IS NOT NULL THEN 'array'
+        ELSE pg_catalog.format_type(a.atttypid, a.atttypmod)
+    END AS data_type,
+    CASE WHEN a.attnotnull THEN 'NO' ELSE 'YES' END AS is_nullable,
+    CASE
+        WHEN t.typelem != 0 AND et.typname IS NOT NULL THEN
+            -- JSON_PARSE returns a super type tokio-postgres does not understand, so cast to text
+            JSON_PARSE('{"type": "array", "element_type": "' || et.typname || '"}')::text
+        ELSE NULL
+    END AS type_details
+FROM pg_class cls
+JOIN pg_namespace ns ON cls.relnamespace = ns.oid
+JOIN pg_attribute a ON a.attrelid = cls.oid
+LEFT JOIN pg_type t ON t.oid = a.atttypid
+LEFT JOIN pg_type et ON t.typelem = et.oid
+WHERE ns.nspname = $1
+    AND cls.relname = $2
+    AND cls.relkind IN ('r','v','m')
+    AND a.attnum > 0
+    AND NOT a.attisdropped
+ORDER BY a.attnum;
+"#;
+
+pub enum PostgresVariant {
+    Default,
+    Redshift,
+}
 
 const SCHEMAS_QUERY: &str = "
 SELECT nspname AS schema_name
@@ -237,33 +269,7 @@ impl<'a> AsyncDbConnection<PostgresPooledConnection, &'a (dyn ToSql + Sync)>
         &self,
         table_reference: &TableReference,
     ) -> Result<SchemaRef, super::Error> {
-        let table_name = table_reference.table();
-        let schema_name = table_reference.schema().unwrap_or("public");
-
-        let rows = match self
-            .conn
-            .query(SCHEMA_QUERY, &[&schema_name, &table_name])
-            .await
-        {
-            Ok(rows) => rows,
-            Err(e) => {
-                if let Some(error_source) = e.source() {
-                    if let Some(pg_error) =
-                        error_source.downcast_ref::<tokio_postgres::error::DbError>()
-                    {
-                        if pg_error.code() == &tokio_postgres::error::SqlState::UNDEFINED_TABLE {
-                            return Err(super::Error::UndefinedTable {
-                                source: Box::new(pg_error.clone()),
-                                table_name: table_reference.to_string(),
-                            });
-                        }
-                    }
-                }
-                return Err(super::Error::UnableToGetSchema {
-                    source: Box::new(e),
-                });
-            }
-        };
+        let (variant, rows) = self.query_variant_and_schema(table_reference).await?;
 
         let mut fields = Vec::new();
         for row in rows {
@@ -271,7 +277,16 @@ impl<'a> AsyncDbConnection<PostgresPooledConnection, &'a (dyn ToSql + Sync)>
             let pg_type = row.get::<usize, String>(1);
             let nullable_str = row.get::<usize, String>(2);
             let nullable = nullable_str == "YES";
-            let type_details = row.get::<usize, Option<serde_json::Value>>(3);
+
+            let type_details = match variant {
+                PostgresVariant::Default => row.get::<usize, Option<serde_json::Value>>(3),
+                // Redshift has no json* functions, so we make and parse the same value struct
+                // from a text column instead.
+                PostgresVariant::Redshift => row
+                    .get::<usize, Option<&str>>(3)
+                    .and_then(|v| serde_json::from_str::<serde_json::Value>(v).ok()),
+            };
+
             let mut context =
                 ParseContext::new().with_unsupported_type_action(self.unsupported_type_action);
 
@@ -362,5 +377,68 @@ impl PostgresConnection {
     pub fn with_unsupported_type_action(mut self, action: UnsupportedTypeAction) -> Self {
         self.unsupported_type_action = action;
         self
+    }
+
+    pub async fn get_variant(&self) -> Result<PostgresVariant, super::Error> {
+        let row = self
+            .conn
+            .query_one("SELECT version()", &[])
+            .await
+            .map_err(|e| super::Error::UnableToGetSchema {
+                source: Box::new(e),
+            })?;
+
+        let version: String = row
+            .try_get(0)
+            .map_err(|e| super::Error::UnableToGetSchema {
+                source: Box::new(e),
+            })?;
+
+        let variant = if version.contains("Redshift") {
+            PostgresVariant::Redshift
+        } else {
+            PostgresVariant::Default
+        };
+
+        Ok(variant)
+    }
+
+    async fn query_variant_and_schema(
+        &self,
+        table_reference: &TableReference,
+    ) -> Result<(PostgresVariant, Vec<Row>), super::Error> {
+        let table_name = table_reference.table();
+        let schema_name = table_reference.schema().unwrap_or("public");
+
+        let variant = self.get_variant().await?;
+
+        let query = match variant {
+            PostgresVariant::Default => SCHEMA_QUERY,
+            PostgresVariant::Redshift => REDSHIFT_SCHEMA_QUERY,
+        };
+
+        let rows = self
+            .conn
+            .query(query, &[&schema_name, &table_name])
+            .await
+            .map_err(|e| {
+                if let Some(error_source) = e.source() {
+                    if let Some(pg_error) =
+                        error_source.downcast_ref::<tokio_postgres::error::DbError>()
+                    {
+                        if pg_error.code() == &tokio_postgres::error::SqlState::UNDEFINED_TABLE {
+                            return super::Error::UndefinedTable {
+                                source: Box::new(pg_error.clone()),
+                                table_name: table_reference.to_string(),
+                            };
+                        }
+                    }
+                }
+                super::Error::UnableToGetSchema {
+                    source: Box::new(e),
+                }
+            });
+
+        Ok((variant, rows?))
     }
 }

--- a/core/src/sql/db_connection_pool/dbconnection/postgresconn.rs
+++ b/core/src/sql/db_connection_pool/dbconnection/postgresconn.rs
@@ -112,32 +112,50 @@ ORDER BY a.attnum;
 ";
 
 // Redshift does not materialize datashare objects into the local `pg_catalog`
-// (pg_class/pg_attribute return zero rows for tables consumed from a datashare),
-// so we read column metadata from `svv_redshift_columns`, which covers both local
-// and datashare tables. The view exposes no type OIDs, so the array/enum/composite
-// `type_details` path is unavailable — that is acceptable because Redshift has no
-// PostgreSQL arrays/enums/composites (semi-structured data uses SUPER).
+// (pg_class/pg_attribute return zero rows for tables consumed from a datashare), and
+// `CREATE EXTERNAL TABLE` objects (Redshift Spectrum tables backed by external
+// catalogs such as AWS Glue / Hive Metastore) are not in `pg_catalog` either.
+//
+// `svv_all_columns` is AWS's unified view: a union of `svv_redshift_columns` (local +
+// datashare/shared columns) and the external columns from all external tables, so a
+// single query covers local, datashare, and external tables. The view exposes no type
+// OIDs, so the array/enum/composite `type_details` path is unavailable — that is
+// acceptable because Redshift has no PostgreSQL arrays/enums/composites (semi-structured
+// data uses SUPER).
 //
 // Notes:
-// - `data_type` is already a formatted type string (e.g. `character varying(256)`,
-//   `numeric(10,2)`), matching what `format_type` produced before.
-// - `is_nullable` is normalized to the literal `YES`/`NO` expected by `get_schema`.
-// - `database_name = current_database()` scopes to the connected database (which is
-//   the datashare consumer DB) so a schema/table that exists in multiple accessible
-//   databases doesn't yield duplicated columns.
+// - `data_type` is the bare type name (e.g. `numeric`, `character varying`), NOT a
+//   formatted string — precision/scale/length live in separate columns. We rebuild the
+//   `numeric(p,s)` form from `numeric_precision`/`numeric_scale` so decimals keep their
+//   real precision instead of falling back to the default; character lengths are dropped
+//   because they don't affect the resulting Arrow `Utf8`/`LargeUtf8`. For external
+//   columns `data_type` is the catalog-reported type, which may use simplified Hive type
+//   names (e.g. `string`, `int`, `double`) — these are resolved leniently by
+//   `pg_data_type_to_arrow_type` when the variant is Redshift.
+// - `is_nullable` is normalized to the literal `YES`/`NO` expected by `get_schema`. It
+//   can be an empty string ("no information", common for external columns), which we
+//   treat as nullable — only an explicit `no`/`false` maps to `NO`.
+// - `database_name = current_database()` scopes to the connected database (the datashare
+//   consumer DB) so a schema/table that exists in multiple accessible databases doesn't
+//   yield duplicated columns.
 const REDSHIFT_SCHEMA_QUERY: &str = r#"
 SELECT
     column_name,
-    data_type,
-    CASE WHEN lower(is_nullable) IN ('yes', 'true') THEN 'YES' ELSE 'NO' END AS is_nullable,
+    CASE
+        WHEN lower(data_type) IN ('numeric', 'decimal') AND numeric_precision IS NOT NULL
+            THEN data_type || '(' || numeric_precision::varchar || ',' || COALESCE(numeric_scale, 0)::varchar || ')'
+        ELSE data_type
+    END AS data_type,
+    CASE WHEN lower(is_nullable) IN ('no', 'false') THEN 'NO' ELSE 'YES' END AS is_nullable,
     CAST(NULL AS VARCHAR) AS type_details
-FROM svv_redshift_columns
+FROM svv_all_columns
 WHERE schema_name = $1
     AND table_name = $2
     AND database_name = current_database()
 ORDER BY ordinal_position;
 "#;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PostgresVariant {
     Default,
     Redshift,
@@ -156,13 +174,15 @@ FROM pg_tables
 WHERE schemaname = $1;
 ";
 
-// Like `REDSHIFT_SCHEMA_QUERY`, these read from the `svv_redshift_*` system views so
-// that schemas/tables consumed from a datashare (absent from the local `pg_catalog`)
-// are listed alongside the connected database's own schemas/tables. `current_database()`
+// Like `REDSHIFT_SCHEMA_QUERY`, these read from the unified `svv_all_*` system views so
+// that schemas/tables consumed from a datashare (absent from the local `pg_catalog`) and
+// external schemas/tables (Redshift Spectrum) are listed alongside the connected
+// database's own schemas/tables. `svv_all_schemas`/`svv_all_tables` are AWS's unions of
+// the `svv_redshift_*` views with the external schemas/tables. `current_database()`
 // scopes results to the connected (datashare consumer) database.
 const REDSHIFT_SCHEMAS_QUERY: &str = "
 SELECT schema_name
-FROM svv_redshift_schemas
+FROM svv_all_schemas
 WHERE database_name = current_database()
   AND schema_name NOT IN ('pg_catalog', 'information_schema')
   AND schema_name NOT LIKE 'pg_temp_%'
@@ -171,7 +191,7 @@ WHERE database_name = current_database()
 
 const REDSHIFT_TABLES_QUERY: &str = "
 SELECT table_name
-FROM svv_redshift_tables
+FROM svv_all_tables
 WHERE database_name = current_database()
   AND schema_name = $1;
 ";
@@ -334,7 +354,8 @@ impl<'a> AsyncDbConnection<PostgresPooledConnection, &'a (dyn ToSql + Sync)>
                 context = context.with_type_details(type_details);
             };
 
-            let Ok(arrow_type) = pg_data_type_to_arrow_type(&pg_type, &context) else {
+            let Ok(arrow_type) = pg_data_type_to_arrow_type(&pg_type, &context, Some(variant))
+            else {
                 handle_unsupported_type_error(
                     self.unsupported_type_action,
                     super::Error::UnsupportedDataType {

--- a/core/src/sql/db_connection_pool/postgrespool.rs
+++ b/core/src/sql/db_connection_pool/postgrespool.rs
@@ -149,6 +149,43 @@ impl ConnectionManager {
     }
 }
 
+/// Applies per-connection session configuration after a connection is established.
+///
+/// Redshift surfaces Spectrum complex external columns (`ARRAY`/`STRUCT`/`MAP`) and
+/// `SUPER` values as JSON text only when `json_serialization_enable` is on; otherwise
+/// selecting such a column errors server-side. `json_serialization_parse_nested_strings`
+/// additionally renders nested string fields that hold valid JSON inline (unescaped)
+/// rather than as escaped string literals, so the decoded values match their schema.
+///
+/// These parameters only exist on Redshift, so rather than spend a `SELECT version()`
+/// round-trip detecting the variant we apply them optimistically and treat vanilla
+/// PostgreSQL's "unrecognized configuration parameter" error (`SQLSTATE 42704`) as a
+/// no-op. The `SET`s run outside a transaction, so a failure leaves the connection
+/// usable.
+///
+/// See <https://docs.aws.amazon.com/redshift/latest/dg/r_json_serialization_enable.html>
+/// and <https://docs.aws.amazon.com/redshift/latest/dg/r_json_serialization_parse_nested_strings.html>.
+async fn configure_session(
+    client: &tokio_postgres::Client,
+) -> std::result::Result<(), ConnectionManagerError> {
+    if let Err(e) = client
+        .batch_execute(
+            "SET json_serialization_enable TO true; \
+             SET json_serialization_parse_nested_strings TO true;",
+        )
+        .await
+    {
+        // Vanilla PostgreSQL rejects these unknown parameters with `undefined_object`
+        // (42704); that just means "not Redshift", so ignore it. Anything else is real.
+        if e.code() == Some(&tokio_postgres::error::SqlState::UNDEFINED_OBJECT) {
+            return Ok(());
+        }
+        return Err(e.into());
+    }
+
+    Ok(())
+}
+
 impl bb8::ManageConnection for ConnectionManager {
     type Connection = tokio_postgres::Client;
     type Error = ConnectionManagerError;
@@ -170,6 +207,9 @@ impl bb8::ManageConnection for ConnectionManager {
                 tracing::debug!("postgres connection error: {e}");
             }
         });
+
+        configure_session(&client).await?;
+
         Ok(client)
     }
 

--- a/core/tests/postgres/mod.rs
+++ b/core/tests/postgres/mod.rs
@@ -198,6 +198,7 @@ async fn test_arrow_postgres_one_way(container_manager: &Mutex<ContainerManager>
     test_postgres_json_type(container_manager.port).await;
     test_postgres_jsonb_list_struct_with_projected_schema(container_manager.port).await;
     test_postgres_json_list_struct_with_projected_schema(container_manager.port).await;
+    test_postgres_composite_array_list_struct(container_manager.port).await;
     test_postgres_sort_limit(container_manager.port).await;
 }
 
@@ -643,6 +644,155 @@ async fn test_postgres_json_list_struct_projected(port: usize, sql_type: &str) {
     assert_eq!(ids.value(1), "u2");
     assert_eq!(emails.value(0), "one@example.com");
     assert_eq!(emails.value(1), "two@example.com");
+}
+
+/// Reads a native PostgreSQL array-of-composite column (`composite_type[]`) back as an
+/// Arrow `List<Struct>`, including the empty-array and NULL cases.
+async fn test_postgres_composite_array_list_struct(port: usize) {
+    let table_name = "composite_array_list_struct_values".to_string();
+
+    let create_type_stmt = "
+        CREATE TYPE line_item AS (
+            sku TEXT,
+            qty INT,
+            price DOUBLE PRECISION
+        );";
+    let create_table_stmt = format!(
+        "CREATE TABLE {table_name} (
+            id INT PRIMARY KEY,
+            items line_item[]
+        );"
+    );
+    let insert_table_stmt = format!(
+        "INSERT INTO {table_name} (id, items) VALUES
+            (1, ARRAY[ROW('a', 2, 9.99), ROW('b', 1, 4.50)]::line_item[]),
+            (2, ARRAY[]::line_item[]),
+            (3, NULL);"
+    );
+
+    let ctx = SessionContext::new();
+
+    let pool = common::get_postgres_connection_pool(port)
+        .await
+        .expect("Postgres connection pool should be created");
+
+    let db_conn = pool
+        .connect_direct()
+        .await
+        .expect("Connection should be established");
+
+    // The container is shared across the module (`#[fixture] #[once]`), so make setup
+    // idempotent: drop any artifacts left by a prior run before recreating them. The
+    // table must go first — it depends on the composite type.
+    let _ = db_conn
+        .conn
+        .execute(&format!("DROP TABLE IF EXISTS {table_name};"), &[])
+        .await
+        .expect("Existing table should be dropped");
+    let _ = db_conn
+        .conn
+        .execute("DROP TYPE IF EXISTS line_item;", &[])
+        .await
+        .expect("Existing composite type should be dropped");
+
+    let _ = db_conn
+        .conn
+        .execute(create_type_stmt, &[])
+        .await
+        .expect("Postgres composite type should be created");
+    let _ = db_conn
+        .conn
+        .execute(&create_table_stmt, &[])
+        .await
+        .expect("Postgres table should be created");
+    let _ = db_conn
+        .conn
+        .execute(&insert_table_stmt, &[])
+        .await
+        .expect("Postgres table data should be inserted");
+
+    let item_struct = DataType::Struct(
+        vec![
+            Field::new("sku", DataType::Utf8, true),
+            Field::new("qty", DataType::Int32, true),
+            Field::new("price", DataType::Float64, true),
+        ]
+        .into(),
+    );
+    let expected_items_type = DataType::List(Arc::new(Field::new("item", item_struct, true)));
+
+    // Register via `SqlTable::new` (no explicit schema) so `get_schema` auto-infers the
+    // composite array as List<Struct> from the catalog, exercising the schema SQL +
+    // `parse_array_type` composite-element path end to end.
+    let sqltable_pool: Arc<DynPostgresConnectionPool> = Arc::new(pool);
+    let table = SqlTable::new("postgres", &sqltable_pool, table_name.clone(), None)
+        .await
+        .expect("SqlTable should infer schema");
+
+    let inferred = table
+        .schema()
+        .field_with_name("items")
+        .expect("items field inferred")
+        .data_type()
+        .clone();
+    assert_eq!(
+        inferred, expected_items_type,
+        "composite array should auto-infer to List<Struct>"
+    );
+
+    ctx.register_table(table_name.as_str(), Arc::new(table))
+        .expect("Table should be registered");
+
+    let df = ctx
+        .sql(&format!("SELECT id, items FROM {table_name} ORDER BY id"))
+        .await
+        .expect("DataFrame should be created from query");
+
+    let record_batch = df.collect().await.expect("RecordBatch should be collected");
+    assert_eq!(record_batch.len(), 1);
+    assert_eq!(record_batch[0].num_rows(), 3);
+
+    let items_col = record_batch[0]
+        .column(1)
+        .as_any()
+        .downcast_ref::<ListArray>()
+        .expect("items should decode to ListArray");
+
+    // row 0: two structs, row 1: empty list (not null), row 2: NULL.
+    assert!(!items_col.is_null(0));
+    assert_eq!(items_col.value_length(0), 2);
+    assert!(!items_col.is_null(1));
+    assert_eq!(items_col.value_length(1), 0);
+    assert!(items_col.is_null(2));
+
+    let row_zero = items_col.value(0);
+    let structs = row_zero
+        .as_any()
+        .downcast_ref::<StructArray>()
+        .expect("list values should be StructArray");
+
+    let skus = structs
+        .column(0)
+        .as_any()
+        .downcast_ref::<StringArray>()
+        .expect("sku field should be StringArray");
+    let qtys = structs
+        .column(1)
+        .as_any()
+        .downcast_ref::<arrow::array::Int32Array>()
+        .expect("qty field should be Int32Array");
+    let prices = structs
+        .column(2)
+        .as_any()
+        .downcast_ref::<arrow::array::Float64Array>()
+        .expect("price field should be Float64Array");
+
+    assert_eq!(skus.value(0), "a");
+    assert_eq!(skus.value(1), "b");
+    assert_eq!(qtys.value(0), 2);
+    assert_eq!(qtys.value(1), 1);
+    assert!((prices.value(0) - 9.99).abs() < f64::EPSILON);
+    assert!((prices.value(1) - 4.50).abs() < f64::EPSILON);
 }
 
 async fn test_postgres_jsonb_list_struct_with_projected_schema(port: usize) {


### PR DESCRIPTION
## Description

* Cherry-picks a number of fixes for Postgres schema inference we have created on our fork:
  * https://github.com/spiceai/datafusion-table-providers/pull/18
  * https://github.com/spiceai/datafusion-table-providers/pull/20
  * https://github.com/spiceai/datafusion-table-providers/pull/21
* TL;DR:
  * Detects the Postgres version to apply a different schema inference method if we detect a connection is Redshift. This is because Redshift does not support certain Postgres functions used in the regular schema inference query - but also because `pg_class` is unpopulated for certain tables like `CREATE EXTERNAL` tables from Redshift Spectrum or tables shared via Redshift Datashare
  * Utilises the Redshift system table `svv_all_columns` to retrieve schema information about all Redshift table types (internal, external, datashare, etc).
  * Imports a Hive data type parser for Hive schema inference, as the `data_type` column in `svv_all_columns` returns the data type of the external type in the case of `CREATE EXTERNAL TABLE`. If this external table is backed by a Glue catalog, these types will be Hive data types - not Postgres ones.
  * Updates the Postgres connection to support reading arrays of structs for both native Postgres and Redshift.
  * Hive parser source originates from `spiceai/spiceai`: https://github.com/spiceai/spiceai/blob/trunk/crates/data_components/src/databricks/sql_warehouse/datatypes.rs