### PR TITLE
Upgrade sea-query to 1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -75,7 +75,7 @@ dependencies = [
  "regex",
  "toml",
  "windows-registry",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -220,7 +220,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -231,7 +231,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2763,7 +2763,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3707,17 +3707,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "inherent"
-version = "1.0.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c727f80bfa4a6c6e2508d2f05b6f4bfce242030bd88ed15ae5331c5b5d30fba7"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "insta"
 version = "1.47.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4551,7 +4540,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6088,7 +6077,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6147,7 +6136,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6239,13 +6228,13 @@ checksum = "c1257cd4248b4132760d6524d6dda4e053bc648c9070b960929bf50cfb1e7add"
 
 [[package]]
 name = "sea-query"
-version = "0.32.7"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a5d1c518eaf5eda38e5773f902b26ab6d5e9e9e2bb2349ca6c64cf96f80448c"
+checksum = "8d190cfb3bcceb8a8d7d04dee5a0c77f60c7627979cdcb47fdcb8934f009badf"
 dependencies = [
  "bigdecimal",
  "chrono",
- "inherent",
+ "itoa",
  "rust_decimal",
  "sea-query-derive",
  "time",
@@ -6253,9 +6242,9 @@ dependencies = [
 
 [[package]]
 name = "sea-query-derive"
-version = "0.4.3"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bae0cbad6ab996955664982739354128c58d16e126114fe88c2a493642502aab"
+checksum = "a0b0f466921cdd3cf4b89d5c3ac2173dba89a873ab395b123a645de181ec7537"
 dependencies = [
  "darling 0.20.11",
  "heck 0.4.1",
@@ -6562,7 +6551,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54254b8531cafa275c5e096f62d48c81435d1015405a91198ddb11e967301d40"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -6591,7 +6580,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6806,7 +6795,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7718,7 +7707,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -75,7 +75,7 @@ rand = { version = "0.9" }
 regex = { version = "1" }
 r2d2 = { version = "0.8", optional = true }
 rusqlite = { version = "0.37", optional = true }
-sea-query = { version = "0.32", features = [
+sea-query = { version = "1.0.0", features = [
   "backend-sqlite",
   "backend-postgres",
   "postgres-array",

--- a/core/src/sql/arrow_sql_gen/statement.rs
+++ b/core/src/sql/arrow_sql_gen/statement.rs
@@ -14,8 +14,9 @@ use num_bigint::BigInt;
 use sea_query::{
     Alias, ColumnDef, ColumnType, Expr, GenericBuilder, Index, InsertStatement, IntoIden,
     IntoIndexColumn, Keyword, MysqlQueryBuilder, OnConflict, PostgresQueryBuilder, Query,
-    QueryBuilder, SeaRc, SimpleExpr, SqliteQueryBuilder, Table, TableRef,
+    QueryBuilder, SimpleExpr, SqliteQueryBuilder, Table, TableRef,
 };
+use sea_query::{ExprTrait, IntoTableRef};
 use snafu::Snafu;
 use std::{str::FromStr, sync::Arc};
 use time::{OffsetDateTime, PrimitiveDateTime};
@@ -1020,7 +1021,7 @@ impl<'a> InsertBuilder<'a> {
                             let mut params_vec = Vec::new();
                             for param_value in &param_values {
                                 let mut params_str = String::new();
-                                query_builder.prepare_simple_expr(param_value, &mut params_str);
+                                query_builder.prepare_expr(param_value, &mut params_str);
                                 params_vec.push(params_str);
                             }
 
@@ -1116,24 +1117,17 @@ impl<'a> InsertBuilder<'a> {
     }
 }
 
-fn table_reference_to_sea_table_ref(table: &TableReference) -> TableRef {
+pub fn table_reference_to_sea_table_ref(table: &TableReference) -> TableRef {
     match table {
-        TableReference::Bare { table } => {
-            TableRef::Table(SeaRc::new(Alias::new(table.to_string())))
+        TableReference::Bare { table } => table.to_string().into_table_ref(),
+        TableReference::Partial { schema, table } => {
+            (schema.to_string(), table.to_string()).into_table_ref()
         }
-        TableReference::Partial { schema, table } => TableRef::SchemaTable(
-            SeaRc::new(Alias::new(schema.to_string())),
-            SeaRc::new(Alias::new(table.to_string())),
-        ),
         TableReference::Full {
             catalog,
             schema,
             table,
-        } => TableRef::DatabaseSchemaTable(
-            SeaRc::new(Alias::new(catalog.to_string())),
-            SeaRc::new(Alias::new(schema.to_string())),
-            SeaRc::new(Alias::new(table.to_string())),
-        ),
+        } => (catalog.to_string(), schema.to_string(), table.to_string()).into_table_ref(),
     }
 }
 

--- a/core/src/sqlite.rs
+++ b/core/src/sqlite.rs
@@ -1,4 +1,6 @@
-use crate::sql::arrow_sql_gen::statement::{CreateTableBuilder, IndexBuilder, InsertBuilder};
+use crate::sql::arrow_sql_gen::statement::{
+    table_reference_to_sea_table_ref, CreateTableBuilder, IndexBuilder, InsertBuilder,
+};
 use crate::sql::db_connection_pool::dbconnection::{self, get_schema, AsyncDbConnection};
 use crate::sql::db_connection_pool::sqlitepool::SqliteConnectionPoolFactory;
 use crate::sql::db_connection_pool::DbInstanceKey;
@@ -628,30 +630,12 @@ impl Sqlite {
 
         // Add ON CONFLICT clause if specified
         if let Some(oc) = on_conflict {
-            use sea_query::SeaRc;
-            use sea_query::{Alias, Query, SqliteQueryBuilder, TableRef};
+            use sea_query::{Alias, Query, SqliteQueryBuilder};
 
             let sea_query_on_conflict = oc.build_sea_query_on_conflict(&self.schema);
 
             // Build a temporary table reference for the dummy statement
-            let table_ref = match &self.table {
-                TableReference::Bare { table } => {
-                    TableRef::Table(SeaRc::new(Alias::new(table.to_string())))
-                }
-                TableReference::Partial { schema, table } => TableRef::SchemaTable(
-                    SeaRc::new(Alias::new(schema.to_string())),
-                    SeaRc::new(Alias::new(table.to_string())),
-                ),
-                TableReference::Full {
-                    catalog,
-                    schema,
-                    table,
-                } => TableRef::DatabaseSchemaTable(
-                    SeaRc::new(Alias::new(catalog.to_string())),
-                    SeaRc::new(Alias::new(schema.to_string())),
-                    SeaRc::new(Alias::new(table.to_string())),
-                ),
-            };
+            let table_ref = table_reference_to_sea_table_ref(&self.table);
 
             // Build a dummy insert statement to get the ON CONFLICT SQL
             let mut dummy_insert = Query::insert();


### PR DESCRIPTION
`sea-query` 1.0 exposes new features which are useful downstream. Also made `table_reference_to_sea_table_ref` public so it can be reused by `sqlite.rs`.