### PR TITLE
chore(deps): bump clickhouse 0.15.1, rand 0.10.1, cmov 0.5.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1185,9 +1185,9 @@ checksum = "93a719913643003b84bd13022b4b7e703c09342cd03b679c4641c7d2e50dc34d"
 
 [[package]]
 name = "clickhouse"
-version = "0.14.3"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bfb36e41b644dcd5be4ef54a3b7d2abc9bb07eda777ab3f90d1b0dbb97c940a"
+checksum = "d8063696febb0a10a6fb9df1460c52c509188f1d19da2157694ab3ca0feffc74"
 dependencies = [
  "bnum",
  "bstr",
@@ -1203,8 +1203,10 @@ dependencies = [
  "lz4_flex 0.11.6",
  "polonius-the-crab",
  "serde",
+ "serde_json",
  "thiserror 2.0.18",
  "tokio",
+ "tracing",
  "url",
 ]
 
@@ -1241,9 +1243,9 @@ dependencies = [
 
 [[package]]
 name = "cmov"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f88a43d011fc4a6876cb7344703e297c71dda42494fee094d5f7c76bf13f746"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
 
 [[package]]
 name = "colorchoice"
@@ -2522,7 +2524,7 @@ dependencies = [
  "prost",
  "r2d2",
  "r2d2_adbc",
- "rand 0.9.4",
+ "rand 0.10.1",
  "regex",
  "reqwest 0.13.2",
  "rstest",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -47,7 +47,7 @@ byteorder = "1.5"
 bytes = { version = "1.11", optional = true }
 byte-unit = { version = "5.2", optional = true }
 chrono = "0.4.44"
-clickhouse = { version = "0.14", optional = true }
+clickhouse = { version = "0.15", optional = true }
 dashmap = "6.1"
 libduckdb-sys = { version = "=1.4.4", optional = true }
 dyn-clone = { version = "1.0", optional = true }
@@ -71,7 +71,7 @@ odbc-api = { version = "24.1", optional = true }
 pem = { version = "3.0", optional = true }
 postgres-native-tls = { version = "0.5.0", optional = true }
 prost = { version = "=0.14.3", optional = true }
-rand = { version = "0.9" }
+rand = { version = "0.10" }
 regex = { version = "1" }
 r2d2 = { version = "0.8", optional = true }
 rusqlite = { version = "0.37", optional = true }
@@ -116,7 +116,7 @@ bollard = "0.20"
 geozero = { version = "0.15.1", features = ["with-wkb"] }
 insta = { version = "1.46.0", features = ["filters"] }
 prost = { version = "=0.14.3" }
-rand = "0.9"
+rand = "0.10"
 reqwest = "0.13"
 rstest = "0.26.1"
 test-log = { version = "0.2", features = ["trace"] }

--- a/core/src/sql/db_connection_pool/clickhousepool.rs
+++ b/core/src/sql/db_connection_pool/clickhousepool.rs
@@ -71,7 +71,7 @@ impl ClickHouseConnectionPool {
                 }
                 key if key.starts_with("option_") => {
                     let opt = &key["option_".len()..];
-                    client = client.with_option(opt, value);
+                    client = client.with_setting(opt, value);
                 }
                 key if key.starts_with("header_") => {
                     let header = &key["header_".len()..];

--- a/core/src/sql/db_connection_pool/duckdbpool.rs
+++ b/core/src/sql/db_connection_pool/duckdbpool.rs
@@ -385,7 +385,7 @@ fn extract_db_name(file_path: Arc<str>) -> Result<String> {
 
 #[cfg(test)]
 mod test {
-    use rand::Rng;
+    use rand::RngExt;
 
     use super::*;
     use crate::sql::db_connection_pool::DbConnectionPool;

--- a/core/src/sql/db_connection_pool/sqlitepool.rs
+++ b/core/src/sql/db_connection_pool/sqlitepool.rs
@@ -284,7 +284,7 @@ impl DbConnectionPool<Connection, &'static (dyn ToSql + Sync)> for SqliteConnect
 mod tests {
     use super::*;
     use crate::sql::db_connection_pool::Mode;
-    use rand::Rng;
+    use rand::RngExt;
     use rstest::rstest;
     use std::time::Duration;
 

--- a/core/tests/integration.rs
+++ b/core/tests/integration.rs
@@ -1,4 +1,4 @@
-use rand::Rng;
+use rand::RngExt;
 
 #[cfg(feature = "adbc")]
 mod adbc;


### PR DESCRIPTION
Consolidated dependency bumps with the code changes their new majors require. Prepares the `v0.11.2` release.

## Changes
- **clickhouse 0.14 → 0.15.1**: `Client::with_option` is deprecated in favor of `with_setting` (identical signature); updated the one call site in `clickhousepool.rs`.
- **rand 0.9 → 0.10.1**: `random_range` moved from `Rng` to the new `RngExt` trait; updated the imports in `sqlitepool.rs`, `duckdbpool.rs`, and `integration.rs`.
- **cmov 0.5.3 → 0.5.4**: transitive, lockfile only.

## Supersedes
Rolls up and unblocks the following Dependabot PRs (which fail CI on their own because they bump the dep without the required code change):
- #667 (clickhouse 0.15.1)
- #610 (rand 0.10.1)
- #677 (cmov 0.5.4, which also bundled rand 0.10.1)

Dependabot will auto-close these once this merges.

## Validation
- `cargo test --no-run --lib` with the full CI feature set (`clickhouse-federation,duckdb-federation,flight,mysql-federation,postgres-federation,sqlite-federation,adbc-federation`) compiles cleanly.
- Verified `with_setting` and `RngExt::random_range` signatures against the 0.15.1 / 0.10.1 crate sources.

https://claude.ai/code/session_01VsTjutiDfiGhEB9bmkenV5