### PR TITLE
chore(deps): upgrade odbc-api 28.2 + arrow-odbc 25.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -75,7 +75,7 @@ dependencies = [
  "regex",
  "toml",
  "windows-registry",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -220,7 +220,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -231,7 +231,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -396,7 +396,7 @@ dependencies = [
  "arrow-ord",
  "arrow-schema",
  "arrow-select",
- "atoi",
+ "atoi 2.0.0",
  "base64",
  "chrono",
  "comfy-table",
@@ -504,12 +504,12 @@ dependencies = [
 
 [[package]]
 name = "arrow-odbc"
-version = "23.1.0"
+version = "25.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4b0a7cccf7bc759fd0d51121d66c497035f9bd1a5ef1dda85ec8365363920f5"
+checksum = "d45b83b76a9a49115106a600f88c90bc484b0b4ccdb231dddb7e72afc64443f1"
 dependencies = [
  "arrow",
- "atoi",
+ "atoi 3.1.0",
  "chrono",
  "encoding_rs",
  "log",
@@ -670,6 +670,15 @@ name = "atoi"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f28d99ec8bfea296261ca1af174f24225171fea9664ba9003cbebee704810528"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "atoi"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7a8bbe9949e43a1edaa043038c68703b04774156afdfb62ba2cef5bf93d67be"
 dependencies = [
  "num-traits",
 ]
@@ -2677,7 +2686,7 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab8ecd87370524b461f8557c119c405552c396ed91fc0a8eec68679eab26f94a"
 dependencies = [
- "libloading 0.8.9",
+ "libloading 0.7.4",
 ]
 
 [[package]]
@@ -2765,7 +2774,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4102,9 +4111,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "logos"
@@ -4542,7 +4551,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4920,11 +4929,11 @@ dependencies = [
 
 [[package]]
 name = "odbc-api"
-version = "24.1.1"
+version = "28.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f04f75fb2176707bce6c9180bf722346005d26df377471672e65fcb63252bf6c"
+checksum = "c81fc7467324b7a4dfcce514d18439f95ec6acec1adcae113f7b72c34b1dc1d8"
 dependencies = [
- "atoi",
+ "atoi 3.1.0",
  "log",
  "odbc-sys",
  "thiserror 2.0.18",
@@ -6079,7 +6088,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6138,7 +6147,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6553,7 +6562,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54254b8531cafa275c5e096f62d48c81435d1015405a91198ddb11e967301d40"
 dependencies = [
- "heck 0.5.0",
+ "heck 0.4.1",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -6582,7 +6591,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6797,7 +6806,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7709,7 +7718,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ arrow-flight = { version = "58.0", features = [
 arrow-ipc = { version = "58.0" }
 arrow-schema = { version = "58.0", features = ["serde"] }
 arrow-json = "58.0"
-arrow-odbc = { version = "23.1" }
+arrow-odbc = { version = "25.2" }
 datafusion = { version = "53.0", default-features = false }
 datafusion-expr = { version = "53.0" }
 datafusion-federation = { version = "0.5.3" }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -67,7 +67,7 @@ mysql_async = { version = "0.36", features = [
 native-tls = { version = "0.2", optional = true }
 num-bigint = "0.4"
 num-traits = { version = "0.2", optional = true }
-odbc-api = { version = "24.1", optional = true }
+odbc-api = { version = "28.2", optional = true }
 pem = { version = "3.0", optional = true }
 postgres-native-tls = { version = "0.5.0", optional = true }
 prost = { version = "=0.14.3", optional = true }


### PR DESCRIPTION
`odbc-api` and `arrow-odbc` are coupled — `arrow-odbc` re-exports `odbc_api` types in its public API, so the two must be upgraded together.

Dependabot #668 bumped `odbc-api` 24 → 28 on its own, which fails to compile because `arrow-odbc` 23.1 caps `odbc-api` at `<25`, producing two incompatible `odbc_api` versions in the tree (the `Cursor` / `ResultSetMetadata` trait-bound errors).

## Changes
- `arrow-odbc` 23.1 → **25.2.0** (supports `odbc-api >=27, <29`)
- `odbc-api` 24.1 → **28.2.0**

Both now resolve to a single `odbc-api` 28.2 in the lockfile. **No source changes were required** — the APIs we use (`odbcpool.rs`, `odbcconn.rs`) are source-compatible across the bump.

## Validation
Built locally against a real unixODBC install:
- `cargo clippy --no-default-features --features odbc -- -D warnings` — clean
- `cargo clippy --all-features -- -D warnings` — clean (full workspace)

Closes #668.