### PR TITLE
feat(postgres): thread libpq `options` connection param onto the Config

### DIFF
--- a/core/src/sql/db_connection_pool/postgrespool.rs
+++ b/core/src/sql/db_connection_pool/postgrespool.rs
@@ -351,10 +351,7 @@ impl PostgresConnectionPool {
         let mut config =
             Config::from_str(connection_string.as_str()).context(ConnectionPoolSnafu)?;
 
-        if let Some(application_name) = params.get("application_name").map(SecretBox::expose_secret)
-        {
-            config.application_name(application_name);
-        }
+        apply_optional_session_params(&mut config, &params);
 
         verify_postgres_config(&config).await?;
 
@@ -494,6 +491,24 @@ fn parse_connection_string(
     }
 
     (connection_string, ssl_mode, ssl_rootcert_path, password)
+}
+
+/// Apply the optional string session params libpq forwards verbatim to the
+/// backend — `application_name` and `options` — onto a parsed [`Config`]. Split
+/// out of `new_inner` so it is unit-testable without a live server.
+///
+/// `options` is the libpq `options` connection parameter: arbitrary command-line
+/// switches sent at connection time (e.g. `-c statement_timeout=5000`), applied via
+/// [`Config::options`]. It lets a caller pin session-level GUCs
+/// (`statement_timeout`, `default_transaction_read_only`, …) that `Config` has no
+/// dedicated setter for.
+fn apply_optional_session_params(config: &mut Config, params: &HashMap<String, SecretString>) {
+    if let Some(application_name) = params.get("application_name").map(SecretBox::expose_secret) {
+        config.application_name(application_name);
+    }
+    if let Some(options) = params.get("options").map(SecretBox::expose_secret) {
+        config.options(options);
+    }
 }
 
 fn get_join_context(config: &Config) -> JoinPushDown {
@@ -703,5 +718,35 @@ mod tests {
             parse_connection_string("host=localhost user=postgres dbname=mydb");
         assert_eq!(conn_str.trim(), "host=localhost user=postgres dbname=mydb");
         assert!(password.is_none());
+    }
+
+    #[test]
+    fn options_param_reaches_the_config() {
+        let mut params: HashMap<String, SecretString> = HashMap::new();
+        params.insert(
+            "options".to_string(),
+            SecretString::from("-c statement_timeout=5000".to_string()),
+        );
+        params.insert(
+            "application_name".to_string(),
+            SecretString::from("semvia".to_string()),
+        );
+
+        let mut config = Config::new();
+        apply_optional_session_params(&mut config, &params);
+
+        assert_eq!(config.get_options(), Some("-c statement_timeout=5000"));
+        assert_eq!(config.get_application_name(), Some("semvia"));
+    }
+
+    #[test]
+    fn absent_options_param_leaves_the_config_untouched() {
+        let params: HashMap<String, SecretString> = HashMap::new();
+
+        let mut config = Config::new();
+        apply_optional_session_params(&mut config, &params);
+
+        assert_eq!(config.get_options(), None);
+        assert_eq!(config.get_application_name(), None);
     }
 }


### PR DESCRIPTION
## What

`PostgresConnectionPool::new` already threads a `application_name` connection
param onto the `tokio_postgres::Config`. This adds the same treatment for the
libpq `options` param, so a caller can pass e.g.
`options = "-c statement_timeout=5000"` and have it reach the server as a
per-session `SET`.

Both params are now applied by one small helper,
`apply_optional_session_params`, keeping `new_inner` tidy:

```rust
fn apply_optional_session_params(config: &mut Config, params: &HashMap<String, SecretString>) {
    if let Some(application_name) = params.get("application_name").map(SecretBox::expose_secret) {
        config.application_name(application_name);
    }
    if let Some(options) = params.get("options").map(SecretBox::expose_secret) {
        config.options(options);
    }
}
```

## Why

`options` is the standard libpq escape hatch for per-connection server
settings (`statement_timeout`, `lock_timeout`, `search_path`, …). Surfacing it
lets a governance layer bound query execution time at the source without a
custom pool wrapper. `application_name` was already special-cased; this widens
that path by exactly one well-understood param rather than adding a bespoke
knob.

## Tests

Two unit tests over the pure config assembly (no live server needed):

- `options_param_reaches_the_config` — asserts `config.get_options()` and
  `config.get_application_name()` reflect the params.
- `absent_options_param_leaves_the_config_untouched` — asserts the default
  (`None`) is preserved when the param is absent.

Run with:

```bash
cargo test --no-default-features --features postgres-federation --lib postgrespool
```
