### PR TITLE
Speed up Python CI tests

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -216,8 +216,9 @@ jobs:
       - name: Install ODBC, Sqlite and Roapi
         run: |
           sudo apt-get install -y unixodbc-dev libsqliteodbc libsqlite3-dev
+          # 0.13.0 musl release panics on HTTP UI route registration; 0.12.7 is fine.
           curl -fsSL -o /tmp/roapi.tar.gz \
-            https://github.com/roapi/roapi/releases/download/roapi-v0.13.0/roapi-x86_64-unknown-linux-musl.tar.gz
+            https://github.com/roapi/roapi/releases/download/roapi-v0.12.7/roapi-x86_64-unknown-linux-musl.tar.gz
           sudo tar -xzf /tmp/roapi.tar.gz -C /usr/local/bin roapi
           sudo chmod +x /usr/local/bin/roapi
           roapi --help >/dev/null

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -205,26 +205,26 @@ jobs:
 
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: |
-            .
-            python
 
       - uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
-          cache-dependency-glob: 'python/pyproject.toml'
+          cache-dependency-glob: |
+            python/pyproject.toml
+            python/uv.lock
 
       - name: Install ODBC, Sqlite and Roapi
         run: |
-          sudo apt-get install -y unixodbc-dev libsqliteodbc
-          sudo apt-get install -y libsqlite3-dev
-          RUSTUP_TOOLCHAIN=stable cargo install --git https://github.com/roapi/roapi --branch main --bins roapi
+          sudo apt-get install -y unixodbc-dev libsqliteodbc libsqlite3-dev
+          curl -fsSL -o /tmp/roapi.tar.gz \
+            https://github.com/roapi/roapi/releases/download/roapi-v0.13.0/roapi-x86_64-unknown-linux-musl.tar.gz
+          sudo tar -xzf /tmp/roapi.tar.gz -C /usr/local/bin roapi
+          sudo chmod +x /usr/local/bin/roapi
+          roapi --help >/dev/null
 
       - name: Build Python package and run tests
+        working-directory: python
         run: |
-          cd python
-          uv sync --dev --no-install-package datafusion
-          uv run --no-project maturin develop --uv --release
-          cd python/tests
-          uv run --no-project pytest -v .
+          uv sync --dev --no-install-project --no-install-package datafusion
+          uv run --no-project maturin develop --uv
+          uv run --no-project pytest -v python/tests

--- a/python/.gitignore
+++ b/python/.gitignore
@@ -24,3 +24,6 @@ dist
 venv
 .venv
 
+# Generated test fixtures
+python/tests/fixtures/
+

--- a/python/python/tests/test_flight.py
+++ b/python/python/tests/test_flight.py
@@ -1,54 +1,103 @@
 from datafusion import SessionContext
 from datafusion_table_providers import flight
 import pytest
+import pyarrow as pa
+import pyarrow.parquet as pq
+import socket
 import subprocess
 import time
+from pathlib import Path
 
 
-class TestFlightIntegration:     
+def _wait_for_port(host: str, port: int, timeout_secs: float = 30.0) -> None:
+    deadline = time.monotonic() + timeout_secs
+    while time.monotonic() < deadline:
+        try:
+            with socket.create_connection((host, port), timeout=1.0):
+                return
+        except OSError:
+            time.sleep(0.25)
+    raise TimeoutError(f"Timed out waiting for {host}:{port}")
+
+
+class TestFlightIntegration:
     @classmethod
-    def setup_class(self):
+    def setup_class(cls):
         """Called once before all test methods in the class"""
-        self.ctx = SessionContext()
-        self.pool = flight.FlightTableFactory()
-        self.process = subprocess.Popen(
-            ["roapi", "-t", "taxi=https://d37ci6vzurychx.cloudfront.net/trip-data/yellow_tripdata_2024-01.parquet"],
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE
-        )
-        # 20s timeout is required to ensure the server is running and data is loaded
-        # The timeout is determined by empirical testing
-        time.sleep(20)
+        cls.ctx = SessionContext()
+        cls.pool = flight.FlightTableFactory()
 
-    @classmethod 
-    def teardown_class(self):
+        # Small local fixture — avoids downloading a multi-GB NYC taxi parquet in CI.
+        fixture_dir = Path(__file__).resolve().parent / "fixtures"
+        fixture_dir.mkdir(exist_ok=True)
+        cls.parquet_path = fixture_dir / "taxi_sample.parquet"
+        # Distinct group sizes so ORDER BY COUNT(*) DESC is deterministic.
+        table = pa.table(
+            {
+                "VendorID": pa.array([2, 2, 2, 1, 1, 6], type=pa.int32()),
+                "passenger_count": pa.array(
+                    [1, 2, 1, 1, None, None], type=pa.float64()
+                ),
+                "total_amount": pa.array(
+                    [10.5, 20.0, 15.0, 5.0, 7.25, 100.03], type=pa.float64()
+                ),
+            }
+        )
+        pq.write_table(table, cls.parquet_path)
+
+        cls.process = subprocess.Popen(
+            ["roapi", "-t", f"taxi={cls.parquet_path}"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        try:
+            _wait_for_port("127.0.0.1", 32010)
+            # Brief settle time for Flight SQL registration after the port opens.
+            time.sleep(1)
+        except Exception:
+            cls.process.kill()
+            stdout, stderr = cls.process.communicate(timeout=5)
+            raise RuntimeError(
+                "roapi failed to become ready.\n"
+                f"stdout:\n{stdout.decode(errors='replace')}\n"
+                f"stderr:\n{stderr.decode(errors='replace')}"
+            ) from None
+
+    @classmethod
+    def teardown_class(cls):
         """Called once after all test methods in the class"""
-        self.process.kill()
+        cls.process.kill()
+        cls.process.wait(timeout=5)
 
     def test_query_companies(self):
         """Test querying companies table with SQL"""
         print("Running test_query_companies")
         table_name = "taxi_flight_table"
-        self.ctx.register_table_provider(table_name, self.pool.get_table("http://localhost:32010", {
-            "flight.sql.query": "SELECT * FROM taxi"
-        }))
-        df = self.ctx.sql(f"""
+        self.ctx.register_table_provider(
+            table_name,
+            self.pool.get_table(
+                "http://localhost:32010",
+                {"flight.sql.query": "SELECT * FROM taxi"},
+            ),
+        )
+        df = self.ctx.sql(
+            f"""
             SELECT "VendorID", COUNT(*) as count, SUM(passenger_count) as passenger_counts, SUM(total_amount) as total_amounts
                 FROM {table_name}
                 GROUP BY "VendorID"
                 ORDER BY COUNT(*) DESC
-            """)
+            """
+        )
         result = df.collect()
-        
-        # Verify the results
-        vendor_ids = result[0]['VendorID'].tolist()
+
+        vendor_ids = result[0]["VendorID"].tolist()
         assert vendor_ids == [2, 1, 6]
-        
-        counts = result[0]['count'].tolist()
-        assert counts == [2234632, 729732, 260]
-        
-        passenger_counts = result[0]['passenger_counts'].tolist()
-        assert passenger_counts == [2971865, 810883, None]
-        
-        total_amounts = result[0]['total_amounts'].tolist()
-        assert total_amounts == pytest.approx([60602721.27, 18841261.98, 12401.03])
+
+        counts = result[0]["count"].tolist()
+        assert counts == [3, 2, 1]
+
+        passenger_counts = result[0]["passenger_counts"].tolist()
+        assert passenger_counts == [4.0, 1.0, None]
+
+        total_amounts = result[0]["total_amounts"].tolist()
+        assert total_amounts == pytest.approx([45.5, 12.25, 100.03])

--- a/python/python/tests/test_flight.py
+++ b/python/python/tests/test_flight.py
@@ -46,7 +46,17 @@ class TestFlightIntegration:
         pq.write_table(table, cls.parquet_path)
 
         cls.process = subprocess.Popen(
-            ["roapi", "-t", f"taxi={cls.parquet_path}"],
+            [
+                "roapi",
+                "-t",
+                f"taxi={cls.parquet_path}",
+                "--addr-http",
+                "127.0.0.1:18080",
+                "--addr-postgres",
+                "127.0.0.1:15432",
+                "--addr-flight-sql",
+                "127.0.0.1:32010",
+            ],
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
         )

--- a/python/python/tests/test_odbc.py
+++ b/python/python/tests/test_odbc.py
@@ -7,7 +7,20 @@ class TestOdbcIntegration:
     def setup_method(self):
         """Set up the test environment"""
         self.ctx = SessionContext()
-        connection_param: dict = {'connection_string': 'driver=SQLite3;database=../../../core/examples/sqlite_example.db;'}
+        db_path = os.path.abspath(
+            os.path.join(
+                os.path.dirname(__file__),
+                "..",
+                "..",
+                "..",
+                "core",
+                "examples",
+                "sqlite_example.db",
+            )
+        )
+        connection_param: dict = {
+            "connection_string": f"driver=SQLite3;database={db_path};"
+        }
         self.pool = odbc.ODBCTableFactory(connection_param)
         
     def test_query_companies(self):


### PR DESCRIPTION
## Summary
- Install prebuilt Roapi from GitHub releases instead of compiling from source (~19 min saved)
- Avoid double-building the Python extension: `uv sync --no-install-project` + single debug `maturin develop` (drops the ~33 min sync build and ~15 min release rebuild)
- Replace the remote NYC taxi parquet Flight fixture with a small local sample and port readiness polling

## Test plan
- [ ] Confirm `Python Tests` job passes in CI
- [ ] Compare step timings vs prior ~71 min baseline (Roapi install, build, pytest)