### PR TITLE
Replace DuckDB fork with official crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1198,10 +1198,11 @@ dependencies = [
 
 [[package]]
 name = "comfy-table"
-version = "7.2.2"
+version = "7.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "958c5d6ecf1f214b4c2bbbbf6ab9523a864bd136dcf71a7e8904799acfe1ad47"
+checksum = "4a65ebfec4fb190b6f90e944a817d60499ee0744e582530e2c9900a22e591d9a"
 dependencies = [
+ "crossterm",
  "unicode-segmentation",
  "unicode-width",
 ]
@@ -1418,6 +1419,28 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crossterm"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
+dependencies = [
+ "bitflags 2.11.1",
+ "crossterm_winapi",
+ "parking_lot",
+ "rustix 0.38.44",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "crunchy"
@@ -2445,6 +2468,7 @@ dependencies = [
  "datafusion-table-providers-odbc",
  "datafusion-table-providers-postgres",
  "datafusion-table-providers-sqlite",
+ "duckdb",
  "futures",
  "geozero",
  "insta",
@@ -2461,7 +2485,6 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.11.0",
- "spiceai_duckdb_fork",
  "tempfile",
  "test-log",
  "tokio",
@@ -2564,6 +2587,7 @@ dependencies = [
  "datafusion",
  "datafusion-federation",
  "datafusion-table-providers-common",
+ "duckdb",
  "dyn-clone",
  "futures",
  "itertools 0.15.0",
@@ -2572,7 +2596,6 @@ dependencies = [
  "sea-query",
  "secrecy",
  "snafu",
- "spiceai_duckdb_fork",
  "tokio",
  "tracing",
  "uuid",
@@ -2715,8 +2738,8 @@ dependencies = [
  "datafusion-ffi",
  "datafusion-python",
  "datafusion-table-providers",
+ "duckdb",
  "pyo3",
- "spiceai_duckdb_fork",
  "tokio",
 ]
 
@@ -2862,6 +2885,25 @@ name = "dpi"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b14ccef22fc6f5a8f4d7d768562a182c04ce9a3b3157b91390b52ddfdf1a76"
+
+[[package]]
+name = "duckdb"
+version = "1.10505.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "970e05eedd3f55c435194d9104f90a9b4a79a80d6e73251bc9ff43e178130c4e"
+dependencies = [
+ "arrow",
+ "cast",
+ "comfy-table",
+ "fallible-iterator 0.3.0",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libduckdb-sys",
+ "num",
+ "num-integer",
+ "r2d2",
+ "strum",
+]
 
 [[package]]
 name = "dunce"
@@ -3598,7 +3640,6 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots",
 ]
 
 [[package]]
@@ -4086,17 +4127,17 @@ checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
 
 [[package]]
 name = "libduckdb-sys"
-version = "1.4.4"
+version = "1.10505.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d78bacb8933586cee3b550c39b610d314f9b7a48701ac7a914a046165a4ad8da"
+checksum = "6cb514dab5e271e849235c1cb98bd65a2ae107fbd619a6740219319c54a71d95"
 dependencies = [
  "cc",
  "flate2",
  "pkg-config",
- "reqwest 0.12.28",
  "serde",
  "serde_json",
  "tar",
+ "ureq",
  "vcpkg",
  "zip",
 ]
@@ -5972,7 +6013,6 @@ checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64 0.22.1",
  "bytes",
- "futures-channel",
  "futures-core",
  "futures-util",
  "h2",
@@ -6005,7 +6045,6 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
- "webpki-roots",
 ]
 
 [[package]]
@@ -6737,25 +6776,6 @@ checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "spiceai_duckdb_fork"
-version = "1.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6ca1d977d7999f72cbaa9246256e3b0e01e3ae17bd7be70935d1848b335adfa"
-dependencies = [
- "arrow",
- "cast",
- "fallible-iterator 0.3.0",
- "fallible-streaming-iterator",
- "hashlink",
- "libduckdb-sys",
- "num",
- "num-integer",
- "r2d2",
- "rust_decimal",
- "strum",
 ]
 
 [[package]]
@@ -7592,6 +7612,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
+name = "ureq"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
+dependencies = [
+ "base64 0.22.1",
+ "log",
+ "percent-encoding",
+ "rustls",
+ "rustls-pki-types",
+ "ureq-proto",
+ "utf8-zero",
+ "webpki-roots",
+]
+
+[[package]]
+name = "ureq-proto"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c"
+dependencies = [
+ "base64 0.22.1",
+ "http",
+ "httparse",
+ "log",
+]
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7608,6 +7656,12 @@ name = "utf8-width"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1292c0d970b54115d14f2492fe0170adf21d68a1de108eebc51c1df4f346a091"
+
+[[package]]
+name = "utf8-zero"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e"
 
 [[package]]
 name = "utf8_iter"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,6 @@ datafusion-table-providers-sqlite = { version = "0.13.0", path = "crates/sqlite"
 datafusion-table-providers-postgres = { version = "0.13.0", path = "crates/postgres" }
 datafusion-table-providers-duckdb = { version = "0.13.0", path = "crates/duckdb" }
 datafusion-table-providers-adbc = { version = "0.13.0", path = "crates/adbc" }
-duckdb = { version = "=1.4.4", package = "spiceai_duckdb_fork" } # Forked to add support for duckdb_scan_arrow, pending: https://github.com/duckdb/duckdb-rs/pull/488
+duckdb = { version = "=1.10505.0" }
 adbc_core = { version = "0.24" }
 adbc_driver_manager = { version = "0.24" }

--- a/Makefile
+++ b/Makefile
@@ -11,4 +11,4 @@ lint:
 
 .PHONY: test-integration
 test-integration:
-	RUST_LOG=$${RUST_LOG:-info} cargo test -p datafusion-table-providers --test integration --no-default-features --features postgres,sqlite,mysql,flight,clickhouse,adbc -- --nocapture
+	RUST_LOG=$${RUST_LOG:-info} cargo test -p datafusion-table-providers --test integration --no-default-features --features postgres,sqlite,mysql,flight,clickhouse,duckdb,adbc -- --nocapture

--- a/core/tests/duckdb/mod.rs
+++ b/core/tests/duckdb/mod.rs
@@ -35,6 +35,7 @@ async fn arrow_duckdb_round_trip(
         constraints: Constraints::default(),
         column_defaults: HashMap::new(),
         temporary: false,
+        or_replace: false,
     };
     let table_provider = factory
         .create(&ctx.state(), &cmd)
@@ -119,6 +120,82 @@ async fn test_arrow_duckdb_roundtrip(
         &format!("{table_name}_types"),
     )
     .await;
+}
+
+#[test_log::test(tokio::test)]
+async fn test_multi_batch_append() {
+    use datafusion::arrow::array::Int32Array;
+    use datafusion::arrow::datatypes::{DataType, Field, Schema};
+
+    let schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)]));
+    let batches = vec![
+        RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![Arc::new(Int32Array::from(vec![1, 2, 3]))],
+        )
+        .expect("first record batch"),
+        RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![Arc::new(Int32Array::from(vec![4, 5, 6]))],
+        )
+        .expect("second record batch"),
+    ];
+
+    let factory = DuckDBTableProviderFactory::new(duckdb::AccessMode::ReadWrite);
+    let ctx = SessionContext::new();
+    let cmd = CreateExternalTable {
+        schema: Arc::new(Arc::clone(&schema).to_dfschema().expect("to df schema")),
+        name: "multi_batch_append".into(),
+        location: String::new(),
+        file_type: String::new(),
+        table_partition_cols: vec![],
+        if_not_exists: false,
+        definition: None,
+        order_exprs: vec![],
+        unbounded: false,
+        options: HashMap::new(),
+        constraints: Constraints::default(),
+        column_defaults: HashMap::new(),
+        temporary: false,
+        or_replace: false,
+    };
+    let table_provider = factory
+        .create(&ctx.state(), &cmd)
+        .await
+        .expect("table provider created");
+
+    let mem_exec = MemorySourceConfig::try_new_exec(&[batches], Arc::clone(&schema), None)
+        .expect("memory exec created");
+    let insert_plan = table_provider
+        .insert_into(&ctx.state(), mem_exec, InsertOp::Append)
+        .await
+        .expect("insert plan created");
+    collect(insert_plan, ctx.task_ctx())
+        .await
+        .expect("insert done");
+
+    ctx.register_table("multi_batch_append", table_provider)
+        .expect("table registered");
+    let result = ctx
+        .sql("SELECT id FROM multi_batch_append ORDER BY id")
+        .await
+        .expect("query created")
+        .collect()
+        .await
+        .expect("query completed");
+    let values: Vec<i32> = result
+        .iter()
+        .flat_map(|batch| {
+            let column = batch
+                .column(0)
+                .as_any()
+                .downcast_ref::<Int32Array>()
+                .expect("Int32 result column");
+            (0..column.len()).map(|index| column.value(index))
+        })
+        .collect();
+
+    assert_eq!(values, vec![1, 2, 3, 4, 5, 6]);
 }
 
 mod sort_limit_pushdown {

--- a/crates/duckdb/src/conn.rs
+++ b/crates/duckdb/src/conn.rs
@@ -465,8 +465,6 @@ impl SyncDbConnection<r2d2::PooledConnection<DuckdbConnectionManager>, DuckDBPar
 
         let sql = sql.to_string();
 
-        let cloned_schema = schema.clone();
-
         let create_stream = || -> Result<SendableRecordBatchStream> {
             let join_handle = tokio::task::spawn_blocking(move || {
                 let mut stmt = conn.prepare(&sql).context(DuckDBQuerySnafu)?;
@@ -474,9 +472,8 @@ impl SyncDbConnection<r2d2::PooledConnection<DuckdbConnectionManager>, DuckDBPar
                     .iter()
                     .map(|f| f.as_input_parameter())
                     .collect::<Vec<_>>();
-                let result: duckdb::ArrowStream<'_> = stmt
-                    .stream_arrow(params, cloned_schema)
-                    .context(DuckDBQuerySnafu)?;
+                let result: duckdb::ArrowStream<'_> =
+                    stmt.stream_arrow(params).context(DuckDBQuerySnafu)?;
                 for i in result {
                     blocking_channel_send(&batch_tx, i)?;
                 }

--- a/crates/duckdb/src/creator.rs
+++ b/crates/duckdb/src/creator.rs
@@ -1,16 +1,12 @@
 use crate::conn::DuckDbConnection;
 use crate::pool::DuckDbConnectionPool;
-use arrow::{
-    array::{RecordBatch, RecordBatchIterator, RecordBatchReader},
-    datatypes::SchemaRef,
-    ffi_stream::FFI_ArrowArrayStream,
-};
+use arrow::{array::RecordBatch, datatypes::SchemaRef};
 use datafusion::common::utils::quote_identifier;
 use datafusion::common::Constraints;
 use datafusion::sql::TableReference;
 use datafusion_table_providers_common::sql::arrow_sql_gen::statement::IndexBuilder;
 use datafusion_table_providers_common::util::on_conflict::OnConflict;
-use duckdb::Transaction;
+use duckdb::{vtab::arrow::arrow_recordbatch_to_query_params, Transaction};
 use itertools::Itertools;
 use snafu::prelude::*;
 use std::collections::HashSet;
@@ -23,7 +19,7 @@ use datafusion_table_providers_common::util::{
     indexes::IndexType,
 };
 
-/// A newtype for a relation name, to better control the inputs for the `TableDefinition`, `TableCreator`, and `ViewCreator`.
+/// A newtype for a relation name, to better control the inputs for the `TableDefinition` and `TableCreator`.
 #[derive(Debug, Clone, PartialEq)]
 pub struct RelationName(String);
 
@@ -397,24 +393,13 @@ impl TableManager {
             .transaction()
             .context(super::UnableToBeginTransactionSnafu)?;
         let table_name = self.table_name();
-        let record_batch_reader =
-            create_empty_record_batch_reader(Arc::clone(&self.table_definition.schema));
-        let stream = FFI_ArrowArrayStream::new(Box::new(record_batch_reader));
-
-        let current_ts = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .context(super::UnableToGetSystemTimeSnafu)?
-            .as_millis();
-
-        let view_name = format!("__scan_{}_{current_ts}", table_name);
-        tx.register_arrow_scan_view(&view_name, &stream)
-            .context(super::UnableToRegisterArrowScanViewForTableCreationSnafu)?;
-
+        let empty_batch = RecordBatch::new_empty(Arc::clone(&self.table_definition.schema));
+        let params = arrow_recordbatch_to_query_params(empty_batch);
         let sql =
-            format!(r#"CREATE TABLE IF NOT EXISTS "{table_name}" AS SELECT * FROM "{view_name}""#,);
+            format!(r#"CREATE TABLE IF NOT EXISTS "{table_name}" AS SELECT * FROM arrow(?, ?)"#,);
         tracing::debug!("{sql}");
 
-        tx.execute(&sql, [])
+        tx.execute(&sql, params)
             .context(super::UnableToCreateDuckDBTableSnafu)?;
 
         let create_stmt = tx
@@ -679,65 +664,6 @@ impl TableManager {
             .context(super::UnableToQueryDataSnafu)?;
 
         Ok(count)
-    }
-}
-
-fn create_empty_record_batch_reader(schema: SchemaRef) -> impl RecordBatchReader {
-    let empty_batch = RecordBatch::new_empty(Arc::clone(&schema));
-    let batches = vec![empty_batch];
-    RecordBatchIterator::new(batches.into_iter().map(Ok), schema)
-}
-
-#[derive(Debug, Clone)]
-pub(crate) struct ViewCreator {
-    name: RelationName,
-}
-
-impl ViewCreator {
-    #[must_use]
-    pub(crate) fn from_name(name: RelationName) -> Self {
-        Self { name }
-    }
-
-    pub(crate) fn insert_into(
-        &self,
-        table: &TableManager,
-        tx: &Transaction<'_>,
-        on_conflict: Option<&OnConflict>,
-    ) -> super::Result<u64> {
-        // insert from this view, into the target table
-        let mut insert_sql = format!(
-            r#"INSERT INTO "{table_name}" SELECT * FROM "{view_name}""#,
-            view_name = self.name,
-            table_name = table.table_name()
-        );
-
-        if let Some(on_conflict) = on_conflict {
-            let on_conflict_sql =
-                on_conflict.build_on_conflict_statement(&table.table_definition.schema);
-            insert_sql.push_str(&format!(" {on_conflict_sql}"));
-        }
-        tracing::debug!("{insert_sql}");
-
-        let rows = tx
-            .execute(&insert_sql, [])
-            .context(super::UnableToInsertToDuckDBTableSnafu)?;
-
-        Ok(rows as u64)
-    }
-
-    pub(crate) fn drop(&self, tx: &Transaction<'_>) -> super::Result<()> {
-        // drop this view
-        tx.execute(
-            &format!(
-                r#"DROP VIEW IF EXISTS "{view_name}""#,
-                view_name = self.name
-            ),
-            [],
-        )
-        .context(super::UnableToDropDuckDBTableSnafu)?;
-
-        Ok(())
     }
 }
 

--- a/crates/duckdb/src/lib.rs
+++ b/crates/duckdb/src/lib.rs
@@ -98,6 +98,15 @@ pub enum Error {
     #[snafu(display("Unable to get appender to duckdb table: {source}"))]
     UnableToGetAppenderToDuckDBTable { source: duckdb::Error },
 
+    #[snafu(display("Unable to append Arrow record batch to duckdb table: {source}"))]
+    UnableToAppendRecordBatchToDuckDBTable { source: duckdb::Error },
+
+    #[snafu(display("Unable to flush DuckDB appender: {source}"))]
+    UnableToFlushDuckDBAppender { source: duckdb::Error },
+
+    #[snafu(display("Unable to decode Arrow dictionary columns for DuckDB: {source}"))]
+    UnableToDecodeDictionaryColumns { source: arrow_schema::ArrowError },
+
     #[snafu(display("Unable to delete data from the duckdb table: {source}"))]
     UnableToDeleteDuckdbData { source: duckdb::Error },
 
@@ -159,17 +168,6 @@ pub enum Error {
 
     #[snafu(display("A table definition is required to create a DuckDBTableWriter"))]
     MissingTableDefinition,
-
-    #[snafu(display("Failed to register Arrow scan view for DuckDB ingestion: {source}"))]
-    UnableToRegisterArrowScanView { source: duckdb::Error },
-
-    #[snafu(display(
-        "Failed to register Arrow scan view to build table creation statement: {source}"
-    ))]
-    UnableToRegisterArrowScanViewForTableCreation { source: duckdb::Error },
-
-    #[snafu(display("Failed to drop Arrow scan view for DuckDB ingestion: {source}"))]
-    UnableToDropArrowScanView { source: duckdb::Error },
 }
 
 type Result<T, E = Error> = std::result::Result<T, E>;

--- a/crates/duckdb/src/write.rs
+++ b/crates/duckdb/src/write.rs
@@ -1,11 +1,14 @@
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{SystemTime, UNIX_EPOCH};
 use std::{fmt, sync::Arc};
 
 use crate::pool::DuckDbConnectionPool;
 use crate::DuckDB;
-use arrow::array::RecordBatchReader;
-use arrow::ffi_stream::FFI_ArrowArrayStream;
-use arrow::{array::RecordBatch, datatypes::SchemaRef};
+use arrow::{
+    array::{ArrayRef, RecordBatch},
+    compute::cast,
+    datatypes::{DataType, Field, Schema, SchemaRef},
+};
 use arrow_schema::ArrowError;
 use async_trait::async_trait;
 use datafusion::catalog::Session;
@@ -30,14 +33,15 @@ use snafu::prelude::*;
 use tokio::sync::mpsc::{self, Receiver, Sender};
 use tokio::task::JoinHandle;
 
-use super::creator::{TableDefinition, TableManager, ViewCreator};
-use super::{to_datafusion_error, RelationName};
+use super::creator::{TableDefinition, TableManager};
+use super::to_datafusion_error;
 
 // checking schemas are equivalent is disabled because it incorrectly marks single-level list fields are different when the name of the field is different
 // e.g. List(Field { name: 'a', data_type: Int32 }) != List(Field { name: 'b', data_type: Int32 })
 // but, in this case, they are actually equivalent because the field name does not matter for the schema.
 // related: https://github.com/apache/arrow-rs/issues/6733#issuecomment-2482582556
 const SCHEMA_EQUIVALENCE_ENABLED: bool = false;
+static NEXT_STAGING_ID: AtomicU64 = AtomicU64::new(0);
 
 #[derive(Default)]
 pub struct DuckDBTableWriterBuilder {
@@ -610,57 +614,101 @@ fn write_to_table(
     table: &TableManager,
     tx: &Transaction<'_>,
     schema: SchemaRef,
-    data_batches: Receiver<RecordBatch>,
+    mut data_batches: Receiver<RecordBatch>,
     on_conflict: Option<&OnConflict>,
 ) -> datafusion::common::Result<u64> {
-    let stream = FFI_ArrowArrayStream::new(Box::new(RecordBatchReaderFromStream::new(
-        data_batches,
-        schema,
-    )));
-
     let current_ts = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .context(super::UnableToGetSystemTimeSnafu)
         .map_err(to_datafusion_error)?
-        .as_millis();
+        .as_nanos();
 
-    let view_name = format!("__scan_{}_{current_ts}", table.table_name());
-    tx.register_arrow_scan_view(&view_name, &stream)
-        .context(super::UnableToRegisterArrowScanViewSnafu)
+    let staging_id = NEXT_STAGING_ID.fetch_add(1, Ordering::Relaxed);
+    let staging_name = format!("__datafusion_ingest_{current_ts}_{staging_id}");
+    let create_staging_sql = format!(
+        r#"CREATE TABLE "{staging_name}" AS SELECT * FROM "{table_name}" LIMIT 0"#,
+        table_name = table.table_name(),
+    );
+    tx.execute(&create_staging_sql, [])
+        .context(super::UnableToCreateDuckDBTableSnafu)
         .map_err(to_datafusion_error)?;
 
-    let view = ViewCreator::from_name(RelationName::new(view_name));
-    let rows = view
-        .insert_into(table, tx, on_conflict)
+    {
+        let mut appender = tx
+            .appender(&staging_name)
+            .context(super::UnableToGetAppenderToDuckDBTableSnafu)
+            .map_err(to_datafusion_error)?;
+
+        while let Some(batch) = data_batches.blocking_recv() {
+            let batch = decode_dictionary_columns(batch)
+                .context(super::UnableToDecodeDictionaryColumnsSnafu)
+                .map_err(to_datafusion_error)?;
+            appender
+                .append_record_batch(batch)
+                .context(super::UnableToAppendRecordBatchToDuckDBTableSnafu)
+                .map_err(to_datafusion_error)?;
+        }
+
+        appender
+            .flush()
+            .context(super::UnableToFlushDuckDBAppenderSnafu)
+            .map_err(to_datafusion_error)?;
+    }
+
+    let mut insert_sql = format!(
+        r#"INSERT INTO "{table_name}" SELECT * FROM "{staging_name}""#,
+        table_name = table.table_name(),
+    );
+    if let Some(on_conflict) = on_conflict {
+        insert_sql.push(' ');
+        insert_sql.push_str(&on_conflict.build_on_conflict_statement(&schema));
+    }
+    tracing::debug!("{insert_sql}");
+
+    let rows = tx
+        .execute(&insert_sql, [])
+        .context(super::UnableToInsertToDuckDBTableSnafu)
         .map_err(to_datafusion_error)?;
-    view.drop(tx).map_err(to_datafusion_error)?;
+
+    tx.execute(&format!(r#"DROP TABLE "{staging_name}""#), [])
+        .context(super::UnableToDropDuckDBTableSnafu)
+        .map_err(to_datafusion_error)?;
 
     Ok(rows as u64)
 }
 
-struct RecordBatchReaderFromStream {
-    stream: Receiver<RecordBatch>,
-    schema: SchemaRef,
-}
+fn decode_dictionary_columns(batch: RecordBatch) -> Result<RecordBatch, ArrowError> {
+    let mut decoded = false;
+    let mut fields = Vec::with_capacity(batch.num_columns());
+    let mut columns: Vec<ArrayRef> = Vec::with_capacity(batch.num_columns());
 
-impl RecordBatchReaderFromStream {
-    fn new(stream: Receiver<RecordBatch>, schema: SchemaRef) -> Self {
-        Self { stream, schema }
+    for (field, column) in batch.schema().fields().iter().zip(batch.columns()) {
+        if let DataType::Dictionary(_, value_type) = field.data_type() {
+            decoded = true;
+            fields.push(Arc::new(
+                Field::new(
+                    field.name(),
+                    value_type.as_ref().clone(),
+                    field.is_nullable(),
+                )
+                .with_metadata(field.metadata().clone()),
+            ));
+            columns.push(cast(column, value_type)?);
+        } else {
+            fields.push(Arc::clone(field));
+            columns.push(Arc::clone(column));
+        }
     }
-}
 
-impl Iterator for RecordBatchReaderFromStream {
-    type Item = Result<RecordBatch, ArrowError>;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        self.stream.blocking_recv().map(Ok)
+    if !decoded {
+        return Ok(batch);
     }
-}
 
-impl RecordBatchReader for RecordBatchReaderFromStream {
-    fn schema(&self) -> SchemaRef {
-        Arc::clone(&self.schema)
-    }
+    let schema = Arc::new(Schema::new_with_metadata(
+        fields,
+        batch.schema().metadata().clone(),
+    ));
+    RecordBatch::try_new(schema, columns)
 }
 
 #[cfg(test)]
@@ -669,6 +717,7 @@ mod test {
     use datafusion::physical_plan::memory::MemoryStream;
 
     use super::*;
+    use crate::RelationName;
     use crate::{
         duckdb::creator::tests::{get_basic_table_definition, get_mem_duckdb, init_tracing},
         util::{column_reference::ColumnReference, indexes::IndexType},


### PR DESCRIPTION
## Summary

- Replace the custom DuckDB fork with the official `duckdb` 1.10505.0 crate, which remains on Arrow 58.
- Replace the fork-only Arrow scan-view ingestion API with the official Arrow appender and a transaction-local staging table.
- Adapt query streaming to the official API and decode dictionary columns before appending.
- Add DuckDB to the integration-test feature set and cover multi-batch ingestion.

## Testing

- `cargo fmt --all -- --check`
- `cargo check -p datafusion-table-providers --all-features`
- `cargo clippy --workspace --all-features -- -D warnings`
- `make test`
- `cargo test -p datafusion-table-providers --test integration --no-default-features --features duckdb -- duckdb --nocapture` (19 passed, 3 pre-existing unsupported cases ignored)
- `cargo package -p datafusion-table-providers-duckdb --allow-dirty --no-verify`