### PR TITLE
Bump rand 0.8.5 to 0.8.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5764,9 +5764,9 @@ checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -6149,7 +6149,7 @@ dependencies = [
  "bytes",
  "num-traits",
  "postgres-types",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rkyv",
  "serde",
  "serde_json",


### PR DESCRIPTION
## Summary

- Update the inactive optional `rand` lockfile entry from 0.8.5 to 0.8.6.
- Use the first patched release for [GHSA-cq8v-f236-94qc](https://github.com/advisories/GHSA-cq8v-f236-94qc), clearing Dependabot alert #44 without changing the active feature graph.

## Testing

- `cargo metadata --locked --no-deps --format-version 1`
- `cargo check -p datafusion-table-providers --all-features --locked`