### PR TITLE
Add connector hardening and DuckDB write features

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2563,6 +2563,7 @@ dependencies = [
  "num-bigint",
  "rand 0.10.2",
  "regex",
+ "reqwest 0.13.2",
  "sea-query",
  "secrecy",
  "serde",
@@ -2572,6 +2573,7 @@ dependencies = [
  "time",
  "tokio",
  "tracing",
+ "tracing-subscriber",
  "url",
 ]
 
@@ -2593,11 +2595,14 @@ dependencies = [
  "itertools 0.15.0",
  "r2d2",
  "rand 0.10.2",
+ "reqwest 0.13.2",
  "sea-query",
  "secrecy",
  "snafu",
+ "tempfile",
  "tokio",
  "tracing",
+ "tracing-subscriber",
  "uuid",
 ]
 
@@ -2712,6 +2717,7 @@ dependencies = [
  "fallible-iterator 0.3.0",
  "futures",
  "geo-types",
+ "geozero",
  "logos",
  "native-tls",
  "pem 4.0.0",
@@ -2756,6 +2762,8 @@ dependencies = [
  "datafusion-table-providers-common",
  "fundu",
  "futures",
+ "rand 0.10.2",
+ "rstest",
  "rusqlite",
  "sea-query",
  "secrecy",

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -8,7 +8,7 @@
 //! and module paths for backward compatibility.
 
 pub use datafusion_table_providers_common::{
-    common, util, Error, UnsupportedTypeAction, DESCRIPTION_METADATA_KEY,
+    common, schema_projection, util, Error, UnsupportedTypeAction, DESCRIPTION_METADATA_KEY,
 };
 
 pub mod sql {

--- a/core/tests/mongodb/mod.rs
+++ b/core/tests/mongodb/mod.rs
@@ -769,6 +769,126 @@ async fn test_mongodb_unnesting_depth_1(port: usize) {
     .await;
 }
 
+/// JSON nesting (`json_object`): declared static columns (`_id`, `name`) stay
+/// top-level while every other document field — scalar, nested document, and
+/// array — folds into one sorted-key JSON `Utf8` catch-all column (`data`).
+/// Exercised end-to-end through the DataFusion scan path against a live MongoDB.
+async fn test_mongodb_json_nesting(port: usize) {
+    use datafusion_table_providers::schema_projection::SchemaProjection;
+
+    let test_docs = vec![
+        doc! {
+            "_id": 1,
+            "name": "Alice",
+            "email": "alice@example.com",
+            "age": 30,
+            "address": { "city": "NYC", "zip": "10001" },
+        },
+        doc! {
+            "_id": 2,
+            "name": "Bob",
+            "email": "bob@example.com",
+            "tags": ["x", "y"],
+        },
+    ];
+
+    let ctx = SessionContext::new();
+    let client = common::get_mongodb_client(port)
+        .await
+        .expect("MongoDB client should be created");
+    let collection = client
+        .database("testdb")
+        .collection::<Document>("json_nesting_collection");
+    let _ = collection.drop().await;
+    collection
+        .insert_many(test_docs)
+        .await
+        .expect("MongoDB documents should be inserted");
+
+    // `_id` and `name` are declared static; every other field folds into `data`.
+    let projection = SchemaProjection::nesting(
+        vec!["_id".to_string(), "name".to_string()],
+        "data".to_string(),
+    );
+
+    let pool = common::get_mongodb_connection_pool(port, None)
+        .await
+        .expect("MongoDB connection pool should be created");
+    let table = MongoDBTable::new_with_projection(
+        &Arc::new(pool),
+        "json_nesting_collection",
+        None,
+        Some(projection),
+    )
+    .await
+    .expect("Table should be created");
+    ctx.register_table("json_nesting_collection", Arc::new(table))
+        .expect("Table should be registered");
+
+    let batches = ctx
+        .sql("SELECT name, data FROM json_nesting_collection ORDER BY _id")
+        .await
+        .expect("query should plan")
+        .collect()
+        .await
+        .expect("query should execute");
+
+    let mut rows: Vec<(String, serde_json::Value)> = Vec::new();
+    for batch in &batches {
+        let names = batch
+            .column_by_name("name")
+            .expect("name column")
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .expect("name should be a static Utf8 column");
+        let data = batch
+            .column_by_name("data")
+            .expect("catch-all data column")
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .expect("catch-all should be a Utf8 JSON string");
+        for row in 0..batch.num_rows() {
+            let catch_all: serde_json::Value =
+                serde_json::from_str(data.value(row)).expect("catch-all must be valid JSON");
+            rows.push((names.value(row).to_string(), catch_all));
+        }
+    }
+
+    assert_eq!(rows.len(), 2, "expected two documents");
+
+    // Row 0 (Alice): non-declared scalar + nested-document fields fold into the
+    // catch-all; declared static keys must not leak into it.
+    let (name0, data0) = &rows[0];
+    assert_eq!(name0, "Alice");
+    assert_eq!(data0["email"], serde_json::json!("alice@example.com"));
+    assert!(
+        data0.get("age").is_some(),
+        "scalar `age` must be in the catch-all"
+    );
+    assert!(
+        data0["address"].is_object(),
+        "nested `address` must be preserved as JSON in the catch-all"
+    );
+    assert!(
+        data0.get("name").is_none(),
+        "static `name` must not leak into the catch-all"
+    );
+    assert!(
+        data0.get("_id").is_none(),
+        "static `_id` must not leak into the catch-all"
+    );
+
+    // Row 1 (Bob): an array field folds in as well.
+    let (name1, data1) = &rows[1];
+    assert_eq!(name1, "Bob");
+    assert_eq!(data1["email"], serde_json::json!("bob@example.com"));
+    assert!(
+        data1["tags"].is_array(),
+        "array `tags` must be preserved in the catch-all"
+    );
+    assert!(data1.get("name").is_none());
+}
+
 use datafusion::common::Result as DFResult;
 fn project_record_batch(batch: &RecordBatch, columns: &[&str]) -> DFResult<RecordBatch> {
     let schema = batch.schema();
@@ -812,6 +932,7 @@ async fn test_mongodb_arrow_oneway() {
     test_mongodb_nested_object_types(port).await;
     test_mongodb_null_and_missing_fields(port).await;
     test_mongodb_unnesting_depth_1(port).await;
+    test_mongodb_json_nesting(port).await;
     test_mongodb_sort_limit(port).await;
 
     mongodb_container.remove().await.expect("container to stop");

--- a/crates/adbc/src/pool.rs
+++ b/crates/adbc/src/pool.rs
@@ -23,6 +23,7 @@ use std::sync::Arc;
 use crate::conn::AdbcDbConnection;
 use datafusion_table_providers_common::sql::db_connection_pool::{
     dbconnection::{DbConnection, SyncDbConnection},
+    runtime::run_async_with_tokio,
     DbConnectionPool, JoinPushDown,
 };
 type Result<T, E = Box<dyn std::error::Error + Send + Sync>> = std::result::Result<T, E>;
@@ -191,10 +192,25 @@ where
     ) -> Result<Box<dyn DbConnection<r2d2::PooledConnection<AdbcConnectionManager<D>>, RecordBatch>>>
     {
         let pool = Arc::clone(&self.pool);
-        let conn: r2d2::PooledConnection<AdbcConnectionManager<D>> =
-            pool.get().context(ConnectionPoolSnafu)?;
 
-        Ok(Box::new(AdbcDbConnection::new(conn)))
+        let connect = async move || -> Result<
+            Box<dyn DbConnection<r2d2::PooledConnection<AdbcConnectionManager<D>>, RecordBatch>>,
+        > {
+            let conn: r2d2::PooledConnection<AdbcConnectionManager<D>> =
+                tokio::task::spawn_blocking(move || pool.get())
+                    .await
+                    .map_err(|e| Box::new(e) as Box<dyn std::error::Error + Send + Sync>)?
+                    .context(ConnectionPoolSnafu)?;
+
+            Ok(Box::new(AdbcDbConnection::new(conn))
+                as Box<
+                    dyn DbConnection<
+                        r2d2::PooledConnection<AdbcConnectionManager<D>>,
+                        RecordBatch,
+                    >,
+                >)
+        };
+        run_async_with_tokio(connect).await
     }
 
     fn join_push_down(&self) -> JoinPushDown {

--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -49,6 +49,10 @@ url = "2.5"
 default = ["federation"]
 federation = ["dep:datafusion-federation"]
 
+[dev-dependencies]
+reqwest = "0.13"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+
 [package.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]

--- a/crates/common/src/common.rs
+++ b/crates/common/src/common.rs
@@ -59,7 +59,7 @@ impl<T, P> std::fmt::Debug for DatabaseSchemaProvider<T, P> {
     }
 }
 
-impl<T, P: 'static> DatabaseSchemaProvider<T, P> {
+impl<T: 'static, P: 'static> DatabaseSchemaProvider<T, P> {
     pub async fn try_new(name: String, pool: Pool<T, P>) -> Result<Self> {
         let conn = pool.connect().await?;
         let tables = get_tables(conn, &name).await?;

--- a/crates/common/src/lib.rs
+++ b/crates/common/src/lib.rs
@@ -4,6 +4,7 @@ use serde::{Deserialize, Serialize};
 use snafu::prelude::*;
 
 pub mod common;
+pub mod schema_projection;
 pub mod sql;
 pub mod util;
 

--- a/crates/common/src/schema_projection.rs
+++ b/crates/common/src/schema_projection.rs
@@ -1,0 +1,510 @@
+//! Connector-agnostic **schema projection** (JSON nesting).
+//!
+//! A single abstraction that unifies two column-shaping features behind one
+//! config and one generic execution core, so adding a future connector is a
+//! small [`RowShape`] adapter rather than a per-feature reimplementation:
+//!
+//! 1. **Declared schema** — pin/override column types ([`ColumnSource::Field`]
+//!    columns).
+//! 2. **JSON nesting** — collapse every field not claimed by a declared column
+//!    into one catch-all JSON `Utf8` column (a single
+//!    [`ColumnSource::JsonObject`] column).
+//!
+//! The two generic entry points are [`SchemaProjection::project_schema`] (build
+//! the exposed Arrow schema) and [`SchemaProjection::project_row`] (reshape one
+//! source row just before Arrow conversion). Each connector contributes a
+//! [`RowShape`] adapter for its native value type (`serde_json::Value`, BSON,
+//! DynamoDB `AttributeValue`, …); a nested object is simply a value that is
+//! itself an object.
+
+use std::collections::{BTreeMap, HashMap, HashSet};
+use std::sync::Arc;
+
+use datafusion::arrow::datatypes::{DataType, Field, Schema, SchemaRef};
+
+use crate::util::schema::merge_inferred_and_declared_schemas;
+
+/// The metadata key (under a column's `metadata:` block) that marks the
+/// catch-all JSON column. Only the value `"*"` is supported.
+pub const JSON_OBJECT_MARKER: &str = "json_object";
+
+/// The only supported value for [`JSON_OBJECT_MARKER`].
+pub const JSON_OBJECT_WILDCARD: &str = "*";
+
+/// How a single projected (output) column draws its value from a source row.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ColumnSource {
+    /// A declared top-level field, read by its own name and kept as its own
+    /// column (used for declared-schema type pinning).
+    Field,
+    /// The catch-all: every source field not claimed by a `Field` column,
+    /// serialized as a single sorted-key JSON object string.
+    JsonObject,
+}
+
+/// One declared output column and how it is sourced from the row.
+#[derive(Debug, Clone)]
+pub struct ProjectedColumn {
+    /// The output/queryable column name (equal to the upstream key).
+    pub output_name: String,
+    /// Where the value comes from.
+    pub source: ColumnSource,
+    /// Optional pinned Arrow type. When `None`, the type is taken from the
+    /// inferred schema (or `Utf8` for the catch-all / an unknown source).
+    pub declared_type: Option<DataType>,
+    /// Whether the output column is nullable.
+    pub nullable: bool,
+}
+
+/// Errors raised while building a [`SchemaProjection`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SchemaProjectionError {
+    /// More than one column carries the `json_object` catch-all marker.
+    MultipleCatchAll { columns: Vec<String> },
+    /// The same output column name is declared twice.
+    DuplicateColumn { output_name: String },
+    /// A required column (e.g. a primary key) was folded into the catch-all
+    /// instead of being declared.
+    RequiredColumnInCatchAll { output_name: String },
+}
+
+impl std::fmt::Display for SchemaProjectionError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::MultipleCatchAll { columns } => write!(
+                f,
+                "multiple columns carry the '{JSON_OBJECT_MARKER}' catch-all marker: {}. Only one column may be the JSON object column.",
+                columns.join(", ")
+            ),
+            Self::DuplicateColumn { output_name } => {
+                write!(f, "column '{output_name}' is declared more than once")
+            }
+            Self::RequiredColumnInCatchAll { output_name } => write!(
+                f,
+                "column '{output_name}' must be declared explicitly and cannot be folded into the '{JSON_OBJECT_MARKER}' catch-all"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for SchemaProjectionError {}
+
+/// A fully-resolved projection: the declared columns plus the precomputed
+/// structures that drive row reshaping.
+#[derive(Debug, Clone)]
+pub struct SchemaProjection {
+    columns: Vec<ProjectedColumn>,
+    /// Output names of the declared `Field` (kept-as-is) columns.
+    static_fields: HashSet<String>,
+    /// Output name of the catch-all column, if any.
+    catch_all: Option<String>,
+}
+
+impl SchemaProjection {
+    /// Build a JSON-nesting projection directly from a set of kept (declared)
+    /// field names plus one catch-all column. Infallible: the field names are
+    /// deduplicated into a set and there is exactly one catch-all, so none of
+    /// [`SchemaProjectionError`]'s conditions can arise. Handy for connectors
+    /// (e.g. HTTP) that already know their static/catch-all split and don't
+    /// want a fallible constructor.
+    #[must_use]
+    pub fn nesting(
+        static_fields: impl IntoIterator<Item = String>,
+        catch_all: impl Into<String>,
+    ) -> Self {
+        let catch_all = catch_all.into();
+        let mut seen = HashSet::new();
+        let ordered_fields: Vec<String> = static_fields
+            .into_iter()
+            .filter(|name| seen.insert(name.clone()))
+            .collect();
+        let static_fields: HashSet<String> = ordered_fields.iter().cloned().collect();
+        let mut columns: Vec<ProjectedColumn> = ordered_fields
+            .into_iter()
+            .map(|name| ProjectedColumn {
+                output_name: name,
+                source: ColumnSource::Field,
+                declared_type: None,
+                nullable: true,
+            })
+            .collect();
+        columns.push(ProjectedColumn {
+            output_name: catch_all.clone(),
+            source: ColumnSource::JsonObject,
+            declared_type: None,
+            nullable: true,
+        });
+        Self {
+            columns,
+            static_fields,
+            catch_all: Some(catch_all),
+        }
+    }
+
+    /// Build a projection from the declared columns. Validates: at most one
+    /// catch-all, no duplicate output names, and that none of
+    /// `required_columns` is folded into the catch-all.
+    ///
+    /// `required_columns` are columns that must be declared explicitly (e.g.
+    /// primary-key / CDC-key columns) — they must appear as declared `Field`
+    /// columns and may not be the catch-all.
+    pub fn new(
+        columns: Vec<ProjectedColumn>,
+        required_columns: &[String],
+    ) -> Result<Self, SchemaProjectionError> {
+        let mut catch_all: Option<String> = None;
+        let mut catch_all_names: Vec<String> = Vec::new();
+        let mut static_fields: HashSet<String> = HashSet::new();
+        let mut seen: HashSet<&str> = HashSet::new();
+
+        for col in &columns {
+            if !seen.insert(col.output_name.as_str()) {
+                return Err(SchemaProjectionError::DuplicateColumn {
+                    output_name: col.output_name.clone(),
+                });
+            }
+            match col.source {
+                ColumnSource::JsonObject => {
+                    catch_all_names.push(col.output_name.clone());
+                    catch_all = Some(col.output_name.clone());
+                }
+                ColumnSource::Field => {
+                    static_fields.insert(col.output_name.clone());
+                }
+            }
+        }
+
+        if catch_all_names.len() > 1 {
+            return Err(SchemaProjectionError::MultipleCatchAll {
+                columns: catch_all_names,
+            });
+        }
+
+        // A required column must be a declared `Field` — never folded into the
+        // catch-all. This only matters when a catch-all exists; without one,
+        // non-declared columns pass through unchanged (open world), so there is
+        // nothing to fold them into.
+        if catch_all.is_some() {
+            for req in required_columns {
+                if !static_fields.contains(req.as_str()) {
+                    return Err(SchemaProjectionError::RequiredColumnInCatchAll {
+                        output_name: req.clone(),
+                    });
+                }
+            }
+        }
+
+        Ok(Self {
+            columns,
+            static_fields,
+            catch_all,
+        })
+    }
+
+    /// True when the projection leaves every row unchanged — i.e. there is no
+    /// catch-all, so only (optional) type-pinning declared columns apply.
+    /// Callers can skip [`Self::project_row`] entirely on this path.
+    #[must_use]
+    pub fn is_identity(&self) -> bool {
+        self.catch_all.is_none()
+    }
+
+    /// True when a catch-all (`json_object`) column is configured.
+    #[must_use]
+    pub fn has_catch_all(&self) -> bool {
+        self.catch_all.is_some()
+    }
+
+    /// The declared output columns, in declared order.
+    #[must_use]
+    pub fn columns(&self) -> &[ProjectedColumn] {
+        &self.columns
+    }
+
+    /// The output names of the declared `Field` (kept-as-is) columns. Useful
+    /// for connectors that must validate declared columns against a source
+    /// schema, or decide projection pushdown.
+    #[must_use]
+    pub fn static_fields(&self) -> &HashSet<String> {
+        &self.static_fields
+    }
+
+    /// The catch-all column's output name, if a `json_object` column exists.
+    #[must_use]
+    pub fn catch_all_name(&self) -> Option<&str> {
+        self.catch_all.as_deref()
+    }
+
+    /// Build the exposed Arrow schema for this projection.
+    ///
+    /// - **Closed world** (a catch-all exists): the schema is exactly the
+    ///   declared columns in declared order; the catch-all is `Utf8`. Field
+    ///   types come from `declared_type`, falling back to the inferred type of
+    ///   the same-named source key, then `Utf8`.
+    /// - **Open world** (no catch-all): preserves the legacy declared-schema
+    ///   merge via [`merge_inferred_and_declared_schemas`] — inferred columns
+    ///   pass through and declared columns override their types.
+    #[must_use]
+    pub fn project_schema(&self, inferred: SchemaRef) -> SchemaRef {
+        let inferred_by_name: HashMap<&str, &Field> = inferred
+            .fields()
+            .iter()
+            .map(|f| (f.name().as_str(), f.as_ref()))
+            .collect();
+
+        if self.catch_all.is_some() {
+            // Closed world: only the declared columns + catch-all.
+            let fields: Vec<Field> = self
+                .columns
+                .iter()
+                .map(|c| self.field_for(c, &inferred_by_name))
+                .collect();
+            return Arc::new(Schema::new(fields));
+        }
+
+        // Open world: build the declared schema and merge with inferred.
+        let declared_fields: Vec<Field> = self
+            .columns
+            .iter()
+            .map(|c| self.field_for(c, &inferred_by_name))
+            .collect();
+        if declared_fields.is_empty() {
+            return inferred;
+        }
+        let declared_schema: SchemaRef = Arc::new(Schema::new(declared_fields));
+        merge_inferred_and_declared_schemas(inferred, Some(&declared_schema))
+    }
+
+    /// Resolve the Arrow field for a declared column.
+    fn field_for(&self, col: &ProjectedColumn, inferred_by_name: &HashMap<&str, &Field>) -> Field {
+        let data_type = match (&col.source, &col.declared_type) {
+            (_, Some(dt)) => dt.clone(),
+            (ColumnSource::JsonObject, None) => DataType::Utf8,
+            (ColumnSource::Field, None) => inferred_by_name
+                .get(col.output_name.as_str())
+                .map_or(DataType::Utf8, |f| f.data_type().clone()),
+        };
+        Field::new(&col.output_name, data_type, col.nullable)
+    }
+
+    /// Reshape one source row into the declared output columns: kept (declared)
+    /// fields stay as-is and every other field is folded into the catch-all as
+    /// a single sorted-key JSON object string. The returned value is the same
+    /// native type, ready for the connector's existing row→Arrow conversion.
+    ///
+    /// When there is no catch-all the row is returned untouched (the projection
+    /// only pins types, which is handled by [`Self::project_schema`]).
+    #[must_use]
+    pub fn project_row<R: RowShape>(&self, row: R) -> R {
+        let Some(catch_all) = &self.catch_all else {
+            return row;
+        };
+
+        let entries = match row.into_object() {
+            Ok(entries) => entries,
+            Err(scalar) => {
+                // A non-object row (array/primitive): no declared field
+                // matches, so the whole row goes to the catch-all.
+                let json = serde_json::to_string(&scalar.to_json()).unwrap_or_default();
+                return R::from_object(vec![(catch_all.clone(), R::from_json_string(json))]);
+            }
+        };
+
+        let mut out: Vec<(String, R)> = Vec::new();
+        // BTreeMap → the catch-all object has alphabetically sorted, stable keys.
+        let mut rest: BTreeMap<String, serde_json::Value> = BTreeMap::new();
+        for (key, value) in entries {
+            if self.static_fields.contains(&key) {
+                out.push((key, value));
+            } else {
+                rest.insert(key, value.to_json());
+            }
+        }
+
+        if !rest.is_empty() {
+            let json = serde_json::to_string(&rest).unwrap_or_default();
+            out.push((catch_all.clone(), R::from_json_string(json)));
+        }
+        // Empty remainder → omit the catch-all so it becomes SQL NULL.
+
+        R::from_object(out)
+    }
+}
+
+/// A connector's native row value, viewed as a possibly-nested object. One
+/// impl per connector value type (`serde_json::Value`, `bson::Bson`, DynamoDB
+/// `AttributeValue`, …) makes the generic core reusable.
+pub trait RowShape: Sized {
+    /// Enumerate one object level as `(key, value)` pairs, or return the value
+    /// unchanged via `Err` when it is a scalar/array (not an object).
+    ///
+    /// # Errors
+    /// Returns `Err(self)` when the value is not an object.
+    fn into_object(self) -> Result<Vec<(String, Self)>, Self>;
+    /// Rebuild one object level from `(key, value)` pairs.
+    fn from_object(entries: Vec<(String, Self)>) -> Self;
+    /// Convert (recursively) to `serde_json::Value` for the catch-all column.
+    fn to_json(&self) -> serde_json::Value;
+    /// Wrap an already-serialized catch-all JSON string as a native value
+    /// (typically the connector's string variant).
+    fn from_json_string(json: String) -> Self;
+}
+
+impl RowShape for serde_json::Value {
+    fn into_object(self) -> Result<Vec<(String, Self)>, Self> {
+        match self {
+            serde_json::Value::Object(map) => Ok(map.into_iter().collect()),
+            other => Err(other),
+        }
+    }
+
+    fn from_object(entries: Vec<(String, Self)>) -> Self {
+        serde_json::Value::Object(entries.into_iter().collect())
+    }
+
+    fn to_json(&self) -> serde_json::Value {
+        self.clone()
+    }
+
+    fn from_json_string(json: String) -> Self {
+        serde_json::Value::String(json)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn field(name: &str) -> ProjectedColumn {
+        ProjectedColumn {
+            output_name: name.to_string(),
+            source: ColumnSource::Field,
+            declared_type: None,
+            nullable: true,
+        }
+    }
+
+    fn catch_all(name: &str) -> ProjectedColumn {
+        ProjectedColumn {
+            output_name: name.to_string(),
+            source: ColumnSource::JsonObject,
+            declared_type: None,
+            nullable: true,
+        }
+    }
+
+    fn proj(columns: Vec<ProjectedColumn>) -> SchemaProjection {
+        SchemaProjection::new(columns, &[]).expect("valid projection")
+    }
+
+    #[test]
+    fn decomposes_object_into_static_and_catchall() {
+        let p = proj(vec![field("id"), field("title"), catch_all("data")]);
+        let out = p.project_row(json!({
+            "id": "abc",
+            "title": "hello",
+            "description": "a value",
+            "count": 42,
+            "nested": {"x": 1, "y": [1, 2]}
+        }));
+        assert_eq!(out["id"], json!("abc"));
+        assert_eq!(out["title"], json!("hello"));
+        let catchall: serde_json::Value =
+            serde_json::from_str(out["data"].as_str().expect("catchall string")).expect("parse");
+        assert_eq!(catchall["description"], json!("a value"));
+        assert_eq!(catchall["count"], json!(42));
+        assert_eq!(catchall["nested"]["x"], json!(1));
+    }
+
+    #[test]
+    fn missing_static_field_is_null() {
+        let p = proj(vec![field("id"), field("title"), catch_all("data")]);
+        let out = p.project_row(json!({"id": "abc"}));
+        assert_eq!(out["id"], json!("abc"));
+        assert!(out.get("title").is_none());
+        assert!(out.get("data").is_none());
+    }
+
+    #[test]
+    fn non_object_row_goes_to_catchall() {
+        let p = proj(vec![field("id"), catch_all("data")]);
+        let out = p.project_row(json!([1, 2, 3]));
+        assert!(out.get("id").is_none());
+        assert_eq!(out["data"], json!("[1,2,3]"));
+    }
+
+    #[test]
+    fn catchall_keys_are_sorted() {
+        let p = proj(vec![field("id"), catch_all("data")]);
+        let out = p.project_row(json!({"id": "x", "zeta": 1, "alpha": 2, "mu": 3}));
+        assert_eq!(out["data"], json!(r#"{"alpha":2,"mu":3,"zeta":1}"#));
+    }
+
+    #[test]
+    fn null_value_is_preserved_in_catchall() {
+        let p = proj(vec![field("id"), catch_all("data")]);
+        let out = p.project_row(json!({"id": null, "extra": 1}));
+        assert_eq!(out["id"], json!(null));
+        assert_eq!(out["data"], json!(r#"{"extra":1}"#));
+    }
+
+    #[test]
+    fn rejects_multiple_catch_all() {
+        let err = SchemaProjection::new(vec![catch_all("a"), catch_all("b")], &[])
+            .expect_err("two catch-alls");
+        assert!(matches!(
+            err,
+            SchemaProjectionError::MultipleCatchAll { .. }
+        ));
+    }
+
+    #[test]
+    fn rejects_duplicate_output_name() {
+        let err = SchemaProjection::new(vec![field("a"), field("a")], &[]).expect_err("duplicate");
+        assert!(matches!(err, SchemaProjectionError::DuplicateColumn { .. }));
+    }
+
+    #[test]
+    fn rejects_required_column_in_catch_all() {
+        let err = SchemaProjection::new(vec![catch_all("data")], &["id".to_string()])
+            .expect_err("pk in catch-all");
+        assert!(matches!(
+            err,
+            SchemaProjectionError::RequiredColumnInCatchAll { .. }
+        ));
+    }
+
+    #[test]
+    fn no_catch_all_passes_row_through() {
+        let p = proj(vec![field("id"), field("name")]);
+        assert!(p.is_identity());
+        let row = json!({"id": 1, "name": "x", "other": true});
+        assert_eq!(p.project_row(row.clone()), row);
+    }
+
+    #[test]
+    fn project_schema_closed_world_is_declared_columns_only() {
+        let p = proj(vec![
+            ProjectedColumn {
+                output_name: "id".to_string(),
+                source: ColumnSource::Field,
+                declared_type: Some(DataType::Int64),
+                nullable: false,
+            },
+            field("title"),
+            catch_all("data"),
+        ]);
+        let inferred = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Utf8, true),
+            Field::new("title", DataType::Utf8, true),
+            Field::new("junk", DataType::Utf8, true),
+        ]));
+        let schema = p.project_schema(inferred);
+        let names: Vec<&str> = schema.fields().iter().map(|f| f.name().as_str()).collect();
+        assert_eq!(names, vec!["id", "title", "data"]);
+        assert_eq!(schema.field(0).data_type(), &DataType::Int64);
+        assert!(!schema.field(0).is_nullable());
+        assert_eq!(schema.field(2).data_type(), &DataType::Utf8);
+    }
+}

--- a/crates/common/src/sql/db_connection_pool/dbconnection.rs
+++ b/crates/common/src/sql/db_connection_pool/dbconnection.rs
@@ -5,6 +5,8 @@ use datafusion::{
 };
 use snafu::prelude::*;
 
+use crate::sql::db_connection_pool::runtime::run_async_with_tokio;
+
 pub type GenericError = Box<dyn std::error::Error + Send + Sync>;
 pub type Result<T, E = GenericError> = std::result::Result<T, E>;
 
@@ -148,18 +150,29 @@ pub trait DbConnection<T, P>: Send {
     }
 }
 
-pub async fn get_tables<T, P>(
+pub async fn get_tables<T: 'static, P: 'static>(
     conn: Box<dyn DbConnection<T, P>>,
     schema: &str,
 ) -> Result<Vec<String>, Error> {
-    let schema = if let Some(conn) = conn.as_sync() {
-        conn.tables(schema)?
+    if conn.as_sync().is_some() {
+        let schema = schema.to_string();
+        let offload = async move || -> Result<Vec<String>, Error> {
+            tokio::task::spawn_blocking(move || {
+                conn.as_sync()
+                    .expect("as_sync() returned Some above")
+                    .tables(&schema)
+            })
+            .await
+            .map_err(|e| Error::UnableToGetTables {
+                source: Box::new(e),
+            })?
+        };
+        run_async_with_tokio(offload).await
     } else if let Some(conn) = conn.as_async() {
-        conn.tables(schema).await?
+        conn.tables(schema).await
     } else {
-        return Err(Error::UnableToDowncastConnection {});
-    };
-    Ok(schema)
+        Err(Error::UnableToDowncastConnection {})
+    }
 }
 
 /// Get the schemas for the database.
@@ -167,15 +180,27 @@ pub async fn get_tables<T, P>(
 /// # Errors
 ///
 /// Returns an error if the schemas cannot be retrieved.
-pub async fn get_schemas<T, P>(conn: Box<dyn DbConnection<T, P>>) -> Result<Vec<String>, Error> {
-    let schema = if let Some(conn) = conn.as_sync() {
-        conn.schemas()?
+pub async fn get_schemas<T: 'static, P: 'static>(
+    conn: Box<dyn DbConnection<T, P>>,
+) -> Result<Vec<String>, Error> {
+    if conn.as_sync().is_some() {
+        let offload = async move || -> Result<Vec<String>, Error> {
+            tokio::task::spawn_blocking(move || {
+                conn.as_sync()
+                    .expect("as_sync() returned Some above")
+                    .schemas()
+            })
+            .await
+            .map_err(|e| Error::UnableToGetSchemas {
+                source: Box::new(e),
+            })?
+        };
+        run_async_with_tokio(offload).await
     } else if let Some(conn) = conn.as_async() {
-        conn.schemas().await?
+        conn.schemas().await
     } else {
-        return Err(Error::UnableToDowncastConnection {});
-    };
-    Ok(schema)
+        Err(Error::UnableToDowncastConnection {})
+    }
 }
 
 /// Get the schema for a table reference.
@@ -188,18 +213,29 @@ pub async fn get_schemas<T, P>(conn: Box<dyn DbConnection<T, P>>) -> Result<Vec<
 /// # Errors
 ///
 /// Returns an error if the schema cannot be retrieved.
-pub async fn get_schema<T, P>(
+pub async fn get_schema<T: 'static, P: 'static>(
     conn: Box<dyn DbConnection<T, P>>,
     table_reference: &datafusion::sql::TableReference,
 ) -> Result<Arc<datafusion::arrow::datatypes::Schema>, Error> {
-    let schema = if let Some(conn) = conn.as_sync() {
-        conn.get_schema(table_reference)?
+    if conn.as_sync().is_some() {
+        let table_reference = table_reference.clone();
+        let offload = async move || -> Result<Arc<datafusion::arrow::datatypes::Schema>, Error> {
+            tokio::task::spawn_blocking(move || {
+                conn.as_sync()
+                    .expect("as_sync() returned Some above")
+                    .get_schema(&table_reference)
+            })
+            .await
+            .map_err(|e| Error::UnableToGetSchema {
+                source: Box::new(e),
+            })?
+        };
+        run_async_with_tokio(offload).await
     } else if let Some(conn) = conn.as_async() {
-        conn.get_schema(table_reference).await?
+        conn.get_schema(table_reference).await
     } else {
-        return Err(Error::UnableToDowncastConnection {});
-    };
-    Ok(schema)
+        Err(Error::UnableToDowncastConnection {})
+    }
 }
 
 /// Query the database with the given SQL statement and parameters, returning a `Result` of `SendableRecordBatchStream`.

--- a/crates/common/src/util/count_exec.rs
+++ b/crates/common/src/util/count_exec.rs
@@ -1,0 +1,144 @@
+use std::{fmt, sync::Arc};
+
+use arrow::array::{ArrayRef, RecordBatch, UInt64Array};
+use arrow::datatypes::{DataType, Field, Schema, SchemaRef};
+use datafusion::{
+    error::DataFusionError,
+    execution::{SendableRecordBatchStream, TaskContext},
+    physical_plan::{
+        stream::RecordBatchStreamAdapter, DisplayAs, DisplayFormatType, ExecutionPlan,
+        PlanProperties,
+    },
+};
+
+pub fn count_schema() -> SchemaRef {
+    Arc::new(Schema::new(vec![Field::new(
+        "count",
+        DataType::UInt64,
+        false,
+    )]))
+}
+
+pub fn count_to_record_batch(
+    schema: SchemaRef,
+    count: u64,
+) -> datafusion::error::Result<RecordBatch> {
+    let array = Arc::new(UInt64Array::from(vec![count])) as ArrayRef;
+    RecordBatch::try_new(schema, vec![array])
+        .map_err(|e| DataFusionError::ArrowError(Box::new(e), None))
+}
+
+/// Creates an `ExecutionPlan` that produces a single row with the given count value.
+pub fn make_count_exec(count: u64) -> datafusion::error::Result<Arc<dyn ExecutionPlan>> {
+    CountExec::try_from_count(count)
+}
+
+/// A minimal `ExecutionPlan` that yields a single pre-computed `RecordBatch`.
+pub struct CountExec {
+    batch: RecordBatch,
+    properties: Arc<PlanProperties>,
+}
+
+impl CountExec {
+    pub fn new(schema: SchemaRef, batch: RecordBatch) -> Self {
+        let properties = PlanProperties::new(
+            datafusion::physical_expr::EquivalenceProperties::new(Arc::clone(&schema)),
+            datafusion::physical_plan::Partitioning::UnknownPartitioning(1),
+            datafusion::physical_plan::execution_plan::EmissionType::Final,
+            datafusion::physical_plan::execution_plan::Boundedness::Bounded,
+        );
+        Self {
+            batch,
+            properties: Arc::new(properties),
+        }
+    }
+
+    /// Creates a `CountExec` that produces a single row with the given count value.
+    pub fn try_from_count(count: u64) -> datafusion::error::Result<Arc<dyn ExecutionPlan>> {
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "count",
+            DataType::UInt64,
+            false,
+        )]));
+        let batch = RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![Arc::new(UInt64Array::from(vec![count])) as ArrayRef],
+        )
+        .map_err(|e| datafusion::error::DataFusionError::ArrowError(Box::new(e), None))?;
+
+        Ok(Arc::new(Self::new(schema, batch)))
+    }
+}
+
+impl fmt::Debug for CountExec {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("CountExec").finish_non_exhaustive()
+    }
+}
+
+impl DisplayAs for CountExec {
+    fn fmt_as(&self, _t: DisplayFormatType, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "CountExec")
+    }
+}
+
+impl ExecutionPlan for CountExec {
+    fn name(&self) -> &'static str {
+        "CountExec"
+    }
+
+    fn properties(&self) -> &Arc<PlanProperties> {
+        &self.properties
+    }
+
+    fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {
+        vec![]
+    }
+
+    fn with_new_children(
+        self: Arc<Self>,
+        _children: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> datafusion::error::Result<Arc<dyn ExecutionPlan>> {
+        Ok(self)
+    }
+
+    fn execute(
+        &self,
+        _partition: usize,
+        _context: Arc<TaskContext>,
+    ) -> datafusion::error::Result<SendableRecordBatchStream> {
+        let batch = self.batch.clone();
+        let schema = self.batch.schema();
+        Ok(Box::pin(RecordBatchStreamAdapter::new(
+            schema,
+            futures::stream::once(async move { Ok(batch) }),
+        )))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_count_exec() {
+        let exec = CountExec::try_from_count(42).expect("should create CountExec");
+        let task_ctx = Arc::new(TaskContext::default());
+        let batches = datafusion::physical_plan::collect(exec, task_ctx)
+            .await
+            .expect("collect should succeed");
+
+        assert_eq!(batches.len(), 1);
+        let batch = &batches[0];
+        assert_eq!(batch.num_rows(), 1);
+        assert_eq!(batch.num_columns(), 1);
+        assert_eq!(batch.schema().field(0).name(), "count");
+
+        let count_array = batch
+            .column(0)
+            .as_any()
+            .downcast_ref::<UInt64Array>()
+            .expect("column should be UInt64Array");
+        assert_eq!(count_array.value(0), 42);
+    }
+}

--- a/crates/common/src/util/dml.rs
+++ b/crates/common/src/util/dml.rs
@@ -1,0 +1,251 @@
+use std::{fmt, sync::Arc};
+
+use async_trait::async_trait;
+use datafusion::sql::unparser::{dialect::Dialect, Unparser};
+use datafusion::{
+    common::utils::quote_identifier,
+    error::DataFusionError,
+    execution::{SendableRecordBatchStream, TaskContext},
+    logical_expr::Expr,
+    physical_plan::{
+        stream::RecordBatchStreamAdapter, DisplayAs, DisplayFormatType, ExecutionPlan,
+        PlanProperties,
+    },
+};
+
+use super::count_exec::{count_schema, count_to_record_batch};
+
+/// Converts filter expressions to a SQL WHERE clause string.
+pub fn filters_to_sql(
+    filters: &[Expr],
+    dialect: &dyn Dialect,
+) -> datafusion::error::Result<String> {
+    let unparser = Unparser::new(dialect);
+    let sql_parts: datafusion::error::Result<Vec<String>> = filters
+        .iter()
+        .map(|filter| unparser.expr_to_sql(filter).map(|sql| sql.to_string()))
+        .collect();
+    sql_parts.map(|parts| parts.join(" AND "))
+}
+
+/// Converts assignment expressions to a SQL SET clause string.
+pub fn assignments_to_sql(
+    assignments: &[(String, Expr)],
+    dialect: &dyn Dialect,
+) -> datafusion::error::Result<String> {
+    let unparser = Unparser::new(dialect);
+    let parts: datafusion::error::Result<Vec<String>> = assignments
+        .iter()
+        .map(|(col, val)| {
+            unparser
+                .expr_to_sql(val)
+                .map(|sql_val| format!("{} = {sql_val}", quote_identifier(col)))
+        })
+        .collect();
+    parts.map(|p| p.join(", "))
+}
+
+#[async_trait]
+pub trait DeletionSink: Send + Sync {
+    async fn delete_from(&self) -> Result<u64, Box<dyn std::error::Error + Send + Sync>>;
+}
+
+pub struct DeletionExec {
+    deletion_sink: Arc<dyn DeletionSink + 'static>,
+    properties: Arc<PlanProperties>,
+}
+
+impl DeletionExec {
+    pub fn new(deletion_sink: Arc<dyn DeletionSink>) -> Self {
+        let properties = PlanProperties::new(
+            datafusion::physical_expr::EquivalenceProperties::new(count_schema()),
+            datafusion::physical_plan::Partitioning::UnknownPartitioning(1),
+            datafusion::physical_plan::execution_plan::EmissionType::Final,
+            datafusion::physical_plan::execution_plan::Boundedness::Bounded,
+        );
+        Self {
+            deletion_sink,
+            properties: Arc::new(properties),
+        }
+    }
+}
+
+impl fmt::Debug for DeletionExec {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("DeletionExec").finish_non_exhaustive()
+    }
+}
+
+impl DisplayAs for DeletionExec {
+    fn fmt_as(&self, _t: DisplayFormatType, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "DeletionExec")
+    }
+}
+
+impl ExecutionPlan for DeletionExec {
+    fn name(&self) -> &'static str {
+        "DeletionExec"
+    }
+
+    fn properties(&self) -> &Arc<PlanProperties> {
+        &self.properties
+    }
+
+    fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {
+        vec![]
+    }
+
+    fn with_new_children(
+        self: Arc<Self>,
+        _children: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> datafusion::error::Result<Arc<dyn ExecutionPlan>> {
+        Ok(self)
+    }
+
+    fn execute(
+        &self,
+        _partition: usize,
+        _context: Arc<TaskContext>,
+    ) -> datafusion::error::Result<SendableRecordBatchStream> {
+        let schema = count_schema();
+        let deletion_sink = Arc::clone(&self.deletion_sink);
+        Ok(Box::pin(RecordBatchStreamAdapter::new(
+            Arc::clone(&schema),
+            futures::stream::once(async move {
+                let count = deletion_sink
+                    .delete_from()
+                    .await
+                    .map_err(DataFusionError::External)?;
+                count_to_record_batch(schema, count)
+            }),
+        )))
+    }
+}
+
+#[async_trait]
+pub trait UpdateSink: Send + Sync {
+    async fn execute_update(&self) -> Result<u64, Box<dyn std::error::Error + Send + Sync>>;
+}
+
+pub struct UpdateExec {
+    update_sink: Arc<dyn UpdateSink + 'static>,
+    properties: Arc<PlanProperties>,
+}
+
+impl UpdateExec {
+    pub fn new(update_sink: Arc<dyn UpdateSink>) -> Self {
+        let properties = PlanProperties::new(
+            datafusion::physical_expr::EquivalenceProperties::new(count_schema()),
+            datafusion::physical_plan::Partitioning::UnknownPartitioning(1),
+            datafusion::physical_plan::execution_plan::EmissionType::Final,
+            datafusion::physical_plan::execution_plan::Boundedness::Bounded,
+        );
+        Self {
+            update_sink,
+            properties: Arc::new(properties),
+        }
+    }
+}
+
+impl fmt::Debug for UpdateExec {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("UpdateExec").finish_non_exhaustive()
+    }
+}
+
+impl DisplayAs for UpdateExec {
+    fn fmt_as(&self, _t: DisplayFormatType, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "UpdateExec")
+    }
+}
+
+impl ExecutionPlan for UpdateExec {
+    fn name(&self) -> &'static str {
+        "UpdateExec"
+    }
+
+    fn properties(&self) -> &Arc<PlanProperties> {
+        &self.properties
+    }
+
+    fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {
+        vec![]
+    }
+
+    fn with_new_children(
+        self: Arc<Self>,
+        _children: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> datafusion::error::Result<Arc<dyn ExecutionPlan>> {
+        Ok(self)
+    }
+
+    fn execute(
+        &self,
+        _partition: usize,
+        _context: Arc<TaskContext>,
+    ) -> datafusion::error::Result<SendableRecordBatchStream> {
+        let schema = count_schema();
+        let update_sink = Arc::clone(&self.update_sink);
+        Ok(Box::pin(RecordBatchStreamAdapter::new(
+            Arc::clone(&schema),
+            futures::stream::once(async move {
+                let count = update_sink
+                    .execute_update()
+                    .await
+                    .map_err(DataFusionError::External)?;
+                count_to_record_batch(schema, count)
+            }),
+        )))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use datafusion::prelude::*;
+    use datafusion::sql::unparser::dialect::DuckDBDialect;
+
+    fn dialect() -> DuckDBDialect {
+        DuckDBDialect::new()
+    }
+
+    #[test]
+    fn test_filters_to_sql_single() {
+        let filter = col("id").eq(lit(1i32));
+        let sql = filters_to_sql(&[filter], &dialect()).expect("filters_to_sql should succeed");
+        assert_eq!(sql, r#"("id" = 1)"#);
+    }
+
+    #[test]
+    fn test_filters_to_sql_multiple() {
+        let f1 = col("id").eq(lit(1i32));
+        let f2 = col("name").eq(lit("foo"));
+        let sql = filters_to_sql(&[f1, f2], &dialect()).expect("filters_to_sql should succeed");
+        assert_eq!(sql, r#"("id" = 1) AND ("name" = 'foo')"#);
+    }
+
+    #[test]
+    fn test_filters_to_sql_empty() {
+        let sql = filters_to_sql(&[], &dialect()).expect("filters_to_sql should succeed");
+        assert_eq!(sql, "");
+    }
+
+    #[test]
+    fn test_assignments_to_sql_single() {
+        let assignments = vec![("name".to_string(), lit("foo"))];
+        let sql = assignments_to_sql(&assignments, &dialect())
+            .expect("assignments_to_sql should succeed");
+        assert_eq!(sql, "name = 'foo'");
+    }
+
+    #[test]
+    fn test_assignments_to_sql_multiple() {
+        let assignments = vec![
+            ("name".to_string(), lit("foo")),
+            ("age".to_string(), lit(30i32)),
+        ];
+        let sql = assignments_to_sql(&assignments, &dialect())
+            .expect("assignments_to_sql should succeed");
+        assert_eq!(sql, "name = 'foo', age = 30");
+    }
+}

--- a/crates/common/src/util/mod.rs
+++ b/crates/common/src/util/mod.rs
@@ -8,6 +8,8 @@ use crate::UnsupportedTypeAction;
 
 pub mod column_reference;
 pub mod constraints;
+pub mod count_exec;
+pub mod dml;
 pub mod indexes;
 pub mod ns_lookup;
 pub mod on_conflict;

--- a/crates/common/src/util/schema.rs
+++ b/crates/common/src/util/schema.rs
@@ -1,11 +1,59 @@
-use std::sync::Arc;
+use std::{
+    collections::{HashMap, HashSet},
+    sync::Arc,
+};
 
 use super::handle_unsupported_type_error;
 use crate::UnsupportedTypeAction;
-use datafusion::arrow::datatypes::{DataType, Field, SchemaBuilder, SchemaRef};
+use datafusion::arrow::datatypes::{DataType, Field, Schema, SchemaBuilder, SchemaRef};
 
 type GenericError = Box<dyn std::error::Error + Send + Sync>;
 type Result<T, E = GenericError> = std::result::Result<T, E>;
+
+/// Merge an inferred schema with a declared schema.
+///
+/// Declared fields override inferred fields with the same name; inferred-only
+/// fields are kept, and declared-only fields are appended.
+#[must_use]
+pub fn merge_inferred_and_declared_schemas(
+    inferred: SchemaRef,
+    declared: Option<&SchemaRef>,
+) -> SchemaRef {
+    let Some(declared) = declared else {
+        return inferred;
+    };
+
+    let declared_by_name: HashMap<&str, &Field> = declared
+        .fields()
+        .iter()
+        .map(|f| (f.name().as_str(), f.as_ref()))
+        .collect();
+    let inferred_names: HashSet<&str> = inferred
+        .fields()
+        .iter()
+        .map(|f| f.name().as_str())
+        .collect();
+
+    let mut merged: Vec<Field> = inferred
+        .fields()
+        .iter()
+        .map(|f| {
+            declared_by_name
+                .get(f.name().as_str())
+                .copied()
+                .cloned()
+                .unwrap_or_else(|| f.as_ref().clone())
+        })
+        .collect();
+
+    for field in declared.fields() {
+        if !inferred_names.contains(field.name().as_str()) {
+            merged.push(field.as_ref().clone());
+        }
+    }
+
+    Arc::new(Schema::new(merged))
+}
 
 pub trait SchemaValidator {
     type Error: std::error::Error + Send + Sync;

--- a/crates/duckdb/Cargo.toml
+++ b/crates/duckdb/Cargo.toml
@@ -33,6 +33,11 @@ uuid = { version = "1.18" }
 default = ["federation"]
 federation = ["dep:datafusion-federation", "datafusion-table-providers-common/federation"]
 
+[dev-dependencies]
+reqwest = "0.13"
+tempfile = "3.27.0"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+
 [package.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]

--- a/crates/duckdb/src/conn.rs
+++ b/crates/duckdb/src/conn.rs
@@ -2,7 +2,9 @@ use std::any::Any;
 use std::collections::HashSet;
 use std::sync::Arc;
 
-use arrow::array::RecordBatch;
+use arrow::array::{ArrayRef, RecordBatch};
+use arrow::compute::cast;
+use arrow_schema::ArrowError;
 use arrow_schema::{DataType, Field};
 use async_stream::stream;
 use datafusion::arrow::datatypes::SchemaRef;
@@ -63,11 +65,44 @@ impl<T: ToSql + Sync + Send + DynClone> DuckDBSyncParameter for T {
 dyn_clone::clone_trait_object!(DuckDBSyncParameter);
 pub type DuckDBParameter = Box<dyn DuckDBSyncParameter>;
 
+/// Filesystem identity used to detect when a database path has been replaced.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct FileIdentity {
+    device: u64,
+    inode: u64,
+}
+
+/// Read the identity of `path`, or `None` when it cannot be determined.
+#[must_use]
+pub fn file_identity(path: &str) -> Option<FileIdentity> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::MetadataExt;
+        let metadata = std::fs::metadata(path).ok()?;
+        Some(FileIdentity {
+            device: metadata.dev(),
+            inode: metadata.ino(),
+        })
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = path;
+        None
+    }
+}
+
+#[derive(Debug)]
+struct AttachedState {
+    search_path: Arc<str>,
+    identities: Vec<(Arc<str>, Option<FileIdentity>)>,
+}
+
 #[derive(Debug)]
 pub struct DuckDBAttachments {
     attachments: HashSet<Arc<str>>,
     random_id: String,
     main_db: String,
+    attached: std::sync::Mutex<Option<AttachedState>>,
 }
 
 impl DuckDBAttachments {
@@ -80,7 +115,23 @@ impl DuckDBAttachments {
             attachments,
             random_id,
             main_db: main_db.to_string(),
+            attached: std::sync::Mutex::new(None),
         }
+    }
+
+    fn attachment_identities(&self) -> Vec<(Arc<str>, Option<FileIdentity>)> {
+        let mut identities: Vec<_> = self
+            .attachments
+            .iter()
+            .map(|path| (Arc::clone(path), file_identity(path)))
+            .collect();
+        identities.sort_by(|(left, _), (right, _)| left.cmp(right));
+        identities
+    }
+
+    #[must_use]
+    pub fn attachments(&self) -> &HashSet<Arc<str>> {
+        &self.attachments
     }
 
     /// Returns the search path for the given database and attachments.
@@ -211,6 +262,45 @@ impl DuckDBAttachments {
     fn get_attachment_name(random_id: &str, index: usize) -> String {
         format!("attachment_{random_id}_{index}")
     }
+
+    /// Attach once per DuckDB instance and re-attach when a backing file at an
+    /// attachment path has been replaced.
+    pub fn attach_once(&self, conn: &Connection) -> Result<()> {
+        let identities = self.attachment_identities();
+        let search_path = {
+            let mut attached = self
+                .attached
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+
+            match attached.as_ref() {
+                Some(state) if state.identities == identities => Arc::clone(&state.search_path),
+                previous => {
+                    if previous.is_some() {
+                        tracing::debug!(
+                            "Re-attaching DuckDB databases {:?}: an attached file was replaced",
+                            self.attachments
+                        );
+                        if let Err(error) = self.detach(conn) {
+                            tracing::warn!(
+                                "Failed to detach replaced DuckDB databases; retrying on the next checkout: {error}"
+                            );
+                        }
+                    }
+                    let search_path = self.attach(conn)?;
+                    *attached = Some(AttachedState {
+                        search_path: Arc::clone(&search_path),
+                        identities,
+                    });
+                    search_path
+                }
+            }
+        };
+
+        conn.execute(&format!("SET search_path = '{}'", search_path), [])
+            .context(DuckDBConnectionSnafu)?;
+        Ok(())
+    }
 }
 
 pub struct DuckDbConnection {
@@ -293,7 +383,7 @@ impl DuckDbConnection {
     /// See `DuckDBAttachments::attach` for more information.
     pub fn attach(conn: &Connection, attachments: &Option<Arc<DuckDBAttachments>>) -> Result<()> {
         if let Some(attachments) = attachments {
-            attachments.attach(conn)?;
+            attachments.attach_once(conn)?;
         }
         Ok(())
     }
@@ -439,7 +529,7 @@ impl SyncDbConnection<r2d2::PooledConnection<DuckdbConnectionManager>, DuckDBPar
         &self,
         sql: &str,
         params: &[DuckDBParameter],
-        _projected_schema: Option<SchemaRef>,
+        projected_schema: Option<SchemaRef>,
     ) -> Result<SendableRecordBatchStream> {
         let (batch_tx, mut batch_rx) = tokio::sync::mpsc::channel::<RecordBatch>(4);
 
@@ -459,7 +549,8 @@ impl SyncDbConnection<r2d2::PooledConnection<DuckdbConnectionManager>, DuckDBPar
             .boxed()
             .context(datafusion_table_providers_common::sql::db_connection_pool::dbconnection::UnableToGetSchemaSnafu)?;
 
-        let schema = result.get_schema();
+        let schema = projected_schema.unwrap_or_else(|| result.get_schema());
+        let cast_schema = Arc::clone(&schema);
 
         let params = params.iter().map(dyn_clone::clone).collect::<Vec<_>>();
 
@@ -474,8 +565,9 @@ impl SyncDbConnection<r2d2::PooledConnection<DuckdbConnectionManager>, DuckDBPar
                     .collect::<Vec<_>>();
                 let result: duckdb::ArrowStream<'_> =
                     stmt.stream_arrow(params).context(DuckDBQuerySnafu)?;
-                for i in result {
-                    blocking_channel_send(&batch_tx, i)?;
+                for batch in result {
+                    let batch = cast_batch_to_schema(batch, &cast_schema)?;
+                    blocking_channel_send(&batch_tx, batch)?;
                 }
                 Ok::<_, Box<dyn std::error::Error + Send + Sync>>(())
             });
@@ -518,6 +610,34 @@ impl SyncDbConnection<r2d2::PooledConnection<DuckdbConnectionManager>, DuckDBPar
         let rows_modified = self.conn.execute(sql, params).context(DuckDBQuerySnafu)?;
         Ok(rows_modified as u64)
     }
+}
+
+fn cast_batch_to_schema(
+    batch: RecordBatch,
+    schema: &SchemaRef,
+) -> std::result::Result<RecordBatch, ArrowError> {
+    if batch.num_columns() != schema.fields().len() {
+        return Err(ArrowError::SchemaError(format!(
+            "DuckDB returned {} columns for projected schema with {} fields",
+            batch.num_columns(),
+            schema.fields().len()
+        )));
+    }
+
+    let columns: std::result::Result<Vec<ArrayRef>, ArrowError> = batch
+        .columns()
+        .iter()
+        .zip(schema.fields())
+        .map(|(column, field)| {
+            if column.data_type() == field.data_type() {
+                Ok(Arc::clone(column))
+            } else {
+                cast(column, field.data_type())
+            }
+        })
+        .collect();
+
+    RecordBatch::try_new(Arc::clone(schema), columns?)
 }
 
 fn blocking_channel_send<T>(channel: &Sender<T>, item: T) -> Result<()> {
@@ -760,7 +880,7 @@ mod tests {
             .into();
 
         for db in [&db1, &db2, &db3] {
-            let conn1 = Connection::open(db.as_ref())?;
+            let conn1 = Connection::open(db.as_ref() as &str)?;
             conn1.execute("CREATE TABLE test1 (id INTEGER, name VARCHAR)", [])?;
         }
 

--- a/crates/duckdb/src/creator.rs
+++ b/crates/duckdb/src/creator.rs
@@ -11,7 +11,7 @@ use itertools::Itertools;
 use snafu::prelude::*;
 use std::collections::HashSet;
 use std::fmt::Display;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 use super::DuckDB;
 use datafusion_table_providers_common::util::{
@@ -44,35 +44,45 @@ impl From<TableReference> for RelationName {
 
 /// A table definition, which includes the table name, schema, constraints, and indexes.
 /// This is used to store the definition of a table for a dataset, and can be re-used to create one or more tables (like internal data tables).
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug)]
 pub struct TableDefinition {
     name: RelationName,
     schema: SchemaRef,
     constraints: Option<Constraints>,
     indexes: Vec<(ColumnReference, IndexType)>,
+    ignored_index_prefixes: Mutex<Vec<String>>,
 }
 
 impl TableDefinition {
     #[must_use]
-    pub(crate) fn new(name: RelationName, schema: SchemaRef) -> Self {
+    pub fn new(name: RelationName, schema: SchemaRef) -> Self {
         Self {
             name,
             schema,
             constraints: None,
             indexes: Vec::new(),
+            ignored_index_prefixes: Mutex::new(Vec::new()),
         }
     }
 
     #[must_use]
-    pub(crate) fn with_constraints(mut self, constraints: Constraints) -> Self {
+    pub fn with_constraints(mut self, constraints: Constraints) -> Self {
         self.constraints = Some(constraints);
         self
     }
 
     #[must_use]
-    pub(crate) fn with_indexes(mut self, indexes: Vec<(ColumnReference, IndexType)>) -> Self {
+    pub fn with_indexes(mut self, indexes: Vec<(ColumnReference, IndexType)>) -> Self {
         self.indexes = indexes;
         self
+    }
+
+    /// Ignore indexes managed outside this writer when checking index drift.
+    pub fn add_ignored_index_prefix(&self, prefix: impl Into<String>) {
+        self.ignored_index_prefixes
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .push(prefix.into());
     }
 
     #[must_use]
@@ -80,8 +90,7 @@ impl TableDefinition {
         &self.name
     }
 
-    #[cfg(test)]
-    pub(crate) fn schema(&self) -> SchemaRef {
+    pub fn schema(&self) -> SchemaRef {
         Arc::clone(&self.schema)
     }
 
@@ -97,7 +106,7 @@ impl TableDefinition {
         )))
     }
 
-    pub(crate) fn constraints(&self) -> Option<&Constraints> {
+    pub fn constraints(&self) -> Option<&Constraints> {
         self.constraints.as_ref()
     }
 
@@ -168,17 +177,53 @@ impl TableDefinition {
             .map(|(name, time_created)| (RelationName(name), time_created))
             .collect())
     }
+
+    /// Resolve the physical table targeted by DELETE and UPDATE. Overwrites
+    /// expose a view backed by the latest internal table, and DuckDB cannot
+    /// apply DML directly to that view.
+    pub fn resolve_dml_table_name(&self, tx: &Transaction<'_>) -> super::Result<String> {
+        let internal_tables = self.list_internal_tables(tx)?;
+        Ok(internal_tables
+            .last()
+            .map_or_else(|| self.name.to_string(), |(name, _)| name.to_string()))
+    }
+}
+
+impl PartialEq for TableDefinition {
+    fn eq(&self, other: &Self) -> bool {
+        self.name == other.name
+            && self.schema == other.schema
+            && self.constraints == other.constraints
+            && self.indexes == other.indexes
+    }
+}
+
+impl Clone for TableDefinition {
+    fn clone(&self) -> Self {
+        let ignored_index_prefixes = self
+            .ignored_index_prefixes
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .clone();
+        Self {
+            name: self.name.clone(),
+            schema: Arc::clone(&self.schema),
+            constraints: self.constraints.clone(),
+            indexes: self.indexes.clone(),
+            ignored_index_prefixes: Mutex::new(ignored_index_prefixes),
+        }
+    }
 }
 
 /// A table creator, which is used to create, delete, and manage tables based on a `TableDefinition`.
 #[derive(Debug, Clone)]
-pub(crate) struct TableManager {
+pub struct TableManager {
     table_definition: Arc<TableDefinition>,
     internal_name: Option<RelationName>,
 }
 
 impl TableManager {
-    pub(crate) fn new(table_definition: Arc<TableDefinition>) -> Self {
+    pub fn new(table_definition: Arc<TableDefinition>) -> Self {
         Self {
             table_definition,
             internal_name: None,
@@ -186,7 +231,7 @@ impl TableManager {
     }
 
     /// Set the internal flag for the table creator.
-    pub(crate) fn with_internal(mut self, is_internal: bool) -> super::Result<Self> {
+    pub fn with_internal(mut self, is_internal: bool) -> super::Result<Self> {
         if is_internal {
             self.internal_name = Some(self.table_definition.generate_internal_name()?);
         } else {
@@ -196,12 +241,12 @@ impl TableManager {
         Ok(self)
     }
 
-    pub(crate) fn definition_name(&self) -> &RelationName {
+    pub fn definition_name(&self) -> &RelationName {
         &self.table_definition.name
     }
 
     /// Returns the canonical name for this table, which is the internal name if the table is internal, or the table name if it is not.
-    pub(crate) fn table_name(&self) -> &RelationName {
+    pub fn table_name(&self) -> &RelationName {
         self.internal_name
             .as_ref()
             .unwrap_or_else(|| &self.table_definition.name)
@@ -605,8 +650,18 @@ impl TableManager {
             .map(|index| index.replace(&self.table_name().to_string(), ""))
             .collect::<HashSet<_>>();
 
+        let ignored_index_prefixes = self
+            .table_definition
+            .ignored_index_prefixes
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let actual_indexes_str_map = actual_indexes_str_map
             .iter()
+            .filter(|index| {
+                !ignored_index_prefixes
+                    .iter()
+                    .any(|prefix| index.starts_with(prefix))
+            })
             .map(|index| index.replace(&other_table.table_name().to_string(), ""))
             .collect::<HashSet<_>>();
 
@@ -669,12 +724,10 @@ impl TableManager {
 
 #[cfg(test)]
 pub(crate) mod tests {
-    use crate::{
-        duckdb::make_initial_table, sql::db_connection_pool::crate::conn::DuckDbConnection,
-    };
+    use crate::{conn::DuckDbConnection, make_initial_table};
     use datafusion::{arrow::array::RecordBatch, datasource::sink::DataSink};
     use datafusion::{
-        common::SchemaExt,
+        common::{Constraint, SchemaExt},
         execution::{SendableRecordBatchStream, TaskContext},
         logical_expr::dml::InsertOp,
         parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder,
@@ -683,12 +736,29 @@ pub(crate) mod tests {
     use tracing::subscriber::DefaultGuard;
     use tracing_subscriber::EnvFilter;
 
-    use crate::{
-        duckdb::write::DuckDBDataSink,
-        util::constraints::tests::{get_pk_constraints, get_unique_constraints},
-    };
+    use crate::write::DuckDBDataSink;
 
     use super::*;
+
+    fn constraints_for(
+        columns: &[&str],
+        schema: SchemaRef,
+        make: impl FnOnce(Vec<usize>) -> Constraint,
+    ) -> Constraints {
+        let indices = columns
+            .iter()
+            .filter_map(|name| schema.column_with_name(name).map(|(index, _)| index))
+            .collect();
+        Constraints::new_unverified(vec![make(indices)])
+    }
+
+    fn get_unique_constraints(columns: &[&str], schema: SchemaRef) -> Constraints {
+        constraints_for(columns, schema, Constraint::Unique)
+    }
+
+    fn get_pk_constraints(columns: &[&str], schema: SchemaRef) -> Constraints {
+        constraints_for(columns, schema, Constraint::PrimaryKey)
+    }
 
     pub(crate) fn get_mem_duckdb() -> Arc<DuckDbConnectionPool> {
         Arc::new(

--- a/crates/duckdb/src/file_swap.rs
+++ b/crates/duckdb/src/file_swap.rs
@@ -1,0 +1,1360 @@
+//! Full-refresh database **file swap** for file-backed DuckDB instances.
+//!
+//! An `InsertOp::Overwrite` normally rewrites a dataset's backing table inside
+//! the live database file. DuckDB only reclaims the space of dropped tables at
+//! a CHECKPOINT, and bulk loads bypass the WAL, so the WAL-growth trigger for
+//! automatic checkpoints never fires — the live file grows without bound.
+//! Running `CHECKPOINT` on the live instance is not an option under load: a
+//! standard checkpoint fails while other transactions are active, and `FORCE
+//! CHECKPOINT` aborts them.
+//!
+//! The swap path instead performs the overwrite into a *fresh* database file
+//! and atomically replaces the live file with it:
+//!
+//! 1. **Stage** — stream the refreshed data into a new staging file (a private
+//!    DuckDB instance), using the same internal-table + view layout as an
+//!    in-place overwrite. The live instance serves queries untouched.
+//! 2. **Copy** — under the pool's exclusive write gate (writers are paused,
+//!    readers are not), attach the staging file to the live instance and copy
+//!    every *other* table, view, and index — including metadata tables and
+//!    other datasets sharing the file — into it. The refreshed dataset's stale
+//!    tables are deliberately left behind; that is where the space is
+//!    reclaimed.
+//! 3. **Checkpoint** — checkpoint and cleanly detach the staging file, so it is
+//!    a compact, WAL-free, self-contained database.
+//! 4. **Swap** — rename the staging file over the live path and atomically
+//!    repoint the connection pool at it. In-flight readers drain against the
+//!    old instance; new checkouts observe the new file.
+//!
+//! # Why the old instance can never corrupt the new file
+//!
+//! DuckDB removes a database's WAL *by path* when a checkpoint completes
+//! (including the shutdown checkpoint), so an old draining instance could
+//! delete the new instance's WAL if both used the same path. Two measures
+//! prevent this:
+//!
+//! - Writers are excluded for the entire swap by the write gate, and every
+//!   post-swap write goes to the new pool — the old instance never commits
+//!   (and therefore never checkpoints) again after the swap begins.
+//! - `PRAGMA disable_checkpoint_on_shutdown` is applied to the old instance
+//!   before the swap, so its eventual close performs no checkpoint and never
+//!   touches the WAL path.
+//!
+//! The old database file is unlinked immediately after the swap; the draining
+//! instance keeps reading it through its open file descriptors (the inode
+//! outlives the unlink). If the unlink is denied (e.g. Windows holds the file
+//! open), the pool serves the generation-named file instead and a restart
+//! normalizes the path via [`recover_database_file_generations`].
+
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use datafusion::common::Result as DataFusionResult;
+use duckdb::Connection;
+use snafu::prelude::*;
+use tokio::sync::mpsc::Receiver;
+
+use super::creator::{TableDefinition, TableManager};
+use super::write::{execute_analyze_sql, write_to_table, WriteContext};
+use super::{to_datafusion_error, DuckDB};
+use crate::pool::DuckDbConnectionPool;
+use datafusion_table_providers_common::util::retriable_error::to_retriable_data_write_error;
+
+/// Infix appended to the configured database path for swap generation files:
+/// `{configured}.refresh.{unix_ms}-{seq}` (plus `.building` while the staging
+/// file is still being produced).
+const GENERATION_INFIX: &str = ".refresh.";
+const BUILDING_SUFFIX: &str = ".building";
+const WAL_SUFFIX: &str = ".wal";
+
+/// Monotonic per-process sequence, combined with a millisecond timestamp so
+/// generation file names never collide within a process lifetime — the naming
+/// guarantee that keeps a retiring instance's WAL path disjoint from every
+/// newer generation.
+static GENERATION_SEQ: AtomicU64 = AtomicU64::new(0);
+
+fn wal_path_of(db_path: &str) -> String {
+    format!("{db_path}{WAL_SUFFIX}")
+}
+
+/// Always-quote an identifier for DuckDB SQL, escaping embedded quotes.
+/// Unconditional quoting matters because generation catalogs and user table
+/// names may contain dots or reserved words.
+fn quote_ident(identifier: &str) -> String {
+    format!("\"{}\"", identifier.replace('"', "\"\""))
+}
+
+fn escape_string_literal(value: &str) -> String {
+    value.replace('\'', "''")
+}
+
+/// Best-effort file removal: missing files are fine, anything else is reported
+/// to the caller.
+fn remove_file_if_exists(path: &str) -> std::io::Result<bool> {
+    match std::fs::remove_file(path) {
+        Ok(()) => Ok(true),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(false),
+        Err(e) => Err(e),
+    }
+}
+
+/// The outcome of boot-time generation recovery for a configured database path.
+#[derive(Debug, Default)]
+pub struct SwapFileRecovery {
+    /// A completed generation file that was adopted (renamed to the configured
+    /// path) because the configured file was missing.
+    pub adopted: Option<PathBuf>,
+    /// Leftover swap files that were removed.
+    pub removed: Vec<PathBuf>,
+}
+
+/// Recover from an interrupted database file swap at process startup, before
+/// any DuckDB pool has been created for `configured_path`.
+///
+/// Rules, in order:
+/// - `*.refresh.*.building` files (and their WALs) are incomplete staging
+///   output from a crashed swap and are always deleted.
+/// - If the configured file exists, it is authoritative: every completed
+///   generation file is deleted. (A generation that was fully built but whose
+///   swap never finished holds a refresh that was never acknowledged — the
+///   refresh re-runs against the configured file.)
+/// - If the configured file is missing, the newest completed generation is
+///   adopted: renamed to the configured path together with its WAL if one
+///   exists. Older generations are deleted.
+///
+/// Callers must ensure no DuckDB instance has `configured_path` (or any of its
+/// generation files) open, and must run this at most once per path per
+/// process.
+///
+/// # Errors
+///
+/// Returns an error if the directory cannot be enumerated or the adoption
+/// rename fails. Failures to delete stale files are logged and skipped.
+pub fn recover_database_file_generations(
+    configured_path: &str,
+) -> std::io::Result<SwapFileRecovery> {
+    let configured = Path::new(configured_path);
+    let dir = match configured.parent() {
+        Some(parent) if !parent.as_os_str().is_empty() => parent.to_path_buf(),
+        _ => PathBuf::from("."),
+    };
+    let Some(file_name) = configured.file_name().and_then(|n| n.to_str()) else {
+        return Ok(SwapFileRecovery::default());
+    };
+    if !dir.exists() {
+        return Ok(SwapFileRecovery::default());
+    }
+
+    let generation_prefix = format!("{file_name}{GENERATION_INFIX}");
+    let mut generations: Vec<(u128, u64, PathBuf)> = Vec::new();
+    let mut leftovers: Vec<PathBuf> = Vec::new();
+
+    for entry in std::fs::read_dir(&dir)? {
+        let entry = entry?;
+        let name = entry.file_name();
+        let Some(name) = name.to_str() else { continue };
+        let Some(suffix) = name.strip_prefix(generation_prefix.as_str()) else {
+            continue;
+        };
+
+        if let Some((ts, seq)) = parse_generation_suffix(suffix) {
+            generations.push((ts, seq, entry.path()));
+        } else {
+            // `.building`, `.wal`, `.building.wal`, or unrecognized debris.
+            leftovers.push(entry.path());
+        }
+    }
+
+    let mut recovery = SwapFileRecovery::default();
+
+    // Adopt the newest completed generation only when the configured file is
+    // gone (the swap that produced it got past the point of unlinking the old
+    // file, so the generation is the authoritative newest state).
+    if !configured.exists() {
+        generations.sort_by_key(|(ts, seq, _)| (*ts, *seq));
+        if let Some((_, _, newest)) = generations.pop() {
+            let newest_str = newest.to_string_lossy().to_string();
+            let generation_wal = wal_path_of(&newest_str);
+            std::fs::rename(&newest, configured)?;
+            if Path::new(&generation_wal).exists() {
+                std::fs::rename(&generation_wal, wal_path_of(configured_path))?;
+            }
+            tracing::warn!(
+                "Recovered DuckDB database file {configured_path} from interrupted file swap generation {newest_str}"
+            );
+            recovery.adopted = Some(newest);
+        }
+    }
+
+    for (_, _, stale) in generations {
+        // A completed generation's WAL (if any) is enumerated separately as a
+        // leftover, so removing the database file alone is sufficient here.
+        match std::fs::remove_file(&stale) {
+            Ok(()) => recovery.removed.push(stale),
+            Err(e) => {
+                tracing::warn!(
+                    "Failed to remove stale DuckDB file swap generation {}: {e}",
+                    stale.display()
+                );
+            }
+        }
+    }
+    for leftover in leftovers {
+        // Never remove the WAL belonging to the file just adopted.
+        if let Some(adopted) = &recovery.adopted {
+            let adopted_wal = wal_path_of(&adopted.to_string_lossy());
+            if leftover.to_string_lossy() == adopted_wal.as_str() {
+                continue;
+            }
+        }
+        match std::fs::remove_file(&leftover) {
+            Ok(()) => recovery.removed.push(leftover),
+            Err(e) => {
+                tracing::warn!(
+                    "Failed to remove leftover DuckDB file swap artifact {}: {e}",
+                    leftover.display()
+                );
+            }
+        }
+    }
+
+    Ok(recovery)
+}
+
+fn parse_generation_suffix(suffix: &str) -> Option<(u128, u64)> {
+    let (ts, seq) = suffix.split_once('-')?;
+    let ts = ts.parse::<u128>().ok()?;
+    let seq = seq.parse::<u64>().ok()?;
+    Some((ts, seq))
+}
+
+/// Removes staging files on drop unless disarmed, so a failed swap never
+/// leaves partially built database files behind.
+struct StagingCleanup {
+    building_path: String,
+    armed: bool,
+}
+
+impl Drop for StagingCleanup {
+    fn drop(&mut self) {
+        if !self.armed {
+            return;
+        }
+        for path in [self.building_path.clone(), wal_path_of(&self.building_path)] {
+            if let Err(e) = remove_file_if_exists(&path) {
+                tracing::warn!("Failed to clean up DuckDB file swap staging file {path}: {e}");
+            }
+        }
+    }
+}
+
+/// `InsertOp::Overwrite` via database file swap. See the module docs for the
+/// full protocol.
+pub(super) fn insert_overwrite_swap(
+    pool: Arc<DuckDbConnectionPool>,
+    table_definition: &Arc<TableDefinition>,
+    batch_rx: Receiver<arrow::array::RecordBatch>,
+    mut on_commit_transaction: tokio::sync::oneshot::Receiver<()>,
+    context: &WriteContext<'_>,
+) -> DataFusionResult<u64> {
+    let configured_path = pool.db_path().to_string();
+
+    let unix_ms = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .context(super::UnableToGetSystemTimeSnafu)
+        .map_err(to_datafusion_error)?
+        .as_millis();
+    let seq = GENERATION_SEQ.fetch_add(1, Ordering::Relaxed);
+    let generation_path = format!("{configured_path}{GENERATION_INFIX}{unix_ms}-{seq}");
+    let building_path = format!("{generation_path}{BUILDING_SUFFIX}");
+
+    let mut cleanup = StagingCleanup {
+        building_path: building_path.clone(),
+        armed: true,
+    };
+
+    // ---- Phase 1: stage the refreshed data into a private instance. ----
+    // No locks are held: the live file keeps serving reads and unrelated
+    // writes while the (potentially long) source stream loads.
+    let num_rows =
+        stage_refreshed_data(&pool, table_definition, &building_path, batch_rx, context)?;
+
+    on_commit_transaction
+        .try_recv()
+        .map_err(to_retriable_data_write_error)?;
+
+    // ---- Phase 2: copy live content and swap, writers excluded. ----
+    let write_gate = pool.write_gate();
+    let _exclusive = write_gate
+        .write()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+
+    copy_live_contents_into_staging(&pool, table_definition, &building_path)?;
+    complete_swap(&pool, &building_path, &generation_path)?;
+
+    cleanup.armed = false;
+    Ok(num_rows)
+}
+
+/// Phase 1: build the staging database file with the refreshed dataset,
+/// checkpointed and cleanly closed (no WAL left on disk).
+fn stage_refreshed_data(
+    pool: &Arc<DuckDbConnectionPool>,
+    table_definition: &Arc<TableDefinition>,
+    building_path: &str,
+    batch_rx: Receiver<arrow::array::RecordBatch>,
+    context: &WriteContext<'_>,
+) -> DataFusionResult<u64> {
+    for stale in [building_path.to_string(), wal_path_of(building_path)] {
+        remove_file_if_exists(&stale)
+            .context(super::UnableToPrepareFileSwapSnafu { path: stale })
+            .map_err(to_retriable_data_write_error)?;
+    }
+
+    let mut staging_conn = open_staging_instance(pool, building_path)?;
+
+    let new_table = TableManager::new(Arc::clone(table_definition))
+        .with_internal(true)
+        .map_err(to_retriable_data_write_error)?;
+
+    let tx = staging_conn
+        .transaction()
+        .context(super::UnableToBeginTransactionSnafu)
+        .map_err(to_retriable_data_write_error)?;
+
+    // The CREATE TABLE statement is derived from the Arrow schema on a live
+    // pool connection (created and rolled back there); it executes on the
+    // staging transaction.
+    new_table
+        .create_table(Arc::clone(pool), &tx)
+        .map_err(to_retriable_data_write_error)?;
+
+    tracing::debug!(
+        "Staged overwrite load for {table_name} into {building_path}",
+        table_name = new_table.table_name()
+    );
+    let num_rows = write_to_table(
+        &new_table,
+        &tx,
+        Arc::clone(context.schema),
+        batch_rx,
+        context.on_conflict,
+    )?;
+
+    new_table
+        .create_view(&tx)
+        .map_err(to_retriable_data_write_error)?;
+
+    if let Some(callback) = context.on_data_written {
+        callback(&tx, &new_table, context.schema, num_rows)?;
+    }
+
+    // Mirrors the in-place overwrite: the completion handler may already have
+    // created the configured indexes; `CREATE INDEX IF NOT EXISTS` makes this
+    // a no-op in that case.
+    new_table
+        .create_indexes(&tx)
+        .map_err(to_retriable_data_write_error)?;
+
+    if context.settings.recompute_statistics_on_write {
+        execute_analyze_sql(&tx, &new_table.table_name().to_string());
+    }
+
+    tx.commit()
+        .context(super::UnableToCommitTransactionSnafu)
+        .map_err(to_retriable_data_write_error)?;
+
+    // Flush everything into the database file and close cleanly so no WAL
+    // survives; a WAL here would ride along under the live path after the
+    // rename and be replayed against the wrong database identity.
+    staging_conn
+        .execute("CHECKPOINT", [])
+        .context(super::UnableToCheckpointSwapStagingSnafu {
+            path: building_path.to_string(),
+        })
+        .map_err(to_retriable_data_write_error)?;
+    drop(staging_conn);
+
+    let staging_wal = wal_path_of(building_path);
+    if Path::new(&staging_wal).exists() {
+        return Err(to_datafusion_error(super::Error::FileSwapWalPresent {
+            path: staging_wal,
+        }));
+    }
+
+    Ok(num_rows)
+}
+
+fn open_staging_instance(
+    pool: &Arc<DuckDbConnectionPool>,
+    building_path: &str,
+) -> DataFusionResult<Connection> {
+    let conn = Connection::open(building_path)
+        .context(super::UnableToOpenSwapStagingSnafu {
+            path: building_path.to_string(),
+        })
+        .map_err(to_retriable_data_write_error)?;
+
+    conn.register_table_function::<duckdb::vtab::arrow::ArrowVTab>("arrow")
+        .context(super::UnableToOpenSwapStagingSnafu {
+            path: building_path.to_string(),
+        })
+        .map_err(to_retriable_data_write_error)?;
+
+    // Mirror the live instance's configuration so the staging load runs under
+    // the same limits (memory limit, temp directory, checkpoint threshold, …).
+    let mut setup: Vec<Arc<str>> = pool.instance_setup_queries();
+    setup.extend(pool.connection_setup_queries().iter().cloned());
+    for statement in setup {
+        if let Err(e) = conn.execute(&statement, []) {
+            tracing::warn!(
+                "Failed to apply setting to DuckDB file swap staging instance ({statement}): {e}"
+            );
+        }
+    }
+
+    Ok(conn)
+}
+
+/// A table/view/index copy plan entry.
+struct LiveObject {
+    schema_name: String,
+    name: String,
+    sql: String,
+}
+
+/// Phase 2a: copy every live object that does **not** belong to the refreshed
+/// dataset into the staging file, through the live instance (so data that is
+/// still only in the live WAL is included). Runs with the write gate held
+/// exclusively; concurrent readers are unaffected.
+fn copy_live_contents_into_staging(
+    pool: &Arc<DuckDbConnectionPool>,
+    table_definition: &Arc<TableDefinition>,
+    building_path: &str,
+) -> DataFusionResult<()> {
+    // A private (non-pooled) session on the live instance: `USE` leaks session
+    // state, so it must never run on a connection that returns to the pool.
+    let mut pooled = Arc::clone(pool)
+        .connect_sync()
+        .context(super::DbConnectionPoolSnafu)
+        .map_err(to_retriable_data_write_error)?;
+    let live_conn = DuckDB::duckdb_conn(&mut pooled)
+        .map_err(to_retriable_data_write_error)?
+        .get_underlying_conn_mut()
+        .try_clone()
+        .context(super::UnableToCopyLiveDatabaseSnafu {
+            detail: "clone live connection".to_string(),
+        })
+        .map_err(to_retriable_data_write_error)?;
+    drop(pooled);
+
+    let live_catalog: String = live_conn
+        .query_row("SELECT current_database()", [], |r| r.get(0))
+        .context(super::UnableToCopyLiveDatabaseSnafu {
+            detail: "resolve live catalog".to_string(),
+        })
+        .map_err(to_retriable_data_write_error)?;
+
+    let seq = GENERATION_SEQ.fetch_add(1, Ordering::Relaxed);
+    let stage_alias = format!("__dftp_swap_stage_{seq}");
+
+    let result = copy_with_attached_staging(
+        &live_conn,
+        table_definition,
+        building_path,
+        &live_catalog,
+        &stage_alias,
+    );
+
+    // Whatever happened, restore the session catalog and detach the staging
+    // file. The staging file must not remain attached past this point: renaming
+    // a still-attached file into the live path would leave two instances
+    // writing the same inode.
+    let _ = live_conn.execute(&format!("USE {}", quote_ident(&live_catalog)), []);
+    let detach = live_conn
+        .execute(&format!("DETACH {}", quote_ident(&stage_alias)), [])
+        .context(super::UnableToCopyLiveDatabaseSnafu {
+            detail: "detach staging file".to_string(),
+        })
+        .map_err(to_retriable_data_write_error);
+
+    // The copy error (if any) takes precedence; the detach was still attempted
+    // above so a failed copy never leaks the attachment on the live instance.
+    result?;
+    detach?;
+
+    // The staging file must be complete and WAL-free after the clean detach; a
+    // WAL here would ride along under the live path after the rename and be
+    // replayed against the wrong database identity.
+    let staging_wal = wal_path_of(building_path);
+    if Path::new(&staging_wal).exists() {
+        return Err(to_datafusion_error(super::Error::FileSwapWalPresent {
+            path: staging_wal,
+        }));
+    }
+
+    // The retiring instance must never checkpoint at shutdown: DuckDB removes
+    // the WAL *by path* when a checkpoint completes, and after the swap this
+    // instance's WAL path belongs to the new live file. (The runtime passes
+    // `PRAGMA enable_checkpoint_on_shutdown` as an *instance* setup query, so
+    // no draining connection can re-enable it on this retiring instance.)
+    live_conn
+        .execute("PRAGMA disable_checkpoint_on_shutdown", [])
+        .context(super::UnableToCopyLiveDatabaseSnafu {
+            detail: "disable retiring instance shutdown checkpoint".to_string(),
+        })
+        .map_err(to_retriable_data_write_error)?;
+
+    Ok(())
+}
+
+fn copy_with_attached_staging(
+    live_conn: &Connection,
+    table_definition: &Arc<TableDefinition>,
+    building_path: &str,
+    live_catalog: &str,
+    stage_alias: &str,
+) -> DataFusionResult<()> {
+    live_conn
+        .execute(
+            &format!(
+                "ATTACH '{}' AS {}",
+                escape_string_literal(building_path),
+                quote_ident(stage_alias)
+            ),
+            [],
+        )
+        .context(super::UnableToCopyLiveDatabaseSnafu {
+            detail: format!("attach staging file {building_path}"),
+        })
+        .map_err(to_retriable_data_write_error)?;
+
+    let skip_tables = refreshed_dataset_tables(live_conn, table_definition, live_catalog)?;
+    let base_name = table_definition.name().to_string();
+
+    let tables = query_live_objects(
+        live_conn,
+        &format!(
+            "SELECT schema_name, table_name, sql FROM duckdb_tables() \
+             WHERE database_name = '{live}' AND NOT internal AND NOT temporary \
+             ORDER BY schema_name, table_name",
+            live = escape_string_literal(live_catalog)
+        ),
+        "enumerate live tables",
+    )?;
+    let views = query_live_objects(
+        live_conn,
+        &format!(
+            "SELECT schema_name, view_name, sql FROM duckdb_views() \
+             WHERE database_name = '{live}' AND NOT internal \
+             ORDER BY schema_name, view_name",
+            live = escape_string_literal(live_catalog)
+        ),
+        "enumerate live views",
+    )?;
+    let indexes = query_live_objects(
+        live_conn,
+        &format!(
+            "SELECT schema_name, table_name, sql FROM duckdb_indexes() \
+             WHERE database_name = '{live}' AND sql IS NOT NULL \
+             ORDER BY schema_name, index_name",
+            live = escape_string_literal(live_catalog)
+        ),
+        "enumerate live indexes",
+    )?;
+
+    warn_on_skipped_object_kinds(live_conn, live_catalog);
+
+    let mut hnsw_prepared = false;
+    let mut current_schema: Option<String> = None;
+
+    let use_stage_schema =
+        |schema_name: &str, current: &mut Option<String>| -> DataFusionResult<()> {
+            if current.as_deref() == Some(schema_name) {
+                return Ok(());
+            }
+            if schema_name != "main" {
+                live_conn
+                    .execute(
+                        &format!(
+                            "CREATE SCHEMA IF NOT EXISTS {}.{}",
+                            quote_ident(stage_alias),
+                            quote_ident(schema_name)
+                        ),
+                        [],
+                    )
+                    .context(super::UnableToCopyLiveDatabaseSnafu {
+                        detail: format!("create schema {schema_name} in staging file"),
+                    })
+                    .map_err(to_retriable_data_write_error)?;
+            }
+            live_conn
+                .execute(
+                    &format!(
+                        "USE {}.{}",
+                        quote_ident(stage_alias),
+                        quote_ident(schema_name)
+                    ),
+                    [],
+                )
+                .context(super::UnableToCopyLiveDatabaseSnafu {
+                    detail: format!("switch to staging schema {schema_name}"),
+                })
+                .map_err(to_retriable_data_write_error)?;
+            *current = Some(schema_name.to_string());
+            Ok(())
+        };
+
+    for table in &tables {
+        if skip_tables.contains(&table.name) {
+            continue;
+        }
+        use_stage_schema(&table.schema_name, &mut current_schema)?;
+        live_conn
+            .execute(&table.sql, [])
+            .context(super::UnableToCopyLiveDatabaseSnafu {
+                detail: format!("create table {} in staging file", table.name),
+            })
+            .map_err(to_retriable_data_write_error)?;
+        let insert = format!(
+            "INSERT INTO {schema}.{table} SELECT * FROM {live}.{schema}.{table}",
+            live = quote_ident(live_catalog),
+            schema = quote_ident(&table.schema_name),
+            table = quote_ident(&table.name),
+        );
+        live_conn
+            .execute(&insert, [])
+            .context(super::UnableToCopyLiveDatabaseSnafu {
+                detail: format!("copy rows of table {} into staging file", table.name),
+            })
+            .map_err(to_retriable_data_write_error)?;
+    }
+
+    for index in &indexes {
+        // `duckdb_indexes()` rows carry the owning table in `table_name`.
+        if skip_tables.contains(&index.name) {
+            continue;
+        }
+        if !hnsw_prepared && index.sql.to_uppercase().contains("HNSW") {
+            prepare_hnsw_support(live_conn);
+            hnsw_prepared = true;
+        }
+        use_stage_schema(&index.schema_name, &mut current_schema)?;
+        live_conn
+            .execute(&index.sql, [])
+            .context(super::UnableToCopyLiveDatabaseSnafu {
+                detail: format!("create index on table {} in staging file", index.name),
+            })
+            .map_err(to_retriable_data_write_error)?;
+    }
+
+    for view in &views {
+        if view.name == base_name {
+            // The refreshed dataset's view was already created in the staging
+            // file, pointing at the freshly loaded internal table.
+            continue;
+        }
+        use_stage_schema(&view.schema_name, &mut current_schema)?;
+        live_conn
+            .execute(&view.sql, [])
+            .context(super::UnableToCopyLiveDatabaseSnafu {
+                detail: format!("create view {} in staging file", view.name),
+            })
+            .map_err(to_retriable_data_write_error)?;
+    }
+
+    // Leave the staging catalog as the session default before checkpointing.
+    live_conn
+        .execute(&format!("USE {}", quote_ident(live_catalog)), [])
+        .context(super::UnableToCopyLiveDatabaseSnafu {
+            detail: "restore live catalog".to_string(),
+        })
+        .map_err(to_retriable_data_write_error)?;
+
+    live_conn
+        .execute(&format!("CHECKPOINT {}", quote_ident(stage_alias)), [])
+        .context(super::UnableToCheckpointSwapStagingSnafu {
+            path: building_path.to_string(),
+        })
+        .map_err(to_retriable_data_write_error)?;
+
+    Ok(())
+}
+
+/// The refreshed dataset's own relations in the live file: its base table (if
+/// any) and every `__data_{name}_{ts}` internal table. These are exactly the
+/// relations the swap leaves behind.
+fn refreshed_dataset_tables(
+    live_conn: &Connection,
+    table_definition: &Arc<TableDefinition>,
+    live_catalog: &str,
+) -> DataFusionResult<std::collections::HashSet<String>> {
+    let base_name = table_definition.name().to_string();
+    let mut skip = std::collections::HashSet::from([base_name.clone()]);
+
+    let internal_prefix = format!("__data_{base_name}_");
+    let sql = format!(
+        "SELECT table_name FROM duckdb_tables() \
+         WHERE database_name = '{live}' AND table_name LIKE '{prefix}%'",
+        live = escape_string_literal(live_catalog),
+        prefix = escape_string_literal(&internal_prefix),
+    );
+    let mut stmt = live_conn
+        .prepare(&sql)
+        .context(super::UnableToCopyLiveDatabaseSnafu {
+            detail: "enumerate refreshed dataset internal tables".to_string(),
+        })
+        .map_err(to_retriable_data_write_error)?;
+    let names = stmt
+        .query_map([], |row| row.get::<usize, String>(0))
+        .context(super::UnableToCopyLiveDatabaseSnafu {
+            detail: "enumerate refreshed dataset internal tables".to_string(),
+        })
+        .map_err(to_retriable_data_write_error)?;
+    for name in names {
+        let name = name
+            .context(super::UnableToCopyLiveDatabaseSnafu {
+                detail: "enumerate refreshed dataset internal tables".to_string(),
+            })
+            .map_err(to_retriable_data_write_error)?;
+        // Internal table names end in a millisecond timestamp; anything else
+        // that merely shares the prefix belongs to another dataset.
+        if name
+            .strip_prefix(&internal_prefix)
+            .is_some_and(|suffix| !suffix.is_empty() && suffix.bytes().all(|b| b.is_ascii_digit()))
+        {
+            skip.insert(name);
+        }
+    }
+
+    Ok(skip)
+}
+
+fn query_live_objects(
+    live_conn: &Connection,
+    sql: &str,
+    detail: &str,
+) -> DataFusionResult<Vec<LiveObject>> {
+    let mut stmt = live_conn
+        .prepare(sql)
+        .context(super::UnableToCopyLiveDatabaseSnafu {
+            detail: detail.to_string(),
+        })
+        .map_err(to_retriable_data_write_error)?;
+    let rows = stmt
+        .query_map([], |row| {
+            Ok(LiveObject {
+                schema_name: row.get(0)?,
+                name: row.get(1)?,
+                sql: row.get(2)?,
+            })
+        })
+        .context(super::UnableToCopyLiveDatabaseSnafu {
+            detail: detail.to_string(),
+        })
+        .map_err(to_retriable_data_write_error)?;
+
+    let mut objects = Vec::new();
+    for row in rows {
+        objects.push(
+            row.context(super::UnableToCopyLiveDatabaseSnafu {
+                detail: detail.to_string(),
+            })
+            .map_err(to_retriable_data_write_error)?,
+        );
+    }
+    Ok(objects)
+}
+
+/// Sequences and macros are not part of the accelerator's table layout and are
+/// not copied; surface them loudly if any exist so the omission is never
+/// silent.
+fn warn_on_skipped_object_kinds(live_conn: &Connection, live_catalog: &str) {
+    let live = escape_string_literal(live_catalog);
+    for (kind, sql) in [
+        (
+            "sequences",
+            format!("SELECT COUNT(1) FROM duckdb_sequences() WHERE database_name = '{live}'"),
+        ),
+        (
+            "macros",
+            format!(
+                "SELECT COUNT(1) FROM duckdb_functions() WHERE database_name = '{live}' AND NOT internal"
+            ),
+        ),
+    ] {
+        match live_conn.query_row(&sql, [], |r| r.get::<usize, i64>(0)) {
+            Ok(count) if count > 0 => {
+                tracing::warn!(
+                    "DuckDB file swap does not copy {kind}; {count} {kind} in {live_catalog} will not be carried into the new database file"
+                );
+            }
+            Ok(_) => {}
+            Err(e) => {
+                tracing::debug!("Failed to count {kind} during DuckDB file swap: {e}");
+            }
+        }
+    }
+}
+
+/// HNSW indexes need the `vss` extension and its persistence flag in the
+/// copying session. Best-effort: if this fails, the subsequent CREATE INDEX
+/// fails and aborts the swap with the real error (the live file is untouched).
+fn prepare_hnsw_support(live_conn: &Connection) {
+    for sql in [
+        "INSTALL vss",
+        "LOAD vss",
+        "SET hnsw_enable_experimental_persistence = true",
+    ] {
+        if let Err(e) = live_conn.execute(sql, []) {
+            tracing::warn!(
+                "DuckDB file swap: '{sql}' failed while preparing to copy an HNSW index: {e}"
+            );
+        }
+    }
+}
+
+/// Phase 2b: move the completed staging file into place and repoint the pool.
+///
+/// Ordering (all under the exclusive write gate):
+/// 1. `rename(building, generation)` — marks the staging output complete;
+///    recovery adopts completed generations, never `.building` files.
+/// 2. Unlink the old database file and its WAL. From here the configured path
+///    is free; a crash before step 3 is healed at boot by adopting the
+///    generation.
+/// 3. `rename(generation, configured)` — the new file takes the live name.
+/// 4. Repoint the pool. If the old file could not be unlinked (Windows file
+///    locking), serve the generation path instead; a restart normalizes it.
+fn complete_swap(
+    pool: &Arc<DuckDbConnectionPool>,
+    building_path: &str,
+    generation_path: &str,
+) -> DataFusionResult<()> {
+    let configured_path = pool.db_path().to_string();
+    let old_physical = pool.physical_path().to_string();
+
+    // Refuse to unlink a file this pool does not own. The swap is not the only
+    // mechanism that can replace the database file — a snapshot restore does too,
+    // out-of-band and on its own schedule — and unlinking whatever happens to sit
+    // at the configured path would silently destroy the other mechanism's file,
+    // leaving the pool and the path resolving to different data. Aborting is
+    // retriable: the staging file is cleaned up and the refresh runs again
+    // against whatever is now the live file.
+    if !pool.physical_file_unchanged() {
+        return Err(to_retriable_data_write_error(
+            super::Error::FileSwapFileReplaced {
+                path: old_physical.clone(),
+            },
+        ));
+    }
+
+    std::fs::rename(building_path, generation_path)
+        .context(super::UnableToCompleteFileSwapSnafu {
+            path: building_path.to_string(),
+        })
+        .map_err(to_retriable_data_write_error)?;
+
+    // Free the configured path: remove the retiring file (which may already
+    // live at a generation path if a previous swap could not reclaim the
+    // configured name) and any stale file still holding the configured name.
+    let mut configured_free = true;
+    for stale in [old_physical.clone(), configured_path.clone()] {
+        match remove_file_if_exists(&stale) {
+            Ok(_) => {}
+            Err(e) => {
+                tracing::warn!(
+                    "Failed to remove retiring DuckDB database file {stale} during file swap: {e}"
+                );
+                if stale == configured_path {
+                    configured_free = false;
+                }
+            }
+        }
+        match remove_file_if_exists(&wal_path_of(&stale)) {
+            Ok(_) => {}
+            Err(e) => {
+                tracing::warn!(
+                    "Failed to remove retiring DuckDB WAL file {stale}.wal during file swap: {e}"
+                );
+                if stale == configured_path {
+                    // A foreign WAL beside the configured path would be
+                    // replayed against the new file — do not place it there.
+                    configured_free = false;
+                }
+            }
+        }
+    }
+
+    let target = if configured_free {
+        match std::fs::rename(generation_path, &configured_path) {
+            Ok(()) => configured_path.clone(),
+            Err(e) => {
+                tracing::warn!(
+                    "Failed to restore configured DuckDB database path {configured_path} during file swap; serving {generation_path} until restart: {e}"
+                );
+                generation_path.to_string()
+            }
+        }
+    } else {
+        tracing::warn!(
+            "Configured DuckDB database path {configured_path} is not reclaimable; serving {generation_path} until restart"
+        );
+        generation_path.to_string()
+    };
+
+    pool.swap_database_file(&target)
+        .context(super::DbConnectionPoolSnafu)
+        .map_err(to_datafusion_error)?;
+
+    // Other DuckDB instances that `ATTACH`ed this path resolved it to the file
+    // just retired, and `ATTACH IF NOT EXISTS` never re-resolves it. Those
+    // instances notice the replacement themselves on their next checkout (see
+    // `DuckDBAttachments::attach_once`, which compares the attached files'
+    // identities), so cross-instance reads converge on the new file rather than
+    // serving pre-swap data until the process restarts.
+
+    tracing::info!(
+        "Completed DuckDB database file swap for {configured_path}: refreshed data now served from {target}"
+    );
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::conn::DuckDbConnection;
+    use crate::pool::DuckDbConnectionPoolBuilder;
+    use crate::write::DuckDBDataSink;
+    use crate::write_settings::DuckDBWriteSettings;
+    use arrow::array::{Int64Array, StringArray};
+    use arrow::datatypes::{DataType, Field, Schema};
+    use datafusion::datasource::sink::DataSink;
+    use datafusion::execution::TaskContext;
+    use datafusion::logical_expr::dml::InsertOp;
+    use datafusion::physical_plan::memory::MemoryStream;
+    use datafusion_table_providers_common::util::column_reference::ColumnReference;
+    use datafusion_table_providers_common::util::indexes::IndexType;
+    use duckdb::AccessMode;
+
+    fn swap_dataset_definition() -> Arc<TableDefinition> {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int64, false),
+            Field::new("name", DataType::Utf8, false),
+        ]));
+        Arc::new(
+            TableDefinition::new(super::super::RelationName::new("swap_ds"), schema).with_indexes(
+                vec![(
+                    ColumnReference::try_from("id").expect("valid column ref"),
+                    IndexType::Enabled,
+                )],
+            ),
+        )
+    }
+
+    fn rows_batch(
+        definition: &Arc<TableDefinition>,
+        rows: &[(i64, &str)],
+    ) -> arrow::array::RecordBatch {
+        arrow::array::RecordBatch::try_new(
+            definition.schema(),
+            vec![
+                Arc::new(Int64Array::from(
+                    rows.iter().map(|(id, _)| *id).collect::<Vec<_>>(),
+                )),
+                Arc::new(StringArray::from(
+                    rows.iter().map(|(_, name)| *name).collect::<Vec<_>>(),
+                )),
+            ],
+        )
+        .expect("record batch")
+    }
+
+    async fn overwrite_with_swap(
+        pool: &Arc<DuckDbConnectionPool>,
+        definition: &Arc<TableDefinition>,
+        rows: &[(i64, &str)],
+    ) {
+        let written = try_overwrite_with_swap(pool, definition, rows)
+            .await
+            .expect("overwrite with file swap to succeed");
+        assert_eq!(written, rows.len() as u64);
+    }
+
+    async fn try_overwrite_with_swap(
+        pool: &Arc<DuckDbConnectionPool>,
+        definition: &Arc<TableDefinition>,
+        rows: &[(i64, &str)],
+    ) -> DataFusionResult<u64> {
+        let sink = DuckDBDataSink::new(
+            Arc::clone(pool),
+            Arc::clone(definition),
+            InsertOp::Overwrite,
+            None,
+            definition.schema(),
+        )
+        .with_write_settings(DuckDBWriteSettings::default().with_overwrite_file_swap(true));
+
+        let stream = Box::pin(
+            MemoryStream::try_new(
+                vec![rows_batch(definition, rows)],
+                definition.schema(),
+                None,
+            )
+            .expect("stream"),
+        );
+
+        Arc::new(sink)
+            .write_all(stream, &Arc::new(TaskContext::default()))
+            .await
+    }
+
+    fn count(conn: &Connection, sql: &str) -> i64 {
+        conn.query_row(sql, [], |r| r.get::<usize, i64>(0))
+            .expect("count query")
+    }
+
+    fn pooled_raw_connection(pool: &Arc<DuckDbConnectionPool>) -> Connection {
+        let mut conn = Arc::clone(pool).connect_sync().expect("connect");
+        conn.as_any_mut()
+            .downcast_mut::<DuckDbConnection>()
+            .expect("duckdb connection")
+            .get_underlying_conn_mut()
+            .try_clone()
+            .expect("clone connection")
+    }
+
+    fn swap_artifacts_in(dir: &Path) -> Vec<String> {
+        std::fs::read_dir(dir)
+            .expect("read dir")
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name().to_string_lossy().to_string())
+            .filter(|name| name.contains(GENERATION_INFIX) || name.ends_with(WAL_SUFFIX))
+            .collect()
+    }
+
+    #[tokio::test]
+    async fn test_overwrite_file_swap_end_to_end() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let db_path = dir
+            .path()
+            .join("swap_test.db")
+            .to_string_lossy()
+            .to_string();
+
+        let pool = Arc::new(
+            DuckDbConnectionPoolBuilder::file(&db_path)
+                .with_access_mode(AccessMode::ReadWrite)
+                .build()
+                .expect("pool"),
+        );
+
+        // A sibling dataset sharing the file: data table, index, view, and a
+        // metadata table, all of which the swap must carry over.
+        {
+            let conn = pooled_raw_connection(&pool);
+            conn.execute_batch(
+                "CREATE TABLE other_data (id BIGINT, tag VARCHAR);
+                 INSERT INTO other_data VALUES (1, 'a'), (2, 'b'), (3, 'c');
+                 CREATE INDEX i_other_data_id ON other_data (id);
+                 CREATE VIEW other_view AS SELECT * FROM other_data;
+                 CREATE TABLE provider_dataset_checkpoint (dataset_name TEXT PRIMARY KEY, created_at TIMESTAMP);
+                 INSERT INTO provider_dataset_checkpoint VALUES ('other', now());",
+            )
+            .expect("create sibling dataset");
+        }
+
+        let definition = swap_dataset_definition();
+
+        overwrite_with_swap(&pool, &definition, &[(1, "one"), (2, "two")]).await;
+
+        assert_eq!(pool.physical_path().as_ref(), db_path.as_str());
+        assert!(Path::new(&db_path).exists());
+        assert!(
+            swap_artifacts_in(dir.path()).is_empty(),
+            "no generation/WAL files may remain: {:?}",
+            swap_artifacts_in(dir.path())
+        );
+
+        // Hold a pre-swap connection: it must keep serving the retired file.
+        let old_conn = pooled_raw_connection(&pool);
+
+        overwrite_with_swap(&pool, &definition, &[(1, "uno"), (2, "dos"), (3, "tres")]).await;
+
+        // Wait: old_conn was checked out after the FIRST swap, so it sees the
+        // first generation (2 rows) while the pool now serves the second (3).
+        assert_eq!(count(&old_conn, "SELECT COUNT(1) FROM swap_ds"), 2);
+        assert_eq!(count(&old_conn, "SELECT COUNT(1) FROM other_data"), 3);
+
+        let conn = pooled_raw_connection(&pool);
+        assert_eq!(count(&conn, "SELECT COUNT(1) FROM swap_ds"), 3);
+        assert_eq!(count(&conn, "SELECT COUNT(1) FROM other_data"), 3);
+        assert_eq!(count(&conn, "SELECT COUNT(1) FROM other_view"), 3);
+        assert_eq!(
+            count(
+                &conn,
+                "SELECT COUNT(1) FROM provider_dataset_checkpoint WHERE dataset_name = 'other'"
+            ),
+            1
+        );
+        assert_eq!(
+            count(
+                &conn,
+                "SELECT COUNT(1) FROM duckdb_indexes() WHERE index_name = 'i_other_data_id'"
+            ),
+            1,
+            "sibling dataset's index must be carried into the new file"
+        );
+        assert_eq!(
+            count(
+                &conn,
+                "SELECT COUNT(1) FROM duckdb_indexes() WHERE table_name LIKE '__data_swap_ds_%'"
+            ),
+            1,
+            "refreshed dataset's index must exist in the new file"
+        );
+        // Exactly one internal generation of the refreshed dataset exists: the
+        // stale pre-swap tables were left behind in the retired file.
+        assert_eq!(
+            count(
+                &conn,
+                "SELECT COUNT(1) FROM duckdb_tables() WHERE table_name LIKE '__data_swap_ds_%'"
+            ),
+            1
+        );
+
+        drop(old_conn);
+        drop(conn);
+
+        assert!(
+            swap_artifacts_in(dir.path()).is_empty(),
+            "no generation/WAL files may remain after the second swap: {:?}",
+            swap_artifacts_in(dir.path())
+        );
+    }
+
+    #[tokio::test]
+    async fn test_overwrite_file_swap_reclaims_space() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let db_path = dir
+            .path()
+            .join("reclaim_test.db")
+            .to_string_lossy()
+            .to_string();
+
+        let pool = Arc::new(
+            DuckDbConnectionPoolBuilder::file(&db_path)
+                .with_access_mode(AccessMode::ReadWrite)
+                .build()
+                .expect("pool"),
+        );
+
+        // Grow the live file with incompressible data that the refresh
+        // replaces (md5 output defeats compression, so the size delta is
+        // dominated by the replaced rows rather than block-count noise).
+        {
+            let conn = pooled_raw_connection(&pool);
+            conn.execute_batch(
+                "CREATE TABLE swap_ds AS
+                 SELECT range AS id, md5(range::VARCHAR) AS name FROM range(500000);",
+            )
+            .expect("bulk load");
+            conn.execute("CHECKPOINT", []).expect("checkpoint");
+        }
+        let size_before = std::fs::metadata(&db_path).expect("metadata").len();
+
+        let definition = swap_dataset_definition();
+        overwrite_with_swap(&pool, &definition, &[(1, "tiny")]).await;
+
+        let size_after = std::fs::metadata(&db_path).expect("metadata").len();
+        assert!(
+            size_after < size_before,
+            "swap must reclaim space: before={size_before} after={size_after}"
+        );
+
+        let conn = pooled_raw_connection(&pool);
+        assert_eq!(count(&conn, "SELECT COUNT(1) FROM swap_ds"), 1);
+    }
+
+    /// The swap is not the only mechanism that replaces the database file — a
+    /// snapshot restore does too, out-of-band. If something else has replaced the
+    /// file since this pool opened it, the swap must abort rather than unlink the
+    /// replacement and rename its own generation over it (which would leave the
+    /// pool and the configured path resolving to different data).
+    #[tokio::test]
+    async fn test_overwrite_file_swap_aborts_when_file_replaced_out_of_band() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let db_path = dir.path().join("replaced.db").to_string_lossy().to_string();
+
+        let pool = Arc::new(
+            DuckDbConnectionPoolBuilder::file(&db_path)
+                .with_access_mode(AccessMode::ReadWrite)
+                .build()
+                .expect("pool"),
+        );
+        assert!(
+            pool.physical_file_unchanged(),
+            "a freshly opened pool owns its file"
+        );
+
+        // Something else replaces the configured path with a different file,
+        // exactly as a snapshot restore would.
+        let replacement = dir.path().join("restored.db");
+        {
+            let conn = Connection::open(&replacement).expect("open replacement");
+            conn.execute_batch(
+                "CREATE TABLE restored_marker (v INTEGER); INSERT INTO restored_marker VALUES (7);",
+            )
+            .expect("seed replacement");
+        }
+        std::fs::rename(&replacement, &db_path).expect("replace the live file");
+
+        assert!(
+            !pool.physical_file_unchanged(),
+            "the pool must notice its file was replaced"
+        );
+
+        let definition = swap_dataset_definition();
+        let err = try_overwrite_with_swap(&pool, &definition, &[(1, "one")])
+            .await
+            .expect_err("the swap must refuse to overwrite a replaced file");
+        assert!(
+            err.to_string().contains("replaced by another process"),
+            "unexpected error: {err}"
+        );
+
+        // The replacement survived untouched, and no swap debris was left.
+        let conn = Connection::open(&db_path).expect("open replaced file");
+        assert_eq!(count(&conn, "SELECT COUNT(1) FROM restored_marker"), 1);
+        drop(conn);
+        assert!(
+            swap_artifacts_in(dir.path()).is_empty(),
+            "a refused swap must not leave debris: {:?}",
+            swap_artifacts_in(dir.path())
+        );
+    }
+
+    /// `ATTACH` resolves a path to a file once per instance and `ATTACH IF NOT
+    /// EXISTS` never re-resolves it, so an instance that attached a file which
+    /// was later replaced would keep reading the retired file until the process
+    /// restarted. `attach_once` must notice the replacement and re-attach.
+    #[tokio::test]
+    async fn test_attach_once_reattaches_replaced_database_file() {
+        use crate::conn::DuckDBAttachments;
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let main_path = dir.path().join("main.db").to_string_lossy().to_string();
+        let peer_path = dir.path().join("peer.db").to_string_lossy().to_string();
+
+        // The peer database that `main` attaches, seeded with one row.
+        {
+            let conn = Connection::open(&peer_path).expect("open peer");
+            conn.execute_batch(
+                "CREATE TABLE peer_data (v INTEGER); INSERT INTO peer_data VALUES (1);",
+            )
+            .expect("seed peer");
+        }
+
+        let main = Connection::open(&main_path).expect("open main");
+        let attachments =
+            DuckDBAttachments::new("main", &[Arc::from(peer_path.as_str()) as Arc<str>]);
+
+        attachments.attach_once(&main).expect("initial attach");
+        assert_eq!(count(&main, "SELECT COUNT(1) FROM peer_data"), 1);
+
+        // Replace the peer file with a different file holding three rows —
+        // the same rename-over-the-path shape a file swap produces.
+        let replacement = dir.path().join("peer_new.db");
+        {
+            let conn = Connection::open(&replacement).expect("open replacement peer");
+            conn.execute_batch(
+                "CREATE TABLE peer_data (v INTEGER); INSERT INTO peer_data VALUES (1), (2), (3);",
+            )
+            .expect("seed replacement peer");
+        }
+        std::fs::rename(&replacement, &peer_path).expect("replace peer file");
+
+        // Without re-resolution this would still read the retired file (1 row).
+        attachments
+            .attach_once(&main)
+            .expect("re-attach after replacement");
+        assert_eq!(
+            count(&main, "SELECT COUNT(1) FROM peer_data"),
+            3,
+            "attachment must be re-resolved to the replacement file"
+        );
+    }
+
+    #[test]
+    fn test_parse_generation_suffix() {
+        assert_eq!(
+            parse_generation_suffix("1722200000000-3"),
+            Some((1_722_200_000_000, 3))
+        );
+        assert_eq!(parse_generation_suffix("1722200000000"), None);
+        assert_eq!(parse_generation_suffix("1722200000000-3.building"), None);
+        assert_eq!(parse_generation_suffix("1722200000000-3.wal"), None);
+        assert_eq!(parse_generation_suffix("abc-3"), None);
+    }
+
+    #[test]
+    fn test_recover_prefers_configured_file() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let configured = dir.path().join("test.db");
+        let gen1 = dir.path().join("test.db.refresh.100-0");
+        let building = dir.path().join("test.db.refresh.200-1.building");
+        std::fs::write(&configured, b"configured").expect("write configured");
+        std::fs::write(&gen1, b"gen").expect("write gen");
+        std::fs::write(&building, b"building").expect("write building");
+
+        let recovery =
+            recover_database_file_generations(&configured.to_string_lossy()).expect("recover");
+
+        assert!(recovery.adopted.is_none());
+        assert!(configured.exists());
+        assert!(!gen1.exists());
+        assert!(!building.exists());
+        assert_eq!(recovery.removed.len(), 2);
+    }
+
+    #[test]
+    fn test_recover_adopts_newest_generation() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let configured = dir.path().join("test.db");
+        let gen_old = dir.path().join("test.db.refresh.100-0");
+        let gen_new = dir.path().join("test.db.refresh.200-1");
+        let gen_new_wal = dir.path().join("test.db.refresh.200-1.wal");
+        std::fs::write(&gen_old, b"old").expect("write old gen");
+        std::fs::write(&gen_new, b"new").expect("write new gen");
+        std::fs::write(&gen_new_wal, b"wal").expect("write new gen wal");
+
+        let recovery =
+            recover_database_file_generations(&configured.to_string_lossy()).expect("recover");
+
+        assert_eq!(recovery.adopted, Some(gen_new.clone()));
+        assert!(configured.exists());
+        assert_eq!(
+            std::fs::read(&configured).expect("read adopted"),
+            b"new".to_vec()
+        );
+        let configured_wal = dir.path().join("test.db.wal");
+        assert!(configured_wal.exists(), "generation WAL adopted alongside");
+        assert!(!gen_old.exists());
+        assert!(!gen_new.exists());
+        assert!(!gen_new_wal.exists());
+    }
+
+    #[test]
+    fn test_recover_noop_when_nothing_to_do() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let configured = dir.path().join("test.db");
+        std::fs::write(&configured, b"configured").expect("write configured");
+
+        let recovery =
+            recover_database_file_generations(&configured.to_string_lossy()).expect("recover");
+        assert!(recovery.adopted.is_none());
+        assert!(recovery.removed.is_empty());
+    }
+}

--- a/crates/duckdb/src/lib.rs
+++ b/crates/duckdb/src/lib.rs
@@ -24,7 +24,6 @@ use datafusion_table_providers_common::{
 
 use arrow::datatypes::SchemaRef;
 use async_trait::async_trait;
-use creator::TableManager;
 use datafusion::sql::unparser::dialect::{Dialect, DuckDBDialect};
 use datafusion::{
     catalog::{Session, TableProviderFactory},
@@ -51,10 +50,13 @@ use self::sql_table::DuckDBTable;
 mod federation;
 
 mod creator;
+mod file_swap;
 mod settings;
 mod sql_table;
 pub mod write;
-pub use creator::{RelationName, TableDefinition};
+pub mod write_settings;
+pub use creator::{RelationName, TableDefinition, TableManager};
+pub use file_swap::{recover_database_file_generations, SwapFileRecovery};
 
 #[derive(Debug, Snafu)]
 pub enum Error {
@@ -160,6 +162,12 @@ pub enum Error {
     #[snafu(display("Failed to parse the system time: {source}"))]
     UnableToParseSystemTime { source: std::num::ParseIntError },
 
+    #[snafu(display("Failed to parse 'connection_pool_size' value '{value}': {source}. Provide a positive integer."))]
+    UnableToParseConnectionPoolSize {
+        value: String,
+        source: std::num::ParseIntError,
+    },
+
     #[snafu(display("A read provider is required to create a DuckDBTableWriter"))]
     MissingReadProvider,
 
@@ -168,6 +176,42 @@ pub enum Error {
 
     #[snafu(display("A table definition is required to create a DuckDBTableWriter"))]
     MissingTableDefinition,
+
+    #[snafu(display("Failed to prepare the DuckDB database file swap ({path}): {source}"))]
+    UnableToPrepareFileSwap {
+        path: String,
+        source: std::io::Error,
+    },
+
+    #[snafu(display("Failed to open the DuckDB file-swap staging database ({path}): {source}"))]
+    UnableToOpenSwapStaging { path: String, source: duckdb::Error },
+
+    #[snafu(display(
+        "Failed to checkpoint the DuckDB file-swap staging database ({path}): {source}"
+    ))]
+    UnableToCheckpointSwapStaging { path: String, source: duckdb::Error },
+
+    #[snafu(display("Failed to copy live data during the DuckDB file swap ({detail}): {source}"))]
+    UnableToCopyLiveDatabase {
+        detail: String,
+        source: duckdb::Error,
+    },
+
+    #[snafu(display("Failed to complete the DuckDB database file swap ({path}): {source}"))]
+    UnableToCompleteFileSwap {
+        path: String,
+        source: std::io::Error,
+    },
+
+    #[snafu(display(
+        "A WAL unexpectedly exists beside the DuckDB file-swap staging database ({path})"
+    ))]
+    FileSwapWalPresent { path: String },
+
+    #[snafu(display(
+        "The DuckDB database file {path} was replaced by another process or mechanism while a file swap was in progress. The swap was aborted rather than overwrite the replacement."
+    ))]
+    FileSwapFileReplaced { path: String },
 }
 
 type Result<T, E = Error> = std::result::Result<T, E>;
@@ -277,7 +321,17 @@ impl DuckDBTableProviderFactory {
     }
 
     pub async fn get_or_init_memory_instance(&self) -> Result<DuckDbConnectionPool> {
+        self.get_or_init_memory_instance_with_options(&HashMap::new())
+            .await
+    }
+
+    pub async fn get_or_init_memory_instance_with_options(
+        &self,
+        options: &HashMap<String, String>,
+    ) -> Result<DuckDbConnectionPool> {
+        let max_size = extract_connection_pool_size(options)?;
         let pool_builder = DuckDbConnectionPoolBuilder::memory();
+        let pool_builder = pool_builder.with_max_size(max_size);
         self.get_or_init_instance_with_builder(pool_builder).await
     }
 
@@ -285,8 +339,18 @@ impl DuckDBTableProviderFactory {
         &self,
         db_path: impl Into<Arc<str>>,
     ) -> Result<DuckDbConnectionPool> {
+        self.get_or_init_file_instance_with_options(db_path, &HashMap::new())
+            .await
+    }
+
+    pub async fn get_or_init_file_instance_with_options(
+        &self,
+        db_path: impl Into<Arc<str>>,
+        options: &HashMap<String, String>,
+    ) -> Result<DuckDbConnectionPool> {
         let db_path: Arc<str> = db_path.into();
-        let pool_builder = DuckDbConnectionPoolBuilder::file(&db_path);
+        let pool_builder = DuckDbConnectionPoolBuilder::file(&db_path)
+            .with_max_size(extract_connection_pool_size(options)?);
 
         self.get_or_init_instance_with_builder(pool_builder).await
     }
@@ -317,6 +381,12 @@ impl DuckDBTableProviderFactory {
             return Ok(instance.clone());
         }
 
+        if let DbInstanceKey::File(path) = &key {
+            recover_database_file_generations(path).context(UnableToPrepareFileSwapSnafu {
+                path: path.to_string(),
+            })?;
+        }
+
         let pool = pool_builder
             .build()
             .context(DbConnectionPoolSnafu)?
@@ -325,6 +395,19 @@ impl DuckDBTableProviderFactory {
         instances.insert(key, pool.clone());
 
         Ok(pool)
+    }
+
+    /// Evict a cached instance so the next lookup reopens its backing file.
+    pub async fn invalidate_instance(&self, key: &DbInstanceKey) -> Option<DuckDbConnectionPool> {
+        self.instances.lock().await.remove(key)
+    }
+
+    pub async fn invalidate_file_instance(
+        &self,
+        path: impl Into<Arc<str>>,
+    ) -> Option<DuckDbConnectionPool> {
+        self.invalidate_instance(&DbInstanceKey::file(path.into()))
+            .await
     }
 }
 
@@ -391,12 +474,12 @@ impl TableProviderFactory for DuckDBTableProviderFactory {
                     .duckdb_file_path(&name, &mut options)
                     .map_err(to_datafusion_error)?;
 
-                self.get_or_init_file_instance(db_path)
+                self.get_or_init_file_instance_with_options(db_path, &options)
                     .await
                     .map_err(to_datafusion_error)?
             }
             Mode::Memory => self
-                .get_or_init_memory_instance()
+                .get_or_init_memory_instance_with_options(&options)
                 .await
                 .map_err(to_datafusion_error)?,
         };
@@ -425,12 +508,19 @@ impl TableProviderFactory for DuckDBTableProviderFactory {
                 .with_indexes(indexes.clone());
 
         let pool = Arc::new(pool);
+        pool.record_instance_setup_queries(
+            self.settings_registry
+                .get_setting_statements(&options, DuckDBSettingScope::Global),
+        );
         make_initial_table(Arc::new(table_definition.clone()), &pool)?;
 
+        let write_settings = write_settings::DuckDBWriteSettings::from_params(&options);
         let table_writer_builder = DuckDBTableWriterBuilder::new()
             .with_table_definition(table_definition)
             .with_pool(pool)
-            .set_on_conflict(on_conflict);
+            .set_on_conflict(on_conflict)
+            .with_write_settings(write_settings)
+            .with_dialect(self.dialect.clone());
 
         let dyn_pool: Arc<DynDuckDbConnectionPool> = Arc::new(read_pool);
 
@@ -543,9 +633,22 @@ fn remove_option(options: &mut HashMap<String, String>, key: &str) -> Option<Str
         .or_else(|| options.remove(&format!("duckdb.{key}")))
 }
 
+fn extract_connection_pool_size(options: &HashMap<String, String>) -> Result<Option<u32>> {
+    options
+        .get("connection_pool_size")
+        .map(|value| {
+            value.parse().context(UnableToParseConnectionPoolSizeSnafu {
+                value: value.clone(),
+            })
+        })
+        .transpose()
+}
+
 pub struct DuckDBTableFactory {
     pool: Arc<DuckDbConnectionPool>,
     dialect: Arc<dyn Dialect>,
+    schema: Option<SchemaRef>,
+    indexes: Vec<(ColumnReference, IndexType)>,
 }
 
 impl DuckDBTableFactory {
@@ -554,12 +657,26 @@ impl DuckDBTableFactory {
         Self {
             pool,
             dialect: Arc::new(DuckDBDialect::new()),
+            schema: None,
+            indexes: Vec::new(),
         }
     }
 
     #[must_use]
     pub fn with_dialect(mut self, dialect: Arc<dyn Dialect + Send + Sync>) -> Self {
         self.dialect = dialect;
+        self
+    }
+
+    #[must_use]
+    pub fn with_schema(mut self, schema: SchemaRef) -> Self {
+        self.schema = Some(schema);
+        self
+    }
+
+    #[must_use]
+    pub fn with_indexes(mut self, indexes: Vec<(ColumnReference, IndexType)>) -> Self {
+        self.indexes = indexes;
         self
     }
 
@@ -571,7 +688,10 @@ impl DuckDBTableFactory {
         let conn = Arc::clone(&pool).connect().await?;
         let dyn_pool: Arc<DynDuckDbConnectionPool> = pool;
 
-        let schema = get_schema(conn, &table_reference).await?;
+        let schema = match &self.schema {
+            Some(schema) => Arc::clone(schema),
+            None => get_schema(conn, &table_reference).await?,
+        };
         let (tbl_ref, cte) = if is_table_function(&table_reference) {
             let tbl_ref_view = create_table_function_view_name(&table_reference);
             (
@@ -608,11 +728,13 @@ impl DuckDBTableFactory {
         let schema = read_provider.schema();
 
         let table_name = RelationName::from(table_reference);
-        let table_definition = TableDefinition::new(table_name, Arc::clone(&schema));
+        let table_definition = TableDefinition::new(table_name, Arc::clone(&schema))
+            .with_indexes(self.indexes.clone());
         let table_writer_builder = DuckDBTableWriterBuilder::new()
             .with_read_provider(read_provider)
             .with_pool(Arc::clone(&self.pool))
-            .with_table_definition(table_definition);
+            .with_table_definition(table_definition)
+            .with_dialect(self.dialect.clone());
 
         Ok(Arc::new(table_writer_builder.build()?))
     }
@@ -646,6 +768,11 @@ pub(crate) fn make_initial_table(
     table_definition: Arc<TableDefinition>,
     pool: &Arc<DuckDbConnectionPool>,
 ) -> DataFusionResult<()> {
+    let write_gate = pool.write_gate();
+    let _write_guard = write_gate
+        .read()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+
     let cloned_pool = Arc::clone(pool);
     let mut db_conn = Arc::clone(&cloned_pool)
         .connect_sync()

--- a/crates/duckdb/src/pool.rs
+++ b/crates/duckdb/src/pool.rs
@@ -1,12 +1,15 @@
 use async_trait::async_trait;
 use duckdb::{vtab::arrow::ArrowVTab, AccessMode, DuckdbConnectionManager};
 use snafu::{prelude::*, ResultExt};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex, OnceLock, PoisonError, RwLock};
 
-use crate::conn::{DuckDBAttachments, DuckDBParameter, DuckDbConnection};
+use crate::conn::{
+    file_identity, DuckDBAttachments, DuckDBParameter, DuckDbConnection, FileIdentity,
+};
 use datafusion_table_providers_common::{
     sql::db_connection_pool::{
         dbconnection::{DbConnection, SyncDbConnection},
+        runtime::run_async_with_tokio,
         DbConnectionPool, JoinPushDown, Mode,
     },
     UnsupportedTypeAction,
@@ -28,6 +31,11 @@ pub enum Error {
         "Invalid DuckDB file path: {path}. Ensure it contains a valid database name."
     ))]
     UnableToExtractDatabaseNameFromPath { path: Arc<str> },
+
+    #[snafu(display(
+        "Cannot swap the database file of an in-memory DuckDB instance. Only file-backed DuckDB instances support file swapping."
+    ))]
+    FileSwapUnsupportedForMemory,
 }
 
 pub struct DuckDbConnectionPoolBuilder {
@@ -37,6 +45,7 @@ pub struct DuckDbConnectionPoolBuilder {
     min_idle: Option<u32>,
     mode: Mode,
     connection_setup_queries: Vec<Arc<str>>,
+    instance_setup_queries: Vec<Arc<str>>,
 }
 
 impl DuckDbConnectionPoolBuilder {
@@ -48,6 +57,7 @@ impl DuckDbConnectionPoolBuilder {
             min_idle: None,
             mode: Mode::Memory,
             connection_setup_queries: Vec::new(),
+            instance_setup_queries: Vec::new(),
         }
     }
 
@@ -59,6 +69,7 @@ impl DuckDbConnectionPoolBuilder {
             min_idle: None,
             mode: Mode::File,
             connection_setup_queries: Vec::new(),
+            instance_setup_queries: Vec::new(),
         }
     }
 
@@ -90,33 +101,44 @@ impl DuckDbConnectionPoolBuilder {
         self
     }
 
+    /// Add a statement applied **once per DuckDB instance** (at pool build, and
+    /// again on the replacement instance after a database file swap). Use this
+    /// for instance-scoped settings (`PRAGMA enable_checkpoint_on_shutdown`,
+    /// `PRAGMA checkpoint_threshold`, ...): applying those per connection would
+    /// let a draining connection re-apply them to a retiring instance after a
+    /// file swap has deliberately reconfigured it.
+    pub fn with_instance_setup_query(mut self, query: impl Into<Arc<str>>) -> Self {
+        self.instance_setup_queries.push(query.into());
+        self
+    }
+
     fn build_memory_pool(self) -> Result<DuckDbConnectionPool> {
         let config = get_config(&AccessMode::ReadWrite)?;
         let manager =
             DuckdbConnectionManager::memory_with_flags(config).context(DuckDBConnectionSnafu)?;
 
-        let mut pool_builder = r2d2::Pool::builder();
+        tracing::debug!("Creating DuckDB connection pool for memory instance with max_size {:?} and min_idle {:?}", self.max_size, self.min_idle);
 
-        if let Some(size) = self.max_size {
-            pool_builder = pool_builder.max_size(size)
-        }
-        if self.min_idle.is_some() {
-            pool_builder = pool_builder.min_idle(self.min_idle)
-        }
-
-        let pool = Arc::new(pool_builder.build(manager).context(ConnectionPoolSnafu)?);
-
-        let conn = pool.get().context(ConnectionPoolSnafu)?;
-        conn.register_table_function::<ArrowVTab>("arrow")
-            .context(DuckDBConnectionSnafu)?;
-
-        test_connection(&conn)?;
+        let pool = build_r2d2_pool(manager, self.max_size, self.min_idle)?;
+        initialize_instance(&pool, &self.instance_setup_queries)?;
 
         Ok(DuckDbConnectionPool {
             path: ":memory:".into(),
-            pool,
+            state: Arc::new(RwLock::new(Arc::new(PoolState {
+                pool,
+                physical_path: ":memory:".into(),
+                physical_identity: None,
+            }))),
+            write_gate: Arc::new(RwLock::new(())),
+            instance_setup_queries: Arc::new(Mutex::new(self.instance_setup_queries)),
+            rebuild: Arc::new(PoolRebuildConfig {
+                max_size: self.max_size,
+                min_idle: self.min_idle,
+                access_mode: clone_access_mode(&self.access_mode),
+            }),
             join_push_down: JoinPushDown::AllowedFor(":memory:".to_string()),
-            attached_databases: Vec::new(),
+            attached_databases: Arc::new(OnceLock::new()),
+            attachment_error_path: Arc::new(OnceLock::new()),
             mode: Mode::Memory,
             unsupported_type_action: UnsupportedTypeAction::Error,
             connection_setup_queries: self.connection_setup_queries,
@@ -128,29 +150,34 @@ impl DuckDbConnectionPoolBuilder {
         let manager = DuckdbConnectionManager::file_with_flags(&self.path, config)
             .context(DuckDBConnectionSnafu)?;
 
-        let mut pool_builder = r2d2::Pool::builder();
+        tracing::debug!(
+            "Creating DuckDB connection pool for path {} with max_size {:?} and min_idle {:?}",
+            self.path,
+            self.max_size,
+            self.min_idle
+        );
 
-        if let Some(size) = self.max_size {
-            pool_builder = pool_builder.max_size(size)
-        }
-        if self.min_idle.is_some() {
-            pool_builder = pool_builder.min_idle(self.min_idle)
-        }
-
-        let pool = Arc::new(pool_builder.build(manager).context(ConnectionPoolSnafu)?);
-
-        let conn = pool.get().context(ConnectionPoolSnafu)?;
-        conn.register_table_function::<ArrowVTab>("arrow")
-            .context(DuckDBConnectionSnafu)?;
-
-        test_connection(&conn)?;
+        let pool = build_r2d2_pool(manager, self.max_size, self.min_idle)?;
+        initialize_instance(&pool, &self.instance_setup_queries)?;
 
         Ok(DuckDbConnectionPool {
             path: self.path.as_str().into(),
-            pool,
+            state: Arc::new(RwLock::new(Arc::new(PoolState {
+                pool,
+                physical_identity: file_identity(&self.path),
+                physical_path: self.path.as_str().into(),
+            }))),
+            write_gate: Arc::new(RwLock::new(())),
+            instance_setup_queries: Arc::new(Mutex::new(self.instance_setup_queries)),
+            rebuild: Arc::new(PoolRebuildConfig {
+                max_size: self.max_size,
+                min_idle: self.min_idle,
+                access_mode: clone_access_mode(&self.access_mode),
+            }),
             // Allow join-push down for any other instances that connect to the same underlying file.
             join_push_down: JoinPushDown::AllowedFor(self.path),
-            attached_databases: Vec::new(),
+            attached_databases: Arc::new(OnceLock::new()),
+            attachment_error_path: Arc::new(OnceLock::new()),
             mode: Mode::File,
             unsupported_type_action: UnsupportedTypeAction::Error,
             connection_setup_queries: self.connection_setup_queries,
@@ -165,12 +192,56 @@ impl DuckDbConnectionPoolBuilder {
     }
 }
 
+/// The swappable core of a [`DuckDbConnectionPool`]: the r2d2 pool over one
+/// DuckDB database instance, plus the on-disk path that instance has open.
+///
+/// Shared behind `Arc<RwLock<Arc<..>>>` across every clone of the outer pool so
+/// that a file swap performed through any clone is observed by all of them:
+/// connections checked out after the swap come from the new instance, while
+/// connections already checked out drain against the old instance (which stays
+/// alive until the last of its pooled connections is dropped).
+struct PoolState {
+    pool: Arc<r2d2::Pool<DuckdbConnectionManager>>,
+    physical_path: Arc<str>,
+    /// `(device, inode)` of `physical_path` as it was when this instance opened
+    /// it. A file swap compares this against the file currently at the path
+    /// before unlinking it, so it can never destroy a file some *other*
+    /// mechanism (a snapshot restore, an operator, a future replacement path)
+    /// put there in the meantime. `None` on platforms without inode identity,
+    /// where the check is skipped.
+    physical_identity: Option<FileIdentity>,
+}
+
+/// The r2d2 settings needed to rebuild an equivalent pool over a new database
+/// file during a file swap.
+struct PoolRebuildConfig {
+    max_size: Option<u32>,
+    min_idle: Option<u32>,
+    access_mode: AccessMode,
+}
+
 #[derive(Clone)]
 pub struct DuckDbConnectionPool {
     path: Arc<str>,
-    pool: Arc<r2d2::Pool<DuckdbConnectionManager>>,
+    state: Arc<RwLock<Arc<PoolState>>>,
+    /// Coordinates writers with database file swaps. All write paths hold the
+    /// lock in shared mode for the duration of their transaction(s); a file
+    /// swap holds it exclusively while it copies live data into the new file
+    /// and replaces the pool. Readers do not take this lock.
+    write_gate: Arc<RwLock<()>>,
+    /// Instance-scoped statements (e.g. `SET memory_limit = ...`) applied to the
+    /// current DuckDB instance, recorded so a file swap can replay them on the
+    /// replacement instance. Instance-scoped settings do not carry over to a new
+    /// instance on their own, unlike `connection_setup_queries` which are
+    /// re-applied on every connection checkout.
+    instance_setup_queries: Arc<Mutex<Vec<Arc<str>>>>,
+    rebuild: Arc<PoolRebuildConfig>,
     join_push_down: JoinPushDown,
-    attached_databases: Vec<Arc<str>>,
+    /// Shared across clones. Initialized once, first set of attached databases wins.
+    attached_databases: Arc<OnceLock<Arc<DuckDBAttachments>>>,
+    /// Preserves the historical infallible setter while deferring an invalid
+    /// attachment path error until the next connection attempt.
+    attachment_error_path: Arc<OnceLock<Arc<str>>>,
     mode: Mode,
     unsupported_type_action: UnsupportedTypeAction,
     connection_setup_queries: Vec<Arc<str>>,
@@ -180,8 +251,9 @@ impl std::fmt::Debug for DuckDbConnectionPool {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("DuckDbConnectionPool")
             .field("path", &self.path)
+            .field("physical_path", &self.physical_path())
             .field("join_push_down", &self.join_push_down)
-            .field("attached_databases", &self.attached_databases)
+            .field("attached_databases", &self.attached_databases.get())
             .field("mode", &self.mode)
             .field("unsupported_type_action", &self.unsupported_type_action)
             .finish()
@@ -190,8 +262,141 @@ impl std::fmt::Debug for DuckDbConnectionPool {
 
 impl DuckDbConnectionPool {
     /// Get the dataset path. Returns `:memory:` if the in memory database is used.
+    ///
+    /// This is the *configured* path, which is stable across database file
+    /// swaps; see [`Self::physical_path`] for the file currently backing the
+    /// pool.
     pub fn db_path(&self) -> &str {
         self.path.as_ref()
+    }
+
+    /// The on-disk file currently backing this pool. Equal to [`Self::db_path`]
+    /// except transiently during a database file swap, or after a swap could
+    /// not restore the configured path (e.g. the previous file could not be
+    /// removed on Windows); a restart normalizes the file back to the
+    /// configured path.
+    #[must_use]
+    pub fn physical_path(&self) -> Arc<str> {
+        Arc::clone(&self.load_state().physical_path)
+    }
+
+    /// Whether the file currently at this pool's physical path is still the same
+    /// file the backing instance opened.
+    ///
+    /// Returns `false` only when the identity is known and has changed — i.e.
+    /// something replaced the database file out-of-band. `true` when the pool is
+    /// in-memory, when the platform has no inode identity, or when the path
+    /// cannot be stat'ed, so callers treat "unknown" as "unchanged" and rely on
+    /// their other safeguards.
+    #[must_use]
+    pub fn physical_file_unchanged(&self) -> bool {
+        let state = self.load_state();
+        let Some(expected) = state.physical_identity else {
+            return true;
+        };
+        file_identity(&state.physical_path).is_none_or(|actual| actual == expected)
+    }
+
+    fn load_state(&self) -> Arc<PoolState> {
+        Arc::clone(&self.state.read().unwrap_or_else(PoisonError::into_inner))
+    }
+
+    fn r2d2_pool(&self) -> Arc<r2d2::Pool<DuckdbConnectionManager>> {
+        Arc::clone(&self.load_state().pool)
+    }
+
+    /// The lock coordinating writers with database file swaps.
+    ///
+    /// Every code path that writes to this DuckDB instance outside of the
+    /// built-in `DataSink`/DML paths (which take it internally) must hold the
+    /// returned lock in shared (`read`) mode for the full duration of its
+    /// write, acquiring it *before* checking out a connection. A database file
+    /// swap holds the lock exclusively, so writes never race the swap's
+    /// copy-and-replace and can never land in a database file that is about to
+    /// be retired.
+    #[must_use]
+    pub fn write_gate(&self) -> Arc<RwLock<()>> {
+        Arc::clone(&self.write_gate)
+    }
+
+    /// Record instance-scoped setup statements (e.g. `SET memory_limit = ...`)
+    /// that were applied to the current DuckDB instance, so that a database
+    /// file swap can replay them on the replacement instance.
+    pub fn record_instance_setup_queries<I>(&self, statements: I)
+    where
+        I: IntoIterator<Item = Arc<str>>,
+    {
+        self.instance_setup_queries
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+            .extend(statements);
+    }
+
+    /// Returns the recorded instance-scoped setup statements.
+    #[must_use]
+    pub fn instance_setup_queries(&self) -> Vec<Arc<str>> {
+        self.instance_setup_queries
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+            .clone()
+    }
+
+    /// The per-connection setup statements this pool clone applies on every
+    /// checkout.
+    #[must_use]
+    pub fn connection_setup_queries(&self) -> &[Arc<str>] {
+        &self.connection_setup_queries
+    }
+
+    /// Atomically replace the DuckDB instance backing this pool (and all of its
+    /// clones) with a new instance opened on `new_path`.
+    ///
+    /// Returns the previously backing file path. Connections checked out before
+    /// the swap keep operating against the old instance until they are dropped;
+    /// the old instance closes once the last of them drains. The caller is
+    /// responsible for holding the [`Self::write_gate`] exclusively across the
+    /// swap and for removing the old file afterwards.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if this is an in-memory pool, or if the new instance
+    /// cannot be opened and initialized. On error the pool is left unchanged.
+    pub fn swap_database_file(&self, new_path: &str) -> Result<Arc<str>> {
+        if self.mode != Mode::File {
+            return Err(Box::new(Error::FileSwapUnsupportedForMemory));
+        }
+
+        let config = get_config(&clone_access_mode(&self.rebuild.access_mode))?;
+        let manager = DuckdbConnectionManager::file_with_flags(new_path, config)
+            .context(DuckDBConnectionSnafu)?;
+        let pool = build_r2d2_pool(manager, self.rebuild.max_size, self.rebuild.min_idle)?;
+
+        // Re-establish instance-scoped state on the fresh instance: the arrow
+        // scan table function, this clone's connection setup queries (other
+        // clones re-apply their own on checkout), and the recorded
+        // instance-scoped settings.
+        let mut setup = self.connection_setup_queries.clone();
+        setup.extend(self.instance_setup_queries());
+        initialize_instance(&pool, &setup)?;
+
+        let new_state = Arc::new(PoolState {
+            pool,
+            physical_identity: file_identity(new_path),
+            physical_path: new_path.into(),
+        });
+
+        let old_state = {
+            let mut state = self.state.write().unwrap_or_else(PoisonError::into_inner);
+            std::mem::replace(&mut *state, new_state)
+        };
+
+        tracing::debug!(
+            old_path = %old_state.physical_path,
+            new_path,
+            "Swapped DuckDB database file backing connection pool"
+        );
+
+        Ok(Arc::clone(&old_state.physical_path))
     }
 
     /// Create a new `DuckDbConnectionPool` from memory.
@@ -228,13 +433,8 @@ impl DuckDbConnectionPool {
     /// * `DuckDBConnectionSnafu` - If there is an error creating the connection pool
     /// * `ConnectionPoolSnafu` - If there is an error creating the connection pool
     pub fn new_file(path: &str, access_mode: &AccessMode) -> Result<Self> {
-        let access_mode = match access_mode {
-            AccessMode::Automatic => AccessMode::Automatic,
-            AccessMode::ReadOnly => AccessMode::ReadOnly,
-            AccessMode::ReadWrite => AccessMode::ReadWrite,
-        };
         DuckDbConnectionPoolBuilder::file(path)
-            .with_access_mode(access_mode)
+            .with_access_mode(clone_access_mode(access_mode))
             .build()
     }
 
@@ -244,19 +444,72 @@ impl DuckDbConnectionPool {
         self
     }
 
-    #[must_use]
+    /// Sets the databases to attach for cross-database queries.
+    /// Attachments are performed lazily on first query using `OnceLock`.
+    ///
+    /// If attachments are already configured with the same databases, this is a no-op.
+    /// If attachments are already configured with different databases, a warning is logged
+    /// and the existing attachments are preserved.
+    ///
     pub fn set_attached_databases(mut self, databases: &[Arc<str>]) -> Self {
-        self.attached_databases = databases.to_vec();
-
         if !databases.is_empty() {
-            let mut paths = self.attached_databases.clone();
+            let mut paths: Vec<Arc<str>> = databases.to_vec();
             paths.push(Arc::clone(&self.path));
             paths.sort();
-            let push_down_context = paths.join(";");
+            let push_down_context = paths
+                .iter()
+                .map(|p| p.as_ref())
+                .collect::<Vec<_>>()
+                .join(";");
             self.join_push_down = JoinPushDown::AllowedFor(push_down_context);
+        } else {
+            return self;
+        }
+
+        let new_set: std::collections::HashSet<Arc<str>> = databases.iter().cloned().collect();
+        let path = Arc::clone(&self.path);
+        let db_name = match extract_db_name(Arc::clone(&path)) {
+            Ok(db_name) => db_name,
+            Err(_) => {
+                let _ = self.attachment_error_path.set(path);
+                return self;
+            }
+        };
+
+        let existing = self.attached_databases.get_or_init(|| {
+            tracing::debug!(
+                "pool_path = {}, db_name = {}, databases = {:?}, set_attached_databases: creating new DuckDBAttachments",
+                path, db_name, databases
+            );
+            Arc::new(DuckDBAttachments::new(&db_name, databases))
+        });
+
+        // Check if the existing attachments match what was requested
+        let existing_set = existing.attachments();
+        if *existing_set != new_set {
+            tracing::warn!(
+                "Unable to reconfigure DuckDB attachments for database {}: attachments are already configured with a different set of databases. \
+                 Existing: {existing_set:?}, Requested: {new_set:?}. Keeping existing attachments.",
+                self.path
+            );
         }
 
         self
+    }
+
+    /// Returns the attachments configuration.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the configured database path has no extractable
+    /// database name.
+    pub fn get_attachments(&self) -> Result<Option<Arc<DuckDBAttachments>>> {
+        if let Some(path) = self.attachment_error_path.get() {
+            return Err(Box::new(Error::UnableToExtractDatabaseNameFromPath {
+                path: Arc::clone(path),
+            }));
+        }
+        Ok(self.attached_databases.get().cloned())
     }
 
     #[must_use]
@@ -275,16 +528,16 @@ impl DuckDbConnectionPool {
     ) -> Result<
         Box<dyn DbConnection<r2d2::PooledConnection<DuckdbConnectionManager>, DuckDBParameter>>,
     > {
-        let pool = Arc::clone(&self.pool);
+        let pool = self.r2d2_pool();
         let conn: r2d2::PooledConnection<DuckdbConnectionManager> =
             pool.get().context(ConnectionPoolSnafu)?;
-
-        let attachments = self.get_attachments()?;
 
         for query in self.connection_setup_queries.iter() {
             tracing::debug!("DuckDB connection setup: {}", query);
             conn.execute(query, []).context(DuckDBConnectionSnafu)?;
         }
+
+        let attachments = self.get_attachments()?;
 
         Ok(Box::new(
             DuckDbConnection::new(conn)
@@ -298,21 +551,6 @@ impl DuckDbConnectionPool {
     pub fn mode(&self) -> Mode {
         self.mode
     }
-
-    pub fn get_attachments(&self) -> Result<Option<Arc<DuckDBAttachments>>> {
-        if self.attached_databases.is_empty() {
-            Ok(None)
-        } else {
-            #[cfg(not(feature = "federation"))]
-            return Ok(None);
-
-            #[cfg(feature = "federation")]
-            Ok(Some(Arc::new(DuckDBAttachments::new(
-                &extract_db_name(Arc::clone(&self.path))?,
-                &self.attached_databases,
-            ))))
-        }
-    }
 }
 
 #[async_trait]
@@ -324,28 +562,100 @@ impl DbConnectionPool<r2d2::PooledConnection<DuckdbConnectionManager>, DuckDBPar
     ) -> Result<
         Box<dyn DbConnection<r2d2::PooledConnection<DuckdbConnectionManager>, DuckDBParameter>>,
     > {
-        let pool = Arc::clone(&self.pool);
-        let conn: r2d2::PooledConnection<DuckdbConnectionManager> =
-            pool.get().context(ConnectionPoolSnafu)?;
-
+        // `r2d2::Pool::get()` (blocking checkout, up to the pool timeout) and the
+        // per-connection setup queries are synchronous DuckDB calls. Run them on
+        // the blocking pool so awaiting `connect()` doesn't pin a runtime worker.
+        // `run_async_with_tokio` keeps this usable from non-Tokio executors/FFI.
+        let pool = self.r2d2_pool();
+        let setup_queries = self.connection_setup_queries.clone();
+        let setup_queries_for_conn = self.connection_setup_queries.clone();
         let attachments = self.get_attachments()?;
+        let unsupported_type_action = self.unsupported_type_action;
 
-        for query in self.connection_setup_queries.iter() {
-            tracing::debug!("DuckDB connection setup: {}", query);
-            conn.execute(query, []).context(DuckDBConnectionSnafu)?;
-        }
+        let connect = async move || -> Result<
+            Box<dyn DbConnection<r2d2::PooledConnection<DuckdbConnectionManager>, DuckDBParameter>>,
+        > {
+            let conn: r2d2::PooledConnection<DuckdbConnectionManager> =
+                tokio::task::spawn_blocking(move || -> Result<_> {
+                    let conn = pool.get().context(ConnectionPoolSnafu)?;
 
-        Ok(Box::new(
-            DuckDbConnection::new(conn)
-                .with_attachments(attachments)
-                .with_connection_setup_queries(self.connection_setup_queries.clone())
-                .with_unsupported_type_action(self.unsupported_type_action),
-        ))
+                    for query in setup_queries.iter() {
+                        tracing::debug!("DuckDB connection setup: {}", query);
+                        conn.execute(query, []).context(DuckDBConnectionSnafu)?;
+                    }
+
+                    Ok(conn)
+                })
+                .await
+                .map_err(|e| Box::new(e) as Box<dyn std::error::Error + Send + Sync>)??;
+
+            Ok(Box::new(
+                DuckDbConnection::new(conn)
+                    .with_attachments(attachments)
+                    .with_connection_setup_queries(setup_queries_for_conn)
+                    .with_unsupported_type_action(unsupported_type_action),
+            )
+                as Box<
+                    dyn DbConnection<
+                        r2d2::PooledConnection<DuckdbConnectionManager>,
+                        DuckDBParameter,
+                    >,
+                >)
+        };
+        run_async_with_tokio(connect).await
     }
 
     fn join_push_down(&self) -> JoinPushDown {
         self.join_push_down.clone()
     }
+}
+
+fn clone_access_mode(access_mode: &AccessMode) -> AccessMode {
+    match access_mode {
+        AccessMode::ReadOnly => AccessMode::ReadOnly,
+        AccessMode::ReadWrite => AccessMode::ReadWrite,
+        AccessMode::Automatic => AccessMode::Automatic,
+    }
+}
+
+fn build_r2d2_pool(
+    manager: DuckdbConnectionManager,
+    max_size: Option<u32>,
+    min_idle: Option<u32>,
+) -> Result<Arc<r2d2::Pool<DuckdbConnectionManager>>> {
+    let mut pool_builder = r2d2::Pool::builder();
+
+    if let Some(size) = max_size {
+        pool_builder = pool_builder.max_size(size);
+    }
+    if min_idle.is_some() {
+        pool_builder = pool_builder.min_idle(min_idle);
+    }
+
+    Ok(Arc::new(
+        pool_builder.build(manager).context(ConnectionPoolSnafu)?,
+    ))
+}
+
+/// One-time initialization of a fresh DuckDB instance: registers the arrow
+/// scan table function (instance-wide), applies the given setup statements,
+/// and verifies the connection works.
+fn initialize_instance(
+    pool: &Arc<r2d2::Pool<DuckdbConnectionManager>>,
+    setup_queries: &[Arc<str>],
+) -> Result<()> {
+    let conn = pool.get().context(ConnectionPoolSnafu)?;
+    conn.register_table_function::<ArrowVTab>("arrow")
+        .context(DuckDBConnectionSnafu)?;
+
+    for query in setup_queries {
+        tracing::debug!("DuckDB instance setup: {}", query);
+        conn.execute(query, []).context(DuckDBConnectionSnafu)?;
+    }
+
+    test_connection(&conn)?;
+
+    Ok(())
 }
 
 fn test_connection(conn: &r2d2::PooledConnection<DuckdbConnectionManager>) -> Result<()> {
@@ -422,6 +732,85 @@ mod test {
     }
 
     #[tokio::test]
+    async fn test_swap_database_file_rejected_for_memory() {
+        let pool =
+            DuckDbConnectionPool::new_memory().expect("DuckDB connection pool to be created");
+        let err = pool
+            .swap_database_file("./never-created.duckdb")
+            .expect_err("swap must be rejected for in-memory pools");
+        assert!(
+            err.to_string().contains("in-memory"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_swap_database_file_moves_new_connections() {
+        let db_one = random_db_name();
+        let db_two = random_db_name();
+
+        let pool = Arc::new(
+            DuckDbConnectionPool::new_file(&db_one, &AccessMode::ReadWrite)
+                .expect("DuckDB connection pool to be created"),
+        );
+        // A clone taken before the swap, as a table provider would hold.
+        let cloned = Arc::new(pool.as_ref().clone());
+
+        {
+            let conn = pool.r2d2_pool().get().expect("connection");
+            conn.execute("CREATE TABLE t (v INTEGER)", [])
+                .expect("create");
+            conn.execute("INSERT INTO t VALUES (1)", [])
+                .expect("insert");
+        }
+
+        // Build the second database file out-of-band.
+        {
+            let conn = duckdb::Connection::open(&db_two).expect("open second db");
+            conn.execute("CREATE TABLE t (v INTEGER)", [])
+                .expect("create");
+            conn.execute("INSERT INTO t VALUES (2), (3)", [])
+                .expect("insert");
+        }
+
+        // Hold a connection to the old instance across the swap.
+        let old_conn = pool.r2d2_pool().get().expect("old connection");
+
+        let old_path = pool
+            .swap_database_file(&db_two)
+            .expect("swap should succeed");
+        assert_eq!(old_path.as_ref(), db_one.as_str());
+        assert_eq!(pool.physical_path().as_ref(), db_two.as_str());
+        // The configured path is stable across swaps.
+        assert_eq!(pool.db_path(), db_one.as_str());
+
+        // The held (pre-swap) connection still reads the old file.
+        let old_count = old_conn
+            .query_row("SELECT COUNT(1) FROM t", [], |r| r.get::<usize, i64>(0))
+            .expect("old count");
+        assert_eq!(old_count, 1);
+
+        // New checkouts from BOTH the swapped pool and its pre-existing clone
+        // observe the new file.
+        for p in [&pool, &cloned] {
+            let mut conn = Arc::clone(p).connect_sync().expect("connect");
+            let duck = conn
+                .as_any_mut()
+                .downcast_mut::<DuckDbConnection>()
+                .expect("duckdb connection");
+            let count = duck
+                .get_underlying_conn_mut()
+                .query_row("SELECT COUNT(1) FROM t", [], |r| r.get::<usize, i64>(0))
+                .expect("new count");
+            assert_eq!(count, 2);
+        }
+
+        drop(old_conn);
+        std::fs::remove_file(&db_one).expect("File should be removed");
+        std::fs::remove_file(&db_two).expect("File should be removed");
+    }
+
+    #[tokio::test]
     #[cfg(feature = "federation")]
     async fn test_duckdb_connection_pool_with_attached_databases() {
         let db_base_name = random_db_name();
@@ -436,7 +825,7 @@ mod test {
                 .set_attached_databases(&[Arc::from(db_base_name.as_str())]);
 
         let conn = pool
-            .pool
+            .r2d2_pool()
             .get()
             .expect("DuckDB connection should be established");
 
@@ -446,7 +835,7 @@ mod test {
             .expect("Data should be inserted");
 
         let conn_attached = pool_attached
-            .pool
+            .r2d2_pool()
             .get()
             .expect("DuckDB connection should be established");
 

--- a/crates/duckdb/src/write.rs
+++ b/crates/duckdb/src/write.rs
@@ -12,9 +12,10 @@ use arrow::{
 use arrow_schema::ArrowError;
 use async_trait::async_trait;
 use datafusion::catalog::Session;
-use datafusion::common::{Constraints, SchemaExt};
+use datafusion::common::{utils::quote_identifier, Constraints, SchemaExt};
 use datafusion::datasource::sink::{DataSink, DataSinkExec};
 use datafusion::logical_expr::dml::InsertOp;
+use datafusion::sql::unparser::dialect::{Dialect, DuckDBDialect};
 use datafusion::{
     datasource::{TableProvider, TableType},
     error::DataFusionError,
@@ -22,10 +23,17 @@ use datafusion::{
     logical_expr::Expr,
     physical_plan::{metrics::MetricsSet, DisplayAs, DisplayFormatType, ExecutionPlan},
 };
-use datafusion_table_providers_common::util::{
-    constraints,
-    on_conflict::OnConflict,
-    retriable_error::{check_and_mark_retriable_error, to_retriable_data_write_error},
+use datafusion_table_providers_common::{
+    sql::db_connection_pool::Mode,
+    util::{
+        constraints,
+        count_exec::make_count_exec,
+        dml::{
+            assignments_to_sql, filters_to_sql, DeletionExec, DeletionSink, UpdateExec, UpdateSink,
+        },
+        on_conflict::OnConflict,
+        retriable_error::{check_and_mark_retriable_error, to_retriable_data_write_error},
+    },
 };
 use duckdb::Transaction;
 use futures::StreamExt;
@@ -34,7 +42,25 @@ use tokio::sync::mpsc::{self, Receiver, Sender};
 use tokio::task::JoinHandle;
 
 use super::creator::{TableDefinition, TableManager};
+use super::file_swap;
 use super::to_datafusion_error;
+use super::write_settings::DuckDBWriteSettings;
+
+/// Called after rows have been written but before their transaction commits.
+/// Returning an error rolls back both the write and the callback's work.
+pub type WriteCompletionHandler = Arc<
+    dyn Fn(&Transaction<'_>, &TableManager, &SchemaRef, u64) -> datafusion::common::Result<()>
+        + Send
+        + Sync
+        + 'static,
+>;
+
+pub(super) struct WriteContext<'a> {
+    pub(super) on_conflict: Option<&'a OnConflict>,
+    pub(super) on_data_written: Option<&'a WriteCompletionHandler>,
+    pub(super) schema: &'a SchemaRef,
+    pub(super) settings: &'a DuckDBWriteSettings,
+}
 
 // checking schemas are equivalent is disabled because it incorrectly marks single-level list fields are different when the name of the field is different
 // e.g. List(Field { name: 'a', data_type: Int32 }) != List(Field { name: 'b', data_type: Int32 })
@@ -49,6 +75,9 @@ pub struct DuckDBTableWriterBuilder {
     pool: Option<Arc<DuckDbConnectionPool>>,
     on_conflict: Option<OnConflict>,
     table_definition: Option<TableDefinition>,
+    on_data_written: Option<WriteCompletionHandler>,
+    write_settings: Option<DuckDBWriteSettings>,
+    dialect: Option<Arc<dyn Dialect + Send + Sync>>,
 }
 
 impl DuckDBTableWriterBuilder {
@@ -81,6 +110,24 @@ impl DuckDBTableWriterBuilder {
         self
     }
 
+    #[must_use]
+    pub fn with_on_data_written(mut self, handler: WriteCompletionHandler) -> Self {
+        self.on_data_written = Some(handler);
+        self
+    }
+
+    #[must_use]
+    pub fn with_write_settings(mut self, settings: DuckDBWriteSettings) -> Self {
+        self.write_settings = Some(settings);
+        self
+    }
+
+    #[must_use]
+    pub fn with_dialect(mut self, dialect: Arc<dyn Dialect + Send + Sync>) -> Self {
+        self.dialect = Some(dialect);
+        self
+    }
+
     /// Builds a `DuckDBTableWriter` from the provided configuration.
     ///
     /// # Errors
@@ -107,6 +154,11 @@ impl DuckDBTableWriterBuilder {
             on_conflict: self.on_conflict,
             table_definition: Arc::new(table_definition),
             pool,
+            on_data_written: self.on_data_written,
+            write_settings: self.write_settings.unwrap_or_default(),
+            dialect: self
+                .dialect
+                .unwrap_or_else(|| Arc::new(DuckDBDialect::new())),
         })
     }
 }
@@ -117,11 +169,20 @@ pub struct DuckDBTableWriter {
     pool: Arc<DuckDbConnectionPool>,
     table_definition: Arc<TableDefinition>,
     on_conflict: Option<OnConflict>,
+    on_data_written: Option<WriteCompletionHandler>,
+    write_settings: DuckDBWriteSettings,
+    dialect: Arc<dyn Dialect + Send + Sync>,
 }
 
 impl std::fmt::Debug for DuckDBTableWriter {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "DuckDBTableWriter")
+        f.debug_struct("DuckDBTableWriter")
+            .field("read_provider", &self.read_provider)
+            .field("pool", &self.pool)
+            .field("table_definition", &self.table_definition)
+            .field("on_conflict", &self.on_conflict)
+            .field("write_settings", &self.write_settings)
+            .finish_non_exhaustive()
     }
 }
 
@@ -134,6 +195,22 @@ impl DuckDBTableWriter {
     #[must_use]
     pub fn table_definition(&self) -> Arc<TableDefinition> {
         Arc::clone(&self.table_definition)
+    }
+
+    #[must_use]
+    pub fn on_conflict(&self) -> Option<&OnConflict> {
+        self.on_conflict.as_ref()
+    }
+
+    #[must_use]
+    pub fn write_settings(&self) -> &DuckDBWriteSettings {
+        &self.write_settings
+    }
+
+    #[must_use]
+    pub fn with_on_data_written_handler(mut self, handler: WriteCompletionHandler) -> Self {
+        self.on_data_written = Some(handler);
+        self
     }
 }
 
@@ -169,17 +246,130 @@ impl TableProvider for DuckDBTableWriter {
         input: Arc<dyn ExecutionPlan>,
         op: InsertOp,
     ) -> datafusion::error::Result<Arc<dyn ExecutionPlan>> {
-        Ok(Arc::new(DataSinkExec::new(
-            input,
-            Arc::new(DuckDBDataSink::new(
-                Arc::clone(&self.pool),
-                Arc::clone(&self.table_definition),
-                op,
-                self.on_conflict.clone(),
-                self.schema(),
-            )),
-            None,
-        )) as _)
+        let mut sink = DuckDBDataSink::new(
+            Arc::clone(&self.pool),
+            Arc::clone(&self.table_definition),
+            op,
+            self.on_conflict.clone(),
+            self.schema(),
+        )
+        .with_write_settings(self.write_settings.clone());
+        if let Some(handler) = &self.on_data_written {
+            sink = sink.with_on_data_written_handler(Arc::clone(handler));
+        }
+
+        Ok(Arc::new(DataSinkExec::new(input, Arc::new(sink), None)) as _)
+    }
+
+    async fn delete_from(
+        &self,
+        _state: &dyn Session,
+        filters: Vec<Expr>,
+    ) -> datafusion::error::Result<Arc<dyn ExecutionPlan>> {
+        let sql_where = if filters.is_empty() {
+            None
+        } else {
+            Some(filters_to_sql(&filters, self.dialect.as_ref())?)
+        };
+        Ok(Arc::new(DeletionExec::new(Arc::new(DuckDBDeletionSink {
+            pool: Arc::clone(&self.pool),
+            table_definition: Arc::clone(&self.table_definition),
+            sql_where,
+        }))))
+    }
+
+    async fn update(
+        &self,
+        _state: &dyn Session,
+        assignments: Vec<(String, Expr)>,
+        filters: Vec<Expr>,
+    ) -> datafusion::error::Result<Arc<dyn ExecutionPlan>> {
+        if assignments.is_empty() {
+            return make_count_exec(0);
+        }
+
+        let set_clause = assignments_to_sql(&assignments, self.dialect.as_ref())?;
+        let sql_where = if filters.is_empty() {
+            None
+        } else {
+            Some(filters_to_sql(&filters, self.dialect.as_ref())?)
+        };
+        Ok(Arc::new(UpdateExec::new(Arc::new(DuckDBUpdateSink {
+            pool: Arc::clone(&self.pool),
+            table_definition: Arc::clone(&self.table_definition),
+            set_clause,
+            sql_where,
+        }))))
+    }
+}
+
+struct DuckDBDeletionSink {
+    pool: Arc<DuckDbConnectionPool>,
+    table_definition: Arc<TableDefinition>,
+    sql_where: Option<String>,
+}
+
+#[async_trait]
+impl DeletionSink for DuckDBDeletionSink {
+    async fn delete_from(&self) -> Result<u64, Box<dyn std::error::Error + Send + Sync>> {
+        let pool = Arc::clone(&self.pool);
+        let table_definition = Arc::clone(&self.table_definition);
+        let sql_where = self.sql_where.clone();
+        tokio::task::spawn_blocking(move || {
+            let write_gate = pool.write_gate();
+            let _guard = write_gate
+                .read()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            let mut db_conn = Arc::clone(&pool).connect_sync()?;
+            let duckdb_conn = DuckDB::duckdb_conn(&mut db_conn)?;
+            let tx = duckdb_conn.conn.transaction()?;
+            let table_name = table_definition.resolve_dml_table_name(&tx)?;
+            let table_name = quote_identifier(&table_name);
+            let sql = sql_where.map_or_else(
+                || format!("DELETE FROM {table_name}"),
+                |filter| format!("DELETE FROM {table_name} WHERE {filter}"),
+            );
+            let count = tx.execute(&sql, [])?;
+            tx.commit()?;
+            Ok(count as u64)
+        })
+        .await?
+    }
+}
+
+struct DuckDBUpdateSink {
+    pool: Arc<DuckDbConnectionPool>,
+    table_definition: Arc<TableDefinition>,
+    set_clause: String,
+    sql_where: Option<String>,
+}
+
+#[async_trait]
+impl UpdateSink for DuckDBUpdateSink {
+    async fn execute_update(&self) -> Result<u64, Box<dyn std::error::Error + Send + Sync>> {
+        let pool = Arc::clone(&self.pool);
+        let table_definition = Arc::clone(&self.table_definition);
+        let set_clause = self.set_clause.clone();
+        let sql_where = self.sql_where.clone();
+        tokio::task::spawn_blocking(move || {
+            let write_gate = pool.write_gate();
+            let _guard = write_gate
+                .read()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            let mut db_conn = Arc::clone(&pool).connect_sync()?;
+            let duckdb_conn = DuckDB::duckdb_conn(&mut db_conn)?;
+            let tx = duckdb_conn.conn.transaction()?;
+            let table_name = table_definition.resolve_dml_table_name(&tx)?;
+            let table_name = quote_identifier(&table_name);
+            let sql = sql_where.map_or_else(
+                || format!("UPDATE {table_name} SET {set_clause}"),
+                |filter| format!("UPDATE {table_name} SET {set_clause} WHERE {filter}"),
+            );
+            let count = tx.execute(&sql, [])?;
+            tx.commit()?;
+            Ok(count as u64)
+        })
+        .await?
     }
 }
 
@@ -190,6 +380,8 @@ pub(crate) struct DuckDBDataSink {
     overwrite: InsertOp,
     on_conflict: Option<OnConflict>,
     schema: SchemaRef,
+    on_data_written: Option<WriteCompletionHandler>,
+    write_settings: DuckDBWriteSettings,
 }
 
 #[async_trait]
@@ -211,6 +403,8 @@ impl DataSink for DuckDBDataSink {
         let table_definition = Arc::clone(&self.table_definition);
         let overwrite = self.overwrite;
         let on_conflict = self.on_conflict.clone();
+        let on_data_written = self.on_data_written.clone();
+        let write_settings = self.write_settings.clone();
 
         // Limit channel size to a maximum of 100 RecordBatches queued for cases when DuckDB is slower than the writer stream,
         // so that we don't significantly increase memory usage. After the maximum RecordBatches are queued, the writer stream will wait
@@ -224,22 +418,43 @@ impl DataSink for DuckDBDataSink {
 
         let duckdb_write_handle: JoinHandle<datafusion::common::Result<u64>> =
             tokio::task::spawn_blocking(move || {
+                let write_context = WriteContext {
+                    on_conflict: on_conflict.as_ref(),
+                    on_data_written: on_data_written.as_ref(),
+                    schema: &schema,
+                    settings: &write_settings,
+                };
                 let num_rows = match overwrite {
-                    InsertOp::Overwrite => insert_overwrite(
-                        pool,
-                        &table_definition,
-                        batch_rx,
-                        on_conflict.as_ref(),
-                        on_commit_transaction,
-                        schema,
-                    )?,
+                    InsertOp::Overwrite => {
+                        if write_settings.overwrite_file_swap && pool.mode() == Mode::File {
+                            file_swap::insert_overwrite_swap(
+                                pool,
+                                &table_definition,
+                                batch_rx,
+                                on_commit_transaction,
+                                &write_context,
+                            )?
+                        } else {
+                            if write_settings.overwrite_file_swap {
+                                tracing::warn!(
+                                    "DuckDB overwrite file swap requires a file-backed instance; overwriting in place"
+                                );
+                            }
+                            insert_overwrite(
+                                pool,
+                                &table_definition,
+                                batch_rx,
+                                on_commit_transaction,
+                                &write_context,
+                            )?
+                        }
+                    }
                     InsertOp::Append | InsertOp::Replace => insert_append(
                         pool,
                         &table_definition,
                         batch_rx,
-                        on_conflict.as_ref(),
                         on_commit_transaction,
-                        schema,
+                        &write_context,
                     )?,
                 };
 
@@ -310,7 +525,21 @@ impl DuckDBDataSink {
             overwrite,
             on_conflict,
             schema,
+            on_data_written: None,
+            write_settings: DuckDBWriteSettings::default(),
         }
+    }
+
+    #[must_use]
+    pub fn with_on_data_written_handler(mut self, handler: WriteCompletionHandler) -> Self {
+        self.on_data_written = Some(handler);
+        self
+    }
+
+    #[must_use]
+    pub fn with_write_settings(mut self, settings: DuckDBWriteSettings) -> Self {
+        self.write_settings = settings;
+        self
     }
 }
 
@@ -330,10 +559,14 @@ fn insert_append(
     pool: Arc<DuckDbConnectionPool>,
     table_definition: &Arc<TableDefinition>,
     batch_rx: Receiver<RecordBatch>,
-    on_conflict: Option<&OnConflict>,
     mut on_commit_transaction: tokio::sync::oneshot::Receiver<()>,
-    schema: SchemaRef,
+    context: &WriteContext<'_>,
 ) -> datafusion::common::Result<u64> {
+    let write_gate = pool.write_gate();
+    let _write_guard = write_gate
+        .read()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+
     let mut db_conn = pool
         .connect_sync()
         .context(super::DbConnectionPoolSnafu)
@@ -392,7 +625,11 @@ fn insert_append(
         .current_schema(&tx)
         .map_err(to_retriable_data_write_error)?;
 
-    if SCHEMA_EQUIVALENCE_ENABLED && !schema.equivalent_names_and_types(&append_table_schema) {
+    if SCHEMA_EQUIVALENCE_ENABLED
+        && !context
+            .schema
+            .equivalent_names_and_types(&append_table_schema)
+    {
         return Err(DataFusionError::Execution(
             "Schema of the append table does not match the schema of the new append data."
                 .to_string(),
@@ -403,8 +640,21 @@ fn insert_append(
         "Append load for {table_name}",
         table_name = append_table.table_name()
     );
-    let num_rows = write_to_table(&append_table, &tx, schema, batch_rx, on_conflict)
-        .map_err(to_retriable_data_write_error)?;
+    let num_rows = write_to_table(
+        &append_table,
+        &tx,
+        Arc::clone(context.schema),
+        batch_rx,
+        context.on_conflict,
+    )
+    .map_err(to_retriable_data_write_error)?;
+
+    if let Some(callback) = context.on_data_written {
+        callback(&tx, &append_table, context.schema, num_rows)?;
+    }
+    if context.settings.recompute_statistics_on_write {
+        execute_analyze_sql(&tx, &append_table.table_name().to_string());
+    }
 
     on_commit_transaction
         .try_recv()
@@ -463,10 +713,14 @@ fn insert_overwrite(
     pool: Arc<DuckDbConnectionPool>,
     table_definition: &Arc<TableDefinition>,
     batch_rx: Receiver<RecordBatch>,
-    on_conflict: Option<&OnConflict>,
     mut on_commit_transaction: tokio::sync::oneshot::Receiver<()>,
-    schema: SchemaRef,
+    context: &WriteContext<'_>,
 ) -> datafusion::common::Result<u64> {
+    let write_gate = pool.write_gate();
+    let _write_guard = write_gate
+        .read()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+
     let cloned_pool = Arc::clone(&pool);
     let mut db_conn = pool
         .connect_sync()
@@ -558,8 +812,14 @@ fn insert_overwrite(
     }
 
     tracing::debug!("Initial load for {}", new_table.table_name());
-    let num_rows = write_to_table(&new_table, &tx, schema, batch_rx, on_conflict)
-        .map_err(to_retriable_data_write_error)?;
+    let num_rows = write_to_table(
+        &new_table,
+        &tx,
+        Arc::clone(context.schema),
+        batch_rx,
+        context.on_conflict,
+    )
+    .map_err(to_retriable_data_write_error)?;
 
     on_commit_transaction
         .try_recv()
@@ -574,6 +834,13 @@ fn insert_overwrite(
     new_table
         .create_view(&tx)
         .map_err(to_retriable_data_write_error)?;
+
+    if let Some(callback) = context.on_data_written {
+        callback(&tx, &new_table, context.schema, num_rows)?;
+    }
+    if context.settings.recompute_statistics_on_write {
+        execute_analyze_sql(&tx, &new_table.table_name().to_string());
+    }
 
     tx.commit()
         .context(super::UnableToCommitTransactionSnafu)
@@ -605,12 +872,52 @@ fn insert_overwrite(
         .context(super::UnableToCommitTransactionSnafu)
         .map_err(to_retriable_data_write_error)?;
 
+    if context.settings.checkpoint_on_write {
+        checkpoint_after_write(duckdb_conn, table_definition.name());
+    }
+
     Ok(num_rows)
+}
+
+fn checkpoint_after_write(
+    duckdb_conn: &mut crate::conn::DuckDbConnection,
+    table_name: &super::RelationName,
+) {
+    fn single_line(error: &duckdb::Error) -> String {
+        error.to_string().replace('\n', " ")
+    }
+
+    let start = std::time::Instant::now();
+    let force = match duckdb_conn.conn.execute_batch("CHECKPOINT") {
+        Ok(()) => false,
+        Err(checkpoint_error) => {
+            tracing::debug!(
+                "CHECKPOINT after overwrite of {table_name} could not run ({}); escalating to FORCE CHECKPOINT",
+                single_line(&checkpoint_error)
+            );
+            match duckdb_conn.conn.execute_batch("FORCE CHECKPOINT") {
+                Ok(()) => true,
+                Err(force_error) => {
+                    tracing::warn!(
+                        duration_ms = start.elapsed().as_millis() as u64,
+                        "Failed to checkpoint DuckDB after overwrite of {table_name}: {}",
+                        single_line(&force_error),
+                    );
+                    return;
+                }
+            }
+        }
+    };
+    tracing::debug!(
+        force,
+        duration_ms = start.elapsed().as_millis() as u64,
+        "Checkpoint after overwrite of {table_name} complete"
+    );
 }
 
 #[allow(clippy::doc_markdown)]
 /// Writes a stream of ``RecordBatch``es to a DuckDB table.
-fn write_to_table(
+pub(super) fn write_to_table(
     table: &TableManager,
     tx: &Transaction<'_>,
     schema: SchemaRef,
@@ -677,6 +984,16 @@ fn write_to_table(
     Ok(rows as u64)
 }
 
+/// Update DuckDB optimizer statistics after a write. Statistics failures are
+/// non-fatal because the data transaction itself remains valid.
+pub fn execute_analyze_sql(tx: &Transaction<'_>, table_name: &str) {
+    let analyze_sql = format!("ANALYZE {}", quote_identifier(table_name));
+    tracing::debug!("Executing analyze SQL: {analyze_sql}");
+    if let Err(error) = tx.execute(&analyze_sql, []) {
+        tracing::warn!("Failed to analyze DuckDB table '{table_name}': {error}");
+    }
+}
+
 fn decode_dictionary_columns(batch: RecordBatch) -> Result<RecordBatch, ArrowError> {
     let mut decoded = false;
     let mut fields = Vec::with_capacity(batch.num_columns());
@@ -717,10 +1034,10 @@ mod test {
     use datafusion::physical_plan::memory::MemoryStream;
 
     use super::*;
+    use crate::creator::tests::{get_basic_table_definition, get_mem_duckdb, init_tracing};
     use crate::RelationName;
-    use crate::{
-        duckdb::creator::tests::{get_basic_table_definition, get_mem_duckdb, init_tracing},
-        util::{column_reference::ColumnReference, indexes::IndexType},
+    use datafusion_table_providers_common::util::{
+        column_reference::ColumnReference, indexes::IndexType,
     };
 
     #[tokio::test]
@@ -1334,5 +1651,97 @@ mod test {
         assert_eq!(indexes.len(), 1);
 
         tx.rollback().expect("to rollback");
+    }
+
+    #[tokio::test]
+    async fn delete_and_update_target_view_backing_table() {
+        let pool = get_mem_duckdb();
+        let table_definition = get_basic_table_definition();
+        let batch = RecordBatch::try_new(
+            table_definition.schema(),
+            vec![
+                Arc::new(Int64Array::from(vec![1, 2, 3])),
+                Arc::new(StringArray::from(vec!["a", "b", "c"])),
+            ],
+        )
+        .expect("batch");
+        let stream = Box::pin(
+            MemoryStream::try_new(vec![batch], table_definition.schema(), None).expect("stream"),
+        );
+        DuckDBDataSink::new(
+            Arc::clone(&pool),
+            Arc::clone(&table_definition),
+            InsertOp::Overwrite,
+            None,
+            table_definition.schema(),
+        )
+        .write_all(stream, &Arc::new(TaskContext::default()))
+        .await
+        .expect("overwrite");
+
+        let read_provider: Arc<dyn TableProvider> = Arc::new(
+            datafusion::datasource::MemTable::try_new(table_definition.schema(), vec![vec![]])
+                .expect("mem table"),
+        );
+        let writer = DuckDBTableWriterBuilder::new()
+            .with_read_provider(read_provider)
+            .with_pool(Arc::clone(&pool))
+            .with_table_definition((*table_definition).clone())
+            .build()
+            .expect("writer");
+        let ctx = datafusion::prelude::SessionContext::new();
+
+        let delete = writer
+            .delete_from(
+                &ctx.state(),
+                vec![datafusion::logical_expr::col("id").eq(datafusion::logical_expr::lit(2_i64))],
+            )
+            .await
+            .expect("delete plan");
+        let deleted = datafusion::physical_plan::collect(delete, Arc::new(TaskContext::default()))
+            .await
+            .expect("delete result");
+        assert_eq!(
+            deleted[0]
+                .column(0)
+                .as_any()
+                .downcast_ref::<arrow::array::UInt64Array>()
+                .expect("count")
+                .value(0),
+            1
+        );
+
+        let update = writer
+            .update(
+                &ctx.state(),
+                vec![("name".to_string(), datafusion::logical_expr::lit("updated"))],
+                vec![datafusion::logical_expr::col("id").eq(datafusion::logical_expr::lit(3_i64))],
+            )
+            .await
+            .expect("update plan");
+        let updated = datafusion::physical_plan::collect(update, Arc::new(TaskContext::default()))
+            .await
+            .expect("update result");
+        assert_eq!(
+            updated[0]
+                .column(0)
+                .as_any()
+                .downcast_ref::<arrow::array::UInt64Array>()
+                .expect("count")
+                .value(0),
+            1
+        );
+
+        let mut connection = Arc::clone(&pool).connect_sync().expect("connection");
+        let duckdb = DuckDB::duckdb_conn(&mut connection).expect("duckdb");
+        let rows: Vec<(i64, String)> = duckdb
+            .conn
+            .prepare("SELECT id, name FROM test_table ORDER BY id")
+            .expect("prepare")
+            .query_map([], |row| Ok((row.get(0)?, row.get(1)?)))
+            .expect("query")
+            .collect::<std::result::Result<_, _>>()
+            .expect("rows");
+        assert_eq!(rows, vec![(1, "a".to_string()), (3, "updated".to_string())]);
     }
 }

--- a/crates/duckdb/src/write_settings.rs
+++ b/crates/duckdb/src/write_settings.rs
@@ -1,0 +1,210 @@
+use std::collections::HashMap;
+
+/// Configuration settings for DuckDB write operations
+#[derive(Debug, Clone)]
+pub struct DuckDBWriteSettings {
+    /// Whether to execute ANALYZE statements after data write operations
+    /// to update table statistics for query optimization
+    pub recompute_statistics_on_write: bool,
+    /// Whether an `InsertOp::Overwrite` on a file-backed instance writes into a
+    /// fresh database file and atomically swaps it in (reclaiming disk space
+    /// and leaving a checkpointed, WAL-free file) instead of rewriting the
+    /// table inside the live file. See [`crate::file_swap`].
+    ///
+    /// This and [`Self::checkpoint_on_write`] are two answers to the same
+    /// problem — a repeated overwrite never reclaiming the space of the
+    /// generations it drops — with different costs, and they do not stack. On a
+    /// file-backed instance this one takes over the whole overwrite, so
+    /// `checkpoint_on_write` never runs; the replacement always produces a
+    /// checkpointed file anyway. When it cannot apply (an in-memory instance)
+    /// the overwrite falls back in place and `checkpoint_on_write` applies as
+    /// usual.
+    pub overwrite_file_swap: bool,
+    /// Whether to execute a checkpoint after an overwrite completes.
+    ///
+    /// Cheaper than [`Self::overwrite_file_swap`], but it checkpoints the *live*
+    /// instance: the plain `CHECKPOINT` fails while other transactions are open
+    /// and escalates to `FORCE CHECKPOINT`, which aborts them. Prefer
+    /// `overwrite_file_swap` where in-flight queries must not be interrupted.
+    pub checkpoint_on_write: bool,
+}
+
+impl Default for DuckDBWriteSettings {
+    fn default() -> Self {
+        Self {
+            recompute_statistics_on_write: true, // Enabled by default for better query performance
+            overwrite_file_swap: false,
+            checkpoint_on_write: false, // Disabled by default to avoid unnecessary overhead unless explicitly requested
+        }
+    }
+}
+
+impl DuckDBWriteSettings {
+    /// Create a new `DuckDBWriteSettings` with default values
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Set whether to recompute statistics on write
+    #[must_use]
+    pub fn with_recompute_statistics_on_write(mut self, enabled: bool) -> Self {
+        self.recompute_statistics_on_write = enabled;
+        self
+    }
+
+    /// Set whether overwrites swap in a freshly written database file
+    #[must_use]
+    pub fn with_overwrite_file_swap(mut self, enabled: bool) -> Self {
+        self.overwrite_file_swap = enabled;
+        self
+    }
+
+    /// Set whether to checkpoint the database after an overwrite completes
+    #[must_use]
+    pub fn with_checkpoint_on_write(mut self, enabled: bool) -> Self {
+        self.checkpoint_on_write = enabled;
+        self
+    }
+
+    /// Parse settings from  table creation parameters
+    #[must_use]
+    pub fn from_params(params: &HashMap<String, String>) -> Self {
+        let mut settings = Self::default();
+
+        if let Some(value) = params.get("recompute_statistics_on_write") {
+            settings.recompute_statistics_on_write = match value.to_lowercase().as_str() {
+                "true" | "enabled" => true,
+                "false" | "disabled" => false,
+                _ => {
+                    tracing::warn!(
+                "Invalid value for recompute statistics on write parameter: '{value}'. Expected 'enabled' or 'disabled'. Using default: {}",
+                settings.recompute_statistics_on_write
+                );
+                    settings.recompute_statistics_on_write
+                }
+            };
+        }
+
+        if let Some(value) = params.get("overwrite_file_swap") {
+            settings.overwrite_file_swap = match value.to_lowercase().as_str() {
+                "true" | "enabled" => true,
+                "false" | "disabled" => false,
+                _ => {
+                    tracing::warn!(
+                        "Invalid value for overwrite file swap parameter: '{value}'. Expected 'enabled' or 'disabled'. Using default: {}",
+                        settings.overwrite_file_swap
+                    );
+                    settings.overwrite_file_swap
+                }
+            };
+        }
+
+        if let Some(value) = params.get("checkpoint_on_write") {
+            settings.checkpoint_on_write = match value.to_lowercase().as_str() {
+                "true" | "enabled" => true,
+                "false" | "disabled" => false,
+                _ => {
+                    tracing::warn!(
+                        "Invalid value for checkpoint on write parameter: '{value}'. Expected one of 'enabled', 'disabled', 'true', 'false'. Using default: {}",
+                        settings.checkpoint_on_write
+                    );
+                    settings.checkpoint_on_write
+                }
+            };
+        }
+
+        settings
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    #[test]
+    fn test_default_settings() {
+        let settings = DuckDBWriteSettings::default();
+        assert!(settings.recompute_statistics_on_write);
+    }
+
+    #[test]
+    fn test_new_settings() {
+        let settings = DuckDBWriteSettings::new();
+        assert!(settings.recompute_statistics_on_write);
+    }
+
+    #[test]
+    fn test_with_recompute_statistics_on_write() {
+        let settings = DuckDBWriteSettings::new().with_recompute_statistics_on_write(false);
+        assert!(!settings.recompute_statistics_on_write);
+    }
+
+    #[test]
+    fn test_from_params_valid_enabled() {
+        let mut params = HashMap::new();
+        params.insert(
+            "recompute_statistics_on_write".to_string(),
+            "enabled".to_string(),
+        );
+
+        let settings = DuckDBWriteSettings::from_params(&params);
+        assert!(settings.recompute_statistics_on_write);
+    }
+
+    #[test]
+    fn test_from_params_valid_disabled() {
+        let mut params = HashMap::new();
+        params.insert(
+            "recompute_statistics_on_write".to_string(),
+            "disabled".to_string(),
+        );
+
+        let settings = DuckDBWriteSettings::from_params(&params);
+        assert!(!settings.recompute_statistics_on_write);
+    }
+
+    #[test]
+    fn test_from_params_invalid_value() {
+        let mut params = HashMap::new();
+        params.insert(
+            "recompute_statistics_on_write".to_string(),
+            "invalid".to_string(),
+        );
+
+        let settings = DuckDBWriteSettings::from_params(&params);
+        // Should fall back to default (true) and log a warning
+        assert!(settings.recompute_statistics_on_write);
+    }
+
+    #[test]
+    fn test_from_params_missing_param() {
+        let params = HashMap::new();
+
+        let settings = DuckDBWriteSettings::from_params(&params);
+        // Should use default value
+        assert!(settings.recompute_statistics_on_write);
+        assert!(!settings.checkpoint_on_write);
+    }
+
+    #[test]
+    fn test_with_checkpoint_on_write() {
+        let settings = DuckDBWriteSettings::new().with_checkpoint_on_write(true);
+        assert!(settings.checkpoint_on_write);
+    }
+
+    #[test]
+    fn test_from_params_checkpoint_on_write() {
+        let mut params = HashMap::new();
+        params.insert("checkpoint_on_write".to_string(), "enabled".to_string());
+        assert!(DuckDBWriteSettings::from_params(&params).checkpoint_on_write);
+
+        params.insert("checkpoint_on_write".to_string(), "false".to_string());
+        assert!(!DuckDBWriteSettings::from_params(&params).checkpoint_on_write);
+
+        params.insert("checkpoint_on_write".to_string(), "bogus".to_string());
+        // Should fall back to default (false) and log a warning
+        assert!(!DuckDBWriteSettings::from_params(&params).checkpoint_on_write);
+    }
+}

--- a/crates/mongodb/src/connection.rs
+++ b/crates/mongodb/src/connection.rs
@@ -11,10 +11,13 @@ use mongodb::{
 use snafu::prelude::*;
 use std::sync::Arc;
 
+use crate::projection::project_bson_document;
 use crate::utils::arrow::mongo_docs_to_arrow;
 use crate::utils::schema::infer_arrow_schema_from_documents;
 use crate::utils::unnest::{unnest_bson_documents, UnnestBehavior, UnnestParameters};
 use crate::{Error, QuerySnafu, Result, UnableToGetSchemaSnafu, UnableToGetTablesSnafu};
+use datafusion_table_providers_common::schema_projection::SchemaProjection;
+use datafusion_table_providers_common::util::schema::merge_inferred_and_declared_schemas;
 
 pub struct MongoDBConnection {
     pub client: Arc<Client>,
@@ -56,6 +59,15 @@ impl MongoDBConnection {
     }
 
     pub async fn get_schema(&self, table_reference: &TableReference) -> Result<SchemaRef, Error> {
+        self.get_schema_with_declared_schema(table_reference, None)
+            .await
+    }
+
+    pub async fn get_schema_with_declared_schema(
+        &self,
+        table_reference: &TableReference,
+        declared_schema: Option<SchemaRef>,
+    ) -> Result<SchemaRef, Error> {
         let collection_name = table_reference.table();
         let coll = self.get_collection(collection_name);
 
@@ -77,9 +89,24 @@ impl MongoDBConnection {
             _ => unnest_bson_documents(docs, &self.unnest_parameters)?,
         };
 
-        infer_arrow_schema_from_documents(&unnested_docs, self.tz.clone().as_deref())
-            .boxed()
-            .context(UnableToGetSchemaSnafu)
+        if unnested_docs.is_empty() {
+            return match declared_schema {
+                Some(schema) => Ok(schema),
+                None => Err(Error::EmptyCollection {
+                    collection_name: collection_name.to_string(),
+                }),
+            };
+        }
+
+        let inferred =
+            infer_arrow_schema_from_documents(&unnested_docs, self.tz.clone().as_deref())
+                .boxed()
+                .context(UnableToGetSchemaSnafu)?;
+
+        Ok(merge_inferred_and_declared_schemas(
+            inferred,
+            declared_schema.as_ref(),
+        ))
     }
 
     pub async fn query_arrow(
@@ -90,12 +117,37 @@ impl MongoDBConnection {
         limit: Option<i32>,
         sort_doc: &Document,
     ) -> Result<SendableRecordBatchStream> {
+        self.query_arrow_with_projection(
+            table_reference,
+            projected_schema,
+            filters_doc,
+            limit,
+            sort_doc,
+            None,
+        )
+        .await
+    }
+
+    pub async fn query_arrow_with_projection(
+        &self,
+        table_reference: &Arc<TableReference>,
+        projected_schema: &SchemaRef,
+        filters_doc: &Document,
+        limit: Option<i32>,
+        sort_doc: &Document,
+        schema_projection: Option<&SchemaProjection>,
+    ) -> Result<SendableRecordBatchStream> {
         let collection_name = table_reference.table();
         let coll = self.get_collection(collection_name);
 
-        let mut find = coll
-            .find(filters_doc.clone())
-            .projection(schema_to_mongo_projection(projected_schema));
+        let nesting = schema_projection.filter(|p| p.has_catch_all());
+        let mongo_projection = if nesting.is_some() {
+            Document::new()
+        } else {
+            schema_to_mongo_projection(projected_schema)
+        };
+
+        let mut find = coll.find(filters_doc.clone()).projection(mongo_projection);
 
         if !sort_doc.is_empty() {
             find = find.sort(sort_doc.clone());
@@ -109,6 +161,7 @@ impl MongoDBConnection {
         let chunked_stream = cursor.try_chunks(4_000);
         let projected_schema_clone = Arc::clone(projected_schema);
         let unnest_parameters = self.unnest_parameters.clone();
+        let projection = schema_projection.filter(|p| p.has_catch_all()).cloned();
 
         let schema = Arc::clone(projected_schema);
         let batch_stream = stream! {
@@ -122,7 +175,15 @@ impl MongoDBConnection {
                             }
                         };
 
-                        let batch = mongo_docs_to_arrow(&unnested_docs, Arc::clone(&projected_schema_clone))?;
+                        let projected_docs = match &projection {
+                            Some(projection) => unnested_docs
+                                .into_iter()
+                                .map(|doc| project_bson_document(doc, projection))
+                                .collect(),
+                            None => unnested_docs,
+                        };
+
+                        let batch = mongo_docs_to_arrow(&projected_docs, Arc::clone(&projected_schema_clone))?;
                         yield Ok(batch);
                     }
                     Err(e) => yield Err(Error::QueryError { source: Box::new(e) }),

--- a/crates/mongodb/src/lib.rs
+++ b/crates/mongodb/src/lib.rs
@@ -1,13 +1,16 @@
 pub mod connection;
 pub mod connection_pool;
+pub mod projection;
 pub mod table;
 pub mod utils;
 
 use crate::connection_pool::MongoDBConnectionPool;
 use crate::table::MongoDBTable;
 use arrow_schema::ArrowError;
+use datafusion::arrow::datatypes::SchemaRef;
 use datafusion::datasource::TableProvider;
 use datafusion::sql::TableReference;
+use datafusion_table_providers_common::schema_projection::SchemaProjection;
 use snafu::prelude::*;
 use std::sync::Arc;
 
@@ -34,6 +37,11 @@ pub enum Error {
     UnableToGetSchema {
         source: Box<dyn std::error::Error + std::marker::Send + Sync>,
     },
+
+    #[snafu(display(
+        "Unable to infer schema. Collection empty or non-existent: {collection_name}"
+    ))]
+    EmptyCollection { collection_name: String },
 
     #[snafu(display("Unable to get schemas: {source}"))]
     UnableToGetSchemas {
@@ -76,9 +84,22 @@ impl MongoDBTableFactory {
         &self,
         table_reference: TableReference,
     ) -> Result<Arc<dyn TableProvider + 'static>, Box<dyn std::error::Error + Send + Sync>> {
+        self.table_provider_with_projection(table_reference, None, None)
+            .await
+    }
+
+    /// Build a provider with an optional declared schema and connector-agnostic
+    /// row projection. A declared schema permits registering an empty collection;
+    /// a projection can fold undeclared fields into one JSON catch-all column.
+    pub async fn table_provider_with_projection(
+        &self,
+        table_reference: TableReference,
+        declared_schema: Option<SchemaRef>,
+        projection: Option<SchemaProjection>,
+    ) -> Result<Arc<dyn TableProvider + 'static>, Box<dyn std::error::Error + Send + Sync>> {
         let pool = Arc::clone(&self.pool);
         let table_provider = Arc::new(
-            MongoDBTable::new(&pool, table_reference)
+            MongoDBTable::new_with_projection(&pool, table_reference, declared_schema, projection)
                 .await
                 .map_err(|e| Box::new(e) as Box<dyn std::error::Error + Send + Sync>)?,
         );

--- a/crates/mongodb/src/projection.rs
+++ b/crates/mongodb/src/projection.rs
@@ -1,0 +1,112 @@
+//! `RowShape` adapter for MongoDB BSON, letting the connector-agnostic
+//! [`datafusion_table_providers_common::schema_projection`] core apply JSON
+//! nesting to MongoDB documents on the scan path.
+
+use datafusion_table_providers_common::schema_projection::{RowShape, SchemaProjection};
+use mongodb::bson::{Bson, Document};
+
+/// Local wrapper that permits implementing the common projection trait for BSON
+/// without violating Rust's orphan rules.
+struct BsonRow(Bson);
+
+impl RowShape for BsonRow {
+    fn into_object(self) -> Result<Vec<(String, Self)>, Self> {
+        match self.0 {
+            Bson::Document(doc) => Ok(doc
+                .into_iter()
+                .map(|(key, value)| (key, Self(value)))
+                .collect()),
+            other => Err(Self(other)),
+        }
+    }
+
+    fn from_object(entries: Vec<(String, Self)>) -> Self {
+        Self(Bson::Document(
+            entries
+                .into_iter()
+                .map(|(key, value)| (key, value.0))
+                .collect(),
+        ))
+    }
+
+    fn to_json(&self) -> serde_json::Value {
+        // Relaxed Extended JSON keeps ordinary values (numbers, strings, bools)
+        // as plain JSON while round-tripping MongoDB-specific types.
+        self.0.clone().into_relaxed_extjson()
+    }
+
+    fn from_json_string(json: String) -> Self {
+        Self(Bson::String(json))
+    }
+}
+
+/// Reshape one BSON document through a [`SchemaProjection`], preserving the
+/// `Document` type. Non-declared fields are folded into the catch-all column.
+#[must_use]
+pub fn project_bson_document(doc: Document, projection: &SchemaProjection) -> Document {
+    match projection.project_row(BsonRow(Bson::Document(doc))).0 {
+        Bson::Document(doc) => doc,
+        _ => Document::new(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use datafusion_table_providers_common::schema_projection::{ColumnSource, ProjectedColumn};
+    use mongodb::bson::doc;
+
+    fn nesting_projection() -> SchemaProjection {
+        SchemaProjection::new(
+            vec![
+                ProjectedColumn {
+                    output_name: "_id".to_string(),
+                    source: ColumnSource::Field,
+                    declared_type: None,
+                    nullable: true,
+                },
+                ProjectedColumn {
+                    output_name: "data".to_string(),
+                    source: ColumnSource::JsonObject,
+                    declared_type: None,
+                    nullable: true,
+                },
+            ],
+            &["_id".to_string()],
+        )
+        .expect("projection")
+    }
+
+    #[test]
+    fn folds_non_declared_fields_into_catch_all() {
+        let projection = nesting_projection();
+        let doc = doc! { "_id": "row1", "zeta": 2, "alpha": 1 };
+        let out = project_bson_document(doc, &projection);
+
+        assert_eq!(out.get_str("_id").expect("_id"), "row1");
+        // Non-declared fields, alphabetically sorted, in the catch-all string.
+        assert_eq!(
+            out.get_str("data").expect("data"),
+            r#"{"alpha":1,"zeta":2}"#
+        );
+        assert!(!out.contains_key("zeta"));
+    }
+
+    #[test]
+    fn identity_projection_passes_through() {
+        // No catch-all → document unchanged.
+        let projection = SchemaProjection::new(
+            vec![ProjectedColumn {
+                output_name: "_id".to_string(),
+                source: ColumnSource::Field,
+                declared_type: None,
+                nullable: true,
+            }],
+            &[],
+        )
+        .expect("projection");
+        let doc = doc! { "_id": "row1", "other": 5 };
+        let out = project_bson_document(doc.clone(), &projection);
+        assert_eq!(out, doc);
+    }
+}

--- a/crates/mongodb/src/table.rs
+++ b/crates/mongodb/src/table.rs
@@ -17,6 +17,7 @@ use datafusion::physical_plan::{
     SendableRecordBatchStream,
 };
 use datafusion::sql::TableReference;
+use datafusion_table_providers_common::schema_projection::SchemaProjection;
 use futures::TryStreamExt;
 use mongodb::bson::Document;
 use serde_json;
@@ -27,6 +28,7 @@ pub struct MongoDBTable {
     pool: Arc<MongoDBConnectionPool>,
     schema: SchemaRef,
     table_reference: Arc<TableReference>,
+    projection: Option<SchemaProjection>,
 }
 
 impl MongoDBTable {
@@ -34,13 +36,30 @@ impl MongoDBTable {
         pool: &Arc<MongoDBConnectionPool>,
         table_reference: impl Into<TableReference>,
     ) -> Result<Self, Error> {
+        Self::new_with_projection(pool, table_reference, None, None).await
+    }
+
+    pub async fn new_with_projection(
+        pool: &Arc<MongoDBConnectionPool>,
+        table_reference: impl Into<TableReference>,
+        declared_schema: Option<SchemaRef>,
+        projection: Option<SchemaProjection>,
+    ) -> Result<Self, Error> {
         let table_reference = table_reference.into();
-        let schema = pool.connect().await?.get_schema(&table_reference).await?;
+        let schema = pool
+            .connect()
+            .await?
+            .get_schema_with_declared_schema(&table_reference, declared_schema)
+            .await?;
+        let schema = projection.as_ref().map_or(schema.clone(), |projection| {
+            projection.project_schema(schema)
+        });
 
         Ok(Self {
             pool: Arc::clone(pool),
             schema,
             table_reference: Arc::new(table_reference),
+            projection,
         })
     }
 }
@@ -62,13 +81,14 @@ impl TableProvider for MongoDBTable {
         filters: &[Expr],
         limit: Option<usize>,
     ) -> DataFusionResult<Arc<dyn ExecutionPlan>> {
-        Ok(Arc::new(MongoDBExec::new(
+        Ok(Arc::new(MongoDBExec::new_with_projection(
             Arc::clone(&self.table_reference),
             Arc::clone(&self.pool),
             Arc::clone(&self.schema),
             projection,
             filters,
             limit,
+            self.projection.clone(),
         )?))
     }
 
@@ -103,9 +123,11 @@ struct MongoDBExec {
     sort_doc: Document,
     limit: Option<i32>,
     properties: Arc<PlanProperties>,
+    schema_projection: Option<SchemaProjection>,
 }
 
 impl MongoDBExec {
+    #[cfg(test)]
     pub fn new(
         table_reference: Arc<TableReference>,
         pool: Arc<MongoDBConnectionPool>,
@@ -113,6 +135,26 @@ impl MongoDBExec {
         projections: Option<&Vec<usize>>,
         filters: &[Expr],
         limit: Option<usize>,
+    ) -> DataFusionResult<Self> {
+        Self::new_with_projection(
+            table_reference,
+            pool,
+            schema,
+            projections,
+            filters,
+            limit,
+            None,
+        )
+    }
+
+    pub fn new_with_projection(
+        table_reference: Arc<TableReference>,
+        pool: Arc<MongoDBConnectionPool>,
+        schema: SchemaRef,
+        projections: Option<&Vec<usize>>,
+        filters: &[Expr],
+        limit: Option<usize>,
+        schema_projection: Option<SchemaProjection>,
     ) -> DataFusionResult<Self> {
         let mut projected_schema = project_schema(&schema, projections)?;
 
@@ -161,6 +203,7 @@ impl MongoDBExec {
                 EmissionType::Final,
                 Boundedness::Bounded,
             )),
+            schema_projection,
         })
     }
 }
@@ -244,6 +287,7 @@ impl ExecutionPlan for MongoDBExec {
             sort_doc,
             limit: self.limit,
             properties: self.properties.clone(),
+            schema_projection: self.schema_projection.clone(),
         };
 
         // Update equivalence properties to reflect the output ordering
@@ -278,16 +322,18 @@ impl ExecutionPlan for MongoDBExec {
         let filters_doc = self.filters_doc.clone();
         let sort_doc = self.sort_doc.clone();
         let limit = self.limit;
+        let schema_projection = self.schema_projection.clone();
 
         let stream = futures::stream::once(async move {
             let conn = pool.connect().await.map_err(to_execution_error)?;
 
-            conn.query_arrow(
+            conn.query_arrow_with_projection(
                 &table_reference,
                 &projected_schema,
                 &filters_doc,
                 limit,
                 &sort_doc,
+                schema_projection.as_ref(),
             )
             .await
             .map_err(to_execution_error)

--- a/crates/mysql/src/arrow_sql_gen.rs
+++ b/crates/mysql/src/arrow_sql_gen.rs
@@ -61,6 +61,9 @@ pub enum Error {
 
     #[snafu(display("Projected schema field \"{field_name}\" not found in query result"))]
     FieldNotFoundInResult { field_name: String },
+
+    #[snafu(display("Unsupported MySQL column type {mysql_type}"))]
+    UnsupportedColumnType { mysql_type: String },
 }
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
@@ -622,7 +625,12 @@ pub fn rows_to_arrow(rows: &[Row], projected_schema: &Option<SchemaRef>) -> Resu
                         None => builder.append_null(),
                     }
                 }
-                _ => unimplemented!("Unsupported column type {:?}", mysql_type),
+                _ => {
+                    return UnsupportedColumnTypeSnafu {
+                        mysql_type: format!("{mysql_type:?}"),
+                    }
+                    .fail();
+                }
             }
         }
     }
@@ -681,7 +689,6 @@ pub fn rows_to_arrow(rows: &[Row], projected_schema: &Option<SchemaRef>) -> Resu
     Ok(batch)
 }
 
-#[allow(clippy::unnecessary_wraps)]
 #[allow(clippy::fn_params_excessive_bools)]
 pub fn map_column_to_data_type(
     column_type: ColumnType,
@@ -769,9 +776,7 @@ pub fn map_column_to_data_type(
         | ColumnType::MYSQL_TYPE_TINY_BLOB
         | ColumnType::MYSQL_TYPE_MEDIUM_BLOB
         | ColumnType::MYSQL_TYPE_GEOMETRY
-        | ColumnType::MYSQL_TYPE_VECTOR => {
-            unimplemented!("Unsupported column type {:?}", column_type)
-        }
+        | ColumnType::MYSQL_TYPE_VECTOR => None,
     }
 }
 
@@ -832,5 +837,49 @@ fn handle_null_error<T>(
         Ok(val) => Ok(val),
         Err(FromValueError(Value::NULL)) => Ok(None),
         err => err,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn map_column_to_data_type_unsupported_returns_none() {
+        for column_type in [
+            ColumnType::MYSQL_TYPE_GEOMETRY,
+            ColumnType::MYSQL_TYPE_VECTOR,
+            ColumnType::MYSQL_TYPE_TYPED_ARRAY,
+            ColumnType::MYSQL_TYPE_UNKNOWN,
+            ColumnType::MYSQL_TYPE_LONG_BLOB,
+            ColumnType::MYSQL_TYPE_TINY_BLOB,
+            ColumnType::MYSQL_TYPE_MEDIUM_BLOB,
+        ] {
+            assert_eq!(
+                map_column_to_data_type(column_type, false, false, false, false, None, None),
+                None,
+                "expected None for unsupported column type {column_type:?}",
+            );
+        }
+    }
+
+    #[test]
+    fn map_column_to_data_type_supported_examples() {
+        let cases = [
+            (ColumnType::MYSQL_TYPE_TINY, DataType::Int8),
+            (ColumnType::MYSQL_TYPE_SHORT, DataType::Int16),
+            (ColumnType::MYSQL_TYPE_LONG, DataType::Int32),
+            (ColumnType::MYSQL_TYPE_LONGLONG, DataType::Int64),
+            (ColumnType::MYSQL_TYPE_FLOAT, DataType::Float32),
+            (ColumnType::MYSQL_TYPE_DOUBLE, DataType::Float64),
+            (ColumnType::MYSQL_TYPE_DATE, DataType::Date32),
+        ];
+        for (column_type, expected) in cases {
+            assert_eq!(
+                map_column_to_data_type(column_type, false, false, false, false, None, None),
+                Some(expected.clone()),
+                "unexpected mapping for {column_type:?}",
+            );
+        }
     }
 }

--- a/crates/odbc/src/conn.rs
+++ b/crates/odbc/src/conn.rs
@@ -157,23 +157,38 @@ where
         &self,
         table_reference: &TableReference,
     ) -> Result<SchemaRef, dbconnection::Error> {
-        let cxn = self.conn.lock().await;
-
-        let mut prepared = cxn
-            .prepare(&format!(
-                "SELECT * FROM {} LIMIT 1",
-                table_reference.to_quoted_string()
-            ))
-            .boxed()
-            .map_err(|e| dbconnection::Error::UnableToGetSchema { source: e })?;
-
-        let schema = Arc::new(
-            arrow_schema_from(&mut prepared, None, false)
-                .boxed()
-                .map_err(|e| dbconnection::Error::UnableToGetSchema { source: e })?,
+        let conn = Arc::clone(&self.conn);
+        let sql = format!(
+            "SELECT * FROM {} LIMIT 1",
+            table_reference.to_quoted_string()
         );
 
-        Ok(schema)
+        let get_schema = async || -> Result<SchemaRef, dbconnection::Error> {
+            let join_handle = tokio::task::spawn_blocking(move || {
+                let handle = Handle::current();
+                let cxn = handle.block_on(async { conn.lock().await });
+
+                let mut prepared = cxn
+                    .prepare(&sql)
+                    .boxed()
+                    .map_err(|e| dbconnection::Error::UnableToGetSchema { source: e })?;
+
+                let schema = Arc::new(
+                    arrow_schema_from(&mut prepared, None, false)
+                        .boxed()
+                        .map_err(|e| dbconnection::Error::UnableToGetSchema { source: e })?,
+                );
+
+                Ok::<SchemaRef, dbconnection::Error>(schema)
+            });
+
+            join_handle
+                .await
+                .map_err(|e| dbconnection::Error::UnableToGetSchema {
+                    source: Box::new(e),
+                })?
+        };
+        run_async_with_tokio(get_schema).await
     }
 
     async fn query_arrow(
@@ -263,18 +278,44 @@ where
     }
 
     async fn execute(&self, query: &str, params: &[ODBCParameter]) -> Result<u64> {
-        let cxn = self.conn.lock().await;
-        let prepared = cxn.prepare(query)?;
-        let mut statement = prepared.into_handle();
+        let conn = Arc::clone(&self.conn);
+        let query = query.to_string();
+        let params = params.iter().map(dyn_clone::clone).collect::<Vec<_>>();
 
-        bind_parameters(&mut statement, params)?;
+        let execute = async || -> Result<u64> {
+            let join_handle = tokio::task::spawn_blocking(move || {
+                let handle = Handle::current();
+                let cxn = handle.block_on(async { conn.lock().await });
 
-        let row_count = unsafe {
-            statement.execute().unwrap();
-            statement.row_count()
+                let prepared = cxn.prepare(&query)?;
+                let mut statement = prepared.into_handle();
+
+                bind_parameters(&mut statement, &params)?;
+
+                let row_count = unsafe {
+                    if let SqlResult::Error { function } = statement.execute() {
+                        return Err(Error::ODBCAPIErrorNoSource {
+                            message: function.to_string(),
+                        }
+                        .into());
+                    }
+                    match statement.row_count() {
+                        SqlResult::Success(count) | SqlResult::SuccessWithInfo(count) => count,
+                        result => {
+                            return Err(Error::ODBCAPIErrorNoSource {
+                                message: format!("SQLRowCount returned {result:?}"),
+                            }
+                            .into());
+                        }
+                    }
+                };
+
+                Ok::<u64, GenericError>(row_count.try_into().context(TryFromSnafu)?)
+            });
+
+            join_handle.await.map_err(|e| Box::new(e) as GenericError)?
         };
-
-        Ok(row_count.unwrap().try_into().context(TryFromSnafu)?)
+        run_async_with_tokio(execute).await
     }
 }
 

--- a/crates/odbc/src/pool.rs
+++ b/crates/odbc/src/pool.rs
@@ -17,7 +17,9 @@ limitations under the License.
 use crate::conn::ODBCConnection;
 use crate::conn::{ODBCDbConnection, ODBCParameter};
 use async_trait::async_trait;
-use datafusion_table_providers_common::sql::db_connection_pool::{DbConnectionPool, JoinPushDown};
+use datafusion_table_providers_common::sql::db_connection_pool::{
+    runtime::run_async_with_tokio, DbConnectionPool, JoinPushDown,
+};
 use odbc_api::{sys::AttrConnectionPooling, Connection, ConnectionOptions, Environment};
 use secrecy::{ExposeSecret, SecretBox, SecretString};
 use sha2::{Digest, Sha256};
@@ -107,17 +109,29 @@ where
     async fn connect(
         &self,
     ) -> Result<Box<ODBCDbConnection<'a>>, Box<dyn std::error::Error + Send + Sync>> {
-        let cxn = self.pool.connect_with_connection_string(
-            &self.connection_string,
-            ConnectionOptions::default(),
-        )?;
+        let pool: &'static Environment = self.pool;
+        let connection_string = self.connection_string.clone();
+        let params = Arc::clone(&self.params);
 
-        let odbc_cxn = ODBCConnection {
-            conn: Arc::new(cxn.into()),
-            params: Arc::clone(&self.params),
+        let connect = async move || -> Result<
+            Box<ODBCDbConnection<'a>>,
+            Box<dyn std::error::Error + Send + Sync>,
+        > {
+            let cxn = tokio::task::spawn_blocking(move || {
+                pool.connect_with_connection_string(
+                    &connection_string,
+                    ConnectionOptions::default(),
+                )
+            })
+            .await
+            .map_err(|e| Box::new(e) as Box<dyn std::error::Error + Send + Sync>)??;
+
+            Ok(Box::new(ODBCConnection {
+                conn: Arc::new(cxn.into()),
+                params,
+            }) as Box<ODBCDbConnection<'a>>)
         };
-
-        Ok(Box::new(odbc_cxn))
+        run_async_with_tokio(connect).await
     }
 
     fn join_push_down(&self) -> JoinPushDown {

--- a/crates/postgres/Cargo.toml
+++ b/crates/postgres/Cargo.toml
@@ -43,6 +43,9 @@ url = "2.5"
 default = ["federation"]
 federation = ["dep:datafusion-federation", "datafusion-table-providers-common/federation"]
 
+[dev-dependencies]
+geozero = { version = "0.15.1", features = ["with-wkb"] }
+
 [package.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]

--- a/crates/postgres/src/conn.rs
+++ b/crates/postgres/src/conn.rs
@@ -16,6 +16,14 @@ use datafusion_table_providers_common::util::handle_unsupported_type_error;
 use datafusion_table_providers_common::util::schema::SchemaValidator;
 use datafusion_table_providers_common::UnsupportedTypeAction;
 
+fn maybe_db_source_err(err: tokio_postgres::Error) -> Box<dyn Error + Send + Sync> {
+    if let Some(err) = err.as_db_error() {
+        Box::new(err.clone())
+    } else {
+        Box::new(err)
+    }
+}
+
 /// A pooled Postgres connection obtained from a [`PostgresConnectionPool`](crate::pool::PostgresConnectionPool).
 ///
 /// Dereferences to [`tokio_postgres::Client`](bb8_postgres::tokio_postgres::Client) for executing queries.
@@ -199,7 +207,7 @@ fn map_schema_query_error(
         }
     }
     datafusion_table_providers_common::sql::db_connection_pool::dbconnection::Error::UnableToGetSchema {
-        source: Box::new(e),
+        source: maybe_db_source_err(e),
     }
 }
 
@@ -339,7 +347,7 @@ impl<'a> AsyncDbConnection<PostgresPooledConnection, &'a (dyn ToSql + Sync)>
 
         let rows = self.conn.query(query, &[&schema]).await.map_err(|e| {
             datafusion_table_providers_common::sql::db_connection_pool::dbconnection::Error::UnableToGetTables {
-                source: Box::new(e),
+                source: maybe_db_source_err(e),
             }
         })?;
 
@@ -362,7 +370,7 @@ impl<'a> AsyncDbConnection<PostgresPooledConnection, &'a (dyn ToSql + Sync)>
                 .query(query, &[])
                 .await
                 .map_err(|e| datafusion_table_providers_common::sql::db_connection_pool::dbconnection::Error::UnableToGetSchemas {
-                    source: Box::new(e),
+                    source: maybe_db_source_err(e),
                 })?;
 
         Ok(rows.iter().map(|r| r.get::<usize, String>(0)).collect())
@@ -494,13 +502,13 @@ impl PostgresConnection {
             .query_one("SELECT version()", &[])
             .await
             .map_err(|e| datafusion_table_providers_common::sql::db_connection_pool::dbconnection::Error::UnableToGetSchema {
-                source: Box::new(e),
+                source: maybe_db_source_err(e),
             })?;
 
         let version: String = row
             .try_get(0)
             .map_err(|e| datafusion_table_providers_common::sql::db_connection_pool::dbconnection::Error::UnableToGetSchema {
-                source: Box::new(e),
+                source: maybe_db_source_err(e),
             })?;
 
         let variant = if version.contains("Redshift") {
@@ -577,11 +585,11 @@ impl PostgresConnection {
                 .query_one("SELECT current_database()", &[])
                 .await
                 .map_err(|e| datafusion_table_providers_common::sql::db_connection_pool::dbconnection::Error::UnableToGetSchema {
-                    source: Box::new(e),
+                    source: maybe_db_source_err(e),
                 })?
                 .try_get(0)
                 .map_err(|e| datafusion_table_providers_common::sql::db_connection_pool::dbconnection::Error::UnableToGetSchema {
-                    source: Box::new(e),
+                    source: maybe_db_source_err(e),
                 })?,
         };
 
@@ -610,7 +618,7 @@ impl PostgresConnection {
             }
             Err(e) => {
                 return Err(datafusion_table_providers_common::sql::db_connection_pool::dbconnection::Error::UnableToGetSchema {
-                    source: Box::new(e),
+                    source: maybe_db_source_err(e),
                 })
             }
         };
@@ -683,7 +691,7 @@ impl PostgresConnection {
                     }
                 }
                 datafusion_table_providers_common::sql::db_connection_pool::dbconnection::Error::UnableToGetSchema {
-                    source: Box::new(e),
+                    source: maybe_db_source_err(e),
                 }
             })?;
 

--- a/crates/sqlite/Cargo.toml
+++ b/crates/sqlite/Cargo.toml
@@ -26,6 +26,10 @@ tokio-rusqlite = "0.7"
 tracing = "0.1"
 uuid = { version = "1.18" }
 
+[dev-dependencies]
+rand = "0.10"
+rstest = "0.26.1"
+
 [features]
 default = ["federation", "bundled"]
 federation = ["dep:datafusion-federation", "datafusion-table-providers-common/federation"]

--- a/crates/sqlite/src/arrow_sql_gen.rs
+++ b/crates/sqlite/src/arrow_sql_gen.rs
@@ -26,7 +26,10 @@ use arrow::{
     datatypes::{DataType, Field, Schema, SchemaRef},
 };
 use datafusion_table_providers_common::sql::arrow_sql_gen::arrow::map_data_type_to_array_builder;
-use rusqlite::{types::Type, Row, Rows};
+use rusqlite::{
+    types::{Type, ValueRef},
+    Row, Rows,
+};
 use snafu::prelude::*;
 
 #[derive(Debug, Snafu)]
@@ -47,6 +50,11 @@ pub enum Error {
 
     #[snafu(display("Failed to extract column name: {source}"))]
     FailedToExtractColumnName { source: rusqlite::Error },
+
+    #[snafu(display(
+        "Failed to decode REAL value {value} at index {index} as an integer: the value has a fractional part or is out of range"
+    ))]
+    RealNotRepresentableAsInteger { index: usize, value: f64 },
 }
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
@@ -87,7 +95,9 @@ pub fn rows_to_arrow(
             // Refer to the rusqlite type handling documentation for more details:
             // https://github.com/rusqlite/rusqlite/blob/95680270eca6f405fb51f5fbe6a214aac5fdce58/src/types/mod.rs#L21C1-L22C75
             //
-            // `REAL` to integer: always returns an [`Error::InvalidColumnType`](datafusion_table_providers_common::Error::InvalidColumnType) error.
+            // `REAL` to integer: decoded by `append_integer_value!` when the value is
+            //   exactly integral (SQLite computes e.g. `round()` in REAL even when the
+            //   plan schema says integer); a fractional REAL is a structured error.
             // `INTEGER` to float: casts using `as` operator. Never fails.
             // `REAL` to float: casts using `as` operator. Never fails.
 
@@ -186,6 +196,53 @@ macro_rules! append_value {
     }};
 }
 
+/// Appends a value into an integer-typed builder, tolerating SQLite's dynamic typing.
+///
+/// SQLite computes many numeric expressions in REAL even when DataFusion's plan
+/// schema says integer. A REAL that is exactly integral decodes into the integer
+/// builder; a fractional or out-of-range REAL fails instead of being truncated.
+macro_rules! append_integer_value {
+    ($builder:expr, $row:expr, $index:expr, $type:ty, $builder_type:ty) => {{
+        let Some(builder) = $builder.as_any_mut().downcast_mut::<$builder_type>() else {
+            FailedToDowncastBuilderSnafu {
+                sqlite_type: format!("{}", Type::Integer),
+            }
+            .fail()?
+        };
+        match $row.get_ref($index).context(FailedToExtractRowValueSnafu)? {
+            ValueRef::Null => builder.append_null(),
+            ValueRef::Real(value) => {
+                let as_i64 = integral_real_to_i64($index, value)?;
+                builder.append_value(i64_to_integer::<$type>($index, as_i64)?);
+            }
+            _ => {
+                let value: Option<i64> = $row.get($index).context(FailedToExtractRowValueSnafu)?;
+                match value {
+                    Some(value) => builder.append_value(i64_to_integer::<$type>($index, value)?),
+                    None => builder.append_null(),
+                }
+            }
+        }
+    }};
+}
+
+fn integral_real_to_i64(index: usize, value: f64) -> Result<i64> {
+    const I64_LOWER_INCLUSIVE: f64 = -9_223_372_036_854_775_808.0;
+    const I64_UPPER_EXCLUSIVE: f64 = 9_223_372_036_854_775_808.0;
+    ensure!(
+        value.fract() == 0.0 && (I64_LOWER_INCLUSIVE..I64_UPPER_EXCLUSIVE).contains(&value),
+        RealNotRepresentableAsIntegerSnafu { index, value }
+    );
+    #[allow(clippy::cast_possible_truncation)]
+    Ok(value as i64)
+}
+
+fn i64_to_integer<T: TryFrom<i64>>(index: usize, value: i64) -> Result<T> {
+    T::try_from(value)
+        .map_err(|_| rusqlite::Error::IntegralValueOutOfRange(index, value))
+        .context(FailedToExtractRowValueSnafu)
+}
+
 fn add_row_to_builders(
     row: &Row,
     arrow_types: &[DataType],
@@ -206,14 +263,14 @@ fn add_row_to_builders(
                 };
                 builder.append_null();
             }
-            DataType::Int8 => append_value!(builder, row, i, i8, Int8Builder, Type::Integer),
-            DataType::Int16 => append_value!(builder, row, i, i16, Int16Builder, Type::Integer),
-            DataType::Int32 => append_value!(builder, row, i, i32, Int32Builder, Type::Integer),
-            DataType::Int64 => append_value!(builder, row, i, i64, Int64Builder, Type::Integer),
-            DataType::UInt8 => append_value!(builder, row, i, u8, UInt8Builder, Type::Integer),
-            DataType::UInt16 => append_value!(builder, row, i, u16, UInt16Builder, Type::Integer),
-            DataType::UInt32 => append_value!(builder, row, i, u32, UInt32Builder, Type::Integer),
-            DataType::UInt64 => append_value!(builder, row, i, u64, UInt64Builder, Type::Integer),
+            DataType::Int8 => append_integer_value!(builder, row, i, i8, Int8Builder),
+            DataType::Int16 => append_integer_value!(builder, row, i, i16, Int16Builder),
+            DataType::Int32 => append_integer_value!(builder, row, i, i32, Int32Builder),
+            DataType::Int64 => append_integer_value!(builder, row, i, i64, Int64Builder),
+            DataType::UInt8 => append_integer_value!(builder, row, i, u8, UInt8Builder),
+            DataType::UInt16 => append_integer_value!(builder, row, i, u16, UInt16Builder),
+            DataType::UInt32 => append_integer_value!(builder, row, i, u32, UInt32Builder),
+            DataType::UInt64 => append_integer_value!(builder, row, i, u64, UInt64Builder),
 
             DataType::Boolean => {
                 append_value!(builder, row, i, bool, BooleanBuilder, Type::Integer)
@@ -244,5 +301,130 @@ fn map_column_type_to_data_type(column_type: Type) -> DataType {
         Type::Real => DataType::Float64,
         Type::Text => DataType::Utf8,
         Type::Blob => DataType::Binary,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow::array::{Array, Int64Array, UInt64Array};
+    use rusqlite::Connection;
+
+    fn query_to_arrow(sql: &str, projected_schema: Option<SchemaRef>) -> Result<RecordBatch> {
+        let conn = Connection::open_in_memory().expect("in-memory sqlite connection");
+        let mut stmt = conn.prepare(sql).expect("prepare statement");
+        let num_cols = stmt.column_count();
+        let rows = stmt.query([]).expect("execute query");
+        rows_to_arrow(rows, num_cols, projected_schema)
+    }
+
+    fn int64_schema(name: &str) -> SchemaRef {
+        Arc::new(Schema::new(vec![Field::new(name, DataType::Int64, true)]))
+    }
+
+    #[test]
+    fn integral_real_decodes_into_int64_column() {
+        let batch = query_to_arrow(
+            "SELECT round(5 / 2, 2) AS ratio",
+            Some(int64_schema("ratio")),
+        )
+        .expect("integral REAL should decode into an Int64 column");
+
+        let col = batch
+            .column(0)
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .expect("Int64 array");
+        assert_eq!(col.value(0), 2);
+    }
+
+    #[test]
+    fn fractional_real_into_integer_column_is_an_error() {
+        let err = query_to_arrow("SELECT 2.5 AS v", Some(int64_schema("v")))
+            .expect_err("fractional REAL must not silently truncate");
+        assert!(matches!(
+            err,
+            Error::RealNotRepresentableAsInteger { index: 0, .. }
+        ));
+    }
+
+    #[test]
+    fn out_of_range_real_into_integer_column_is_an_error() {
+        let err = query_to_arrow("SELECT 1e19 AS v", Some(int64_schema("v")))
+            .expect_err("out-of-range REAL must not silently truncate");
+        assert!(matches!(
+            err,
+            Error::RealNotRepresentableAsInteger { index: 0, .. }
+        ));
+    }
+
+    #[test]
+    fn mixed_integer_and_real_rows_decode_into_int64_column() {
+        let batch = query_to_arrow(
+            "SELECT v FROM (SELECT 2 AS v UNION ALL SELECT 3.0 ORDER BY 1)",
+            Some(int64_schema("v")),
+        )
+        .expect("mixed INTEGER/integral-REAL rows should decode");
+
+        let col = batch
+            .column(0)
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .expect("Int64 array");
+        assert_eq!((col.value(0), col.value(1)), (2, 3));
+    }
+
+    #[test]
+    fn null_and_integral_real_decode_into_int64_column() {
+        let batch = query_to_arrow(
+            "SELECT v FROM (SELECT NULL AS v UNION ALL SELECT 4.0)",
+            Some(int64_schema("v")),
+        )
+        .expect("NULL and integral REAL should decode");
+
+        let col = batch
+            .column(0)
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .expect("Int64 array");
+        assert!(col.is_null(0));
+        assert_eq!(col.value(1), 4);
+    }
+
+    #[test]
+    fn integral_real_decodes_into_uint64_column() {
+        let schema = Arc::new(Schema::new(vec![Field::new("v", DataType::UInt64, true)]));
+        let batch = query_to_arrow("SELECT 7.0 AS v", Some(schema))
+            .expect("integral REAL should decode into a UInt64 column");
+
+        let col = batch
+            .column(0)
+            .as_any()
+            .downcast_ref::<UInt64Array>()
+            .expect("UInt64 array");
+        assert_eq!(col.value(0), 7);
+    }
+
+    #[test]
+    fn negative_real_into_uint64_column_is_an_error() {
+        let schema = Arc::new(Schema::new(vec![Field::new("v", DataType::UInt64, true)]));
+        let err = query_to_arrow("SELECT -1.0 AS v", Some(schema))
+            .expect_err("negative value must be out of range for UInt64");
+        assert!(matches!(err, Error::FailedToExtractRowValue { .. }));
+    }
+
+    #[test]
+    fn text_into_integer_column_still_fails() {
+        let err = query_to_arrow(
+            "SELECT v FROM (SELECT 1 AS v UNION ALL SELECT 'abc' ORDER BY 1)",
+            Some(int64_schema("v")),
+        )
+        .expect_err("TEXT into an integer column must keep failing");
+        assert!(matches!(
+            err,
+            Error::FailedToExtractRowValue {
+                source: rusqlite::Error::InvalidColumnType(..)
+            }
+        ));
     }
 }

--- a/crates/sqlite/src/lib.rs
+++ b/crates/sqlite/src/lib.rs
@@ -232,6 +232,19 @@ impl SqliteTableProviderFactory {
 
         Ok(pool)
     }
+
+    /// Evict a cached SQLite instance so the next lookup reopens its file.
+    pub async fn invalidate_instance(&self, key: &DbInstanceKey) -> Option<SqliteConnectionPool> {
+        self.instances.lock().await.remove(key)
+    }
+
+    pub async fn invalidate_file_instance(
+        &self,
+        db_path: impl Into<Arc<str>>,
+    ) -> Option<SqliteConnectionPool> {
+        self.invalidate_instance(&DbInstanceKey::file(db_path.into()))
+            .await
+    }
 }
 
 impl Default for SqliteTableProviderFactory {


### PR DESCRIPTION
## Summary

- offload blocking database driver operations from async workers
- add generic schema projection plus MongoDB declared-schema and nested JSON support
- return structured Postgres, MySQL, SQLite, and ODBC conversion/driver errors
- add DuckDB DML, write settings, cache invalidation, ANALYZE/checkpoint handling, and atomic file-swap overwrites
- keep DuckDB functionality on the official duckdb crate APIs

## Compatibility

Existing DuckDB and MongoDB public APIs remain available. The new functionality is additive, and no fork-specific dependency pins or APIs are introduced.

## Testing

- cargo fmt --all -- --check
- cargo clippy --workspace --all-features -- -D warnings
- cargo check --workspace --all-features --all-targets
- cargo test --workspace --all-features --no-run
- make test
- provider library tests for DuckDB, MongoDB, PostgreSQL, MySQL, SQLite, ADBC, and ODBC