### PR TITLE
Fix silent precision loss on unconstrained Postgres numeric columns

### DIFF
--- a/core/tests/postgres/mod.rs
+++ b/core/tests/postgres/mod.rs
@@ -199,6 +199,68 @@ async fn test_arrow_postgres_one_way(container_manager: &Mutex<ContainerManager>
     test_postgres_json_list_struct_with_projected_schema(container_manager.port).await;
     test_postgres_composite_array_list_struct(container_manager.port).await;
     test_postgres_sort_limit(container_manager.port).await;
+    test_postgres_unconstrained_numeric_precision(container_manager.port).await;
+}
+
+/// An unconstrained `numeric` column (what `max()`, `avg()` and arithmetic over `numeric`
+/// return) has no fixed scale, so the Arrow column scale must not be taken from the first
+/// row: every later row carrying more decimals was rounded down to it.
+///
+/// The fixture order matters — a whole number first, longer values after. Ordered the other
+/// way round the values happen to survive even without the fix.
+async fn test_postgres_unconstrained_numeric_precision(port: usize) {
+    let pool = common::get_postgres_connection_pool(port)
+        .await
+        .expect("Postgres connection pool should be created");
+    let sqltable_pool: Arc<DynPostgresConnectionPool> = Arc::new(pool);
+    let conn = sqltable_pool.connect().await.expect("connect should work");
+    let async_conn = conn.as_async().expect("should be async connection");
+
+    // No projected schema: the scale can only come from the column itself.
+    let stream = async_conn
+        .query_arrow(
+            "SELECT v FROM (VALUES (20::numeric),(17.685::numeric),(15.334::numeric)) t(v)",
+            &[],
+            None,
+        )
+        .await
+        .expect("query should work");
+    let batches: Vec<RecordBatch> = futures::StreamExt::collect::<Vec<_>>(stream)
+        .await
+        .into_iter()
+        .collect::<Result<Vec<_>, _>>()
+        .expect("batches should be readable");
+
+    let scale: u32 = 20;
+    let expected: Vec<i128> = vec![
+        20 * 10i128.pow(scale),
+        17_685 * 10i128.pow(scale - 3),
+        15_334 * 10i128.pow(scale - 3),
+    ];
+
+    let got: Vec<i128> = batches
+        .iter()
+        .flat_map(|batch| {
+            let column = batch
+                .column(0)
+                .as_any()
+                .downcast_ref::<Decimal128Array>()
+                .expect("v should be Decimal128");
+            assert_eq!(
+                column.scale(),
+                20,
+                "unconstrained numeric must use the fixed default scale, not the first row's"
+            );
+            (0..column.len())
+                .map(|i| column.value(i))
+                .collect::<Vec<_>>()
+        })
+        .collect();
+
+    assert_eq!(
+        got, expected,
+        "every numeric value must survive exactly, independent of row order"
+    );
 }
 
 async fn test_postgres_sort_limit(port: usize) {

--- a/crates/postgres/src/arrow_sql_gen/mod.rs
+++ b/crates/postgres/src/arrow_sql_gen/mod.rs
@@ -101,14 +101,23 @@ pub enum Error {
     },
 
     #[snafu(display(
-        "Cannot represent the Postgres numeric value {value} as Decimal128(38, {scale}): the value overflows 128 bits"
+        "Cannot represent the Postgres numeric value {value} in column '{column_name}' as Decimal128({precision}, {scale}): the value overflows 128 bits"
     ))]
-    DecimalOverflowsColumnScale { value: String, scale: u32 },
+    DecimalOverflowsColumnScale {
+        column_name: String,
+        value: String,
+        precision: u8,
+        scale: u32,
+    },
 
     #[snafu(display(
-        "The Postgres numeric value {value} has more decimal places than the column scale {scale}; rescaling it would silently lose precision"
+        "The Postgres numeric value {value} in column '{column_name}' has more decimal places than the column scale {scale}; rescaling it would silently lose precision"
     ))]
-    DecimalExceedsColumnScale { value: String, scale: u32 },
+    DecimalExceedsColumnScale {
+        column_name: String,
+        value: String,
+        scale: u32,
+    },
 
     #[snafu(display("The field '{field_name}' has an unsupported data type: {data_type}."))]
     UnsupportedDataType {
@@ -119,17 +128,14 @@ pub enum Error {
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
 
-/// The Arrow scale used for a Postgres `numeric` column that declares no scale of its own
-/// (bare `numeric`, and anything derived from it such as `max()`, `avg()` or arithmetic).
-///
-/// Such a column has no fixed scale in Postgres: every row may carry a different number of
-/// decimal places. The Arrow column, however, needs one scale for all rows, so it is pinned
-/// here instead of being inferred from whichever row happens to arrive first — inferring it
-/// made the result depend on row order and silently rounded every later, longer value.
-///
-/// This matches the scale schema inference already assigns to a bare `numeric`
-/// (`Decimal128(38, 20)`), so the row path and the schema path agree.
-const DEFAULT_UNCONSTRAINED_NUMERIC_SCALE: u32 = 20;
+/// The Arrow precision for a `numeric` column that declares none, taken from schema inference
+/// so the two paths cannot drift apart — see [`schema::DEFAULT_NUMERIC_PRECISION`].
+const DEFAULT_NUMERIC_PRECISION: u8 = schema::DEFAULT_NUMERIC_PRECISION;
+
+/// The scale for such a column, as the unsigned column scale this decode path carries. Same
+/// source of truth as the precision above; [`schema::DEFAULT_NUMERIC_SCALE`] documents why it
+/// is pinned rather than inferred from the first row.
+const DEFAULT_UNCONSTRAINED_NUMERIC_SCALE: u32 = schema::DEFAULT_NUMERIC_SCALE as u32;
 
 /// Returns the `Decimal128` mantissa representing `value` in a column of scale `dest_scale`,
 /// without losing precision.
@@ -138,7 +144,10 @@ const DEFAULT_UNCONSTRAINED_NUMERIC_SCALE: u32 = 20;
 /// silent corruption this replaces) and refuses to widen past its own 96-bit mantissa. Both
 /// directions are handled explicitly here, and anything that cannot be represented exactly is
 /// reported as an error rather than quietly rounded.
-fn decimal_to_i128_mantissa(value: Decimal, dest_scale: u32) -> Result<i128> {
+///
+/// `column_name` names the offending column in that error — a numeric that will not fit is a
+/// property of one column of the query, and a message without it leaves the user to guess which.
+fn decimal_to_i128_mantissa(value: Decimal, dest_scale: u32, column_name: &str) -> Result<i128> {
     let value_scale = value.scale();
     let mantissa = value.mantissa();
 
@@ -149,11 +158,14 @@ fn decimal_to_i128_mantissa(value: Decimal, dest_scale: u32) -> Result<i128> {
             factor
                 .and_then(|factor| mantissa.checked_mul(factor))
                 .context(DecimalOverflowsColumnScaleSnafu {
+                    column_name,
                     value: value.to_string(),
+                    precision: DEFAULT_NUMERIC_PRECISION,
                     scale: dest_scale,
                 })
         }
         std::cmp::Ordering::Less => DecimalExceedsColumnScaleSnafu {
+            column_name,
             value: value.to_string(),
             scale: dest_scale,
         }
@@ -602,6 +614,10 @@ pub fn rows_to_arrow(rows: &[Row], projected_schema: &Option<SchemaRef>) -> Resu
                     }
                 }
                 Type::NUMERIC => {
+                    let Some(column_name) = column_names.get(i) else {
+                        return NoColumnNameForIndexSnafu { index: i }.fail();
+                    };
+                    let column_name = column_name.clone();
                     let v: Option<Decimal> = row.try_get(i).context(FailedToGetRowValueSnafu {
                         pg_type: Type::NUMERIC,
                     })?;
@@ -629,11 +645,8 @@ pub fn rows_to_arrow(rows: &[Row], projected_schema: &Option<SchemaRef>) -> Resu
                     };
 
                     if arrow_field.is_none() {
-                        let Some(field_name) = column_names.get(i) else {
-                            return NoColumnNameForIndexSnafu { index: i }.fail();
-                        };
                         let new_arrow_field = Field::new(
-                            field_name,
+                            &column_name,
                             DataType::Decimal128(38, scale.try_into().unwrap_or_default()),
                             true,
                         );
@@ -650,9 +663,13 @@ pub fn rows_to_arrow(rows: &[Row], projected_schema: &Option<SchemaRef>) -> Resu
                         continue;
                     };
 
-                    dec_builder.append_value(decimal_to_i128_mantissa(v, scale)?);
+                    dec_builder.append_value(decimal_to_i128_mantissa(v, scale, &column_name)?);
                 }
                 Type::NUMERIC_ARRAY => {
+                    let Some(column_name) = column_names.get(i) else {
+                        return NoColumnNameForIndexSnafu { index: i }.fail();
+                    };
+                    let column_name = column_name.clone();
                     let v: Option<Vec<Option<Decimal>>> =
                         row.try_get(i).context(FailedToGetRowValueSnafu {
                             pg_type: Type::NUMERIC_ARRAY,
@@ -683,12 +700,8 @@ pub fn rows_to_arrow(rows: &[Row], projected_schema: &Option<SchemaRef>) -> Resu
                     };
 
                     if arrow_field.is_none() {
-                        let Some(field_name) = column_names.get(i) else {
-                            return NoColumnNameForIndexSnafu { index: i }.fail();
-                        };
-
                         let new_arrow_field = Field::new(
-                            field_name,
+                            &column_name,
                             DataType::List(Arc::new(Field::new(
                                 "item",
                                 DataType::Decimal128(38, decimal_scale),
@@ -713,7 +726,11 @@ pub fn rows_to_arrow(rows: &[Row], projected_schema: &Option<SchemaRef>) -> Resu
                         if let Some(decimal) = item {
                             decimal_array_builder
                                 .values()
-                                .append_value(decimal_to_i128_mantissa(decimal, dest_scale)?);
+                                .append_value(decimal_to_i128_mantissa(
+                                    decimal,
+                                    dest_scale,
+                                    &column_name,
+                                )?);
                         } else {
                             decimal_array_builder.values().append_null();
                         }
@@ -1619,7 +1636,8 @@ mod tests {
         ] {
             let decimal = Decimal::from_str(value).expect("decimal parses");
             assert_eq!(
-                decimal_to_i128_mantissa(decimal, scale).expect("value is representable"),
+                decimal_to_i128_mantissa(decimal, scale, "reading")
+                    .expect("value is representable"),
                 expected,
                 "value {value} must be widened to scale {scale} exactly"
             );
@@ -1628,24 +1646,27 @@ mod tests {
         // A declared scale that already matches is passed through untouched.
         let decimal = Decimal::from_str("1.23").expect("decimal parses");
         assert_eq!(
-            decimal_to_i128_mantissa(decimal, 2).expect("value is representable"),
+            decimal_to_i128_mantissa(decimal, 2, "reading").expect("value is representable"),
             123
         );
 
         // More decimal places than the column can hold is an error, not a rounded value.
         let decimal = Decimal::from_str("1.235").expect("decimal parses");
-        let error = decimal_to_i128_mantissa(decimal, 2).expect_err("must not round silently");
+        let error =
+            decimal_to_i128_mantissa(decimal, 2, "reading").expect_err("must not round silently");
         assert!(
-            error.to_string().contains("more decimal places"),
+            error.to_string().contains("more decimal places")
+                && error.to_string().contains("'reading'"),
             "unexpected error: {error}"
         );
 
         // Widening that overflows 128 bits is reported rather than wrapped.
         let decimal = Decimal::from_str("79228162514264337593543950335").expect("decimal parses");
-        let error = decimal_to_i128_mantissa(decimal, DEFAULT_UNCONSTRAINED_NUMERIC_SCALE)
-            .expect_err("must not wrap");
+        let error =
+            decimal_to_i128_mantissa(decimal, DEFAULT_UNCONSTRAINED_NUMERIC_SCALE, "reading")
+                .expect_err("must not wrap");
         assert!(
-            error.to_string().contains("overflows"),
+            error.to_string().contains("overflows") && error.to_string().contains("'reading'"),
             "unexpected error: {error}"
         );
     }

--- a/crates/postgres/src/arrow_sql_gen/mod.rs
+++ b/crates/postgres/src/arrow_sql_gen/mod.rs
@@ -100,6 +100,16 @@ pub enum Error {
         source: arrow::error::ArrowError,
     },
 
+    #[snafu(display(
+        "Cannot represent the Postgres numeric value {value} as Decimal128(38, {scale}): the value overflows 128 bits"
+    ))]
+    DecimalOverflowsColumnScale { value: String, scale: u32 },
+
+    #[snafu(display(
+        "The Postgres numeric value {value} has more decimal places than the column scale {scale}; rescaling it would silently lose precision"
+    ))]
+    DecimalExceedsColumnScale { value: String, scale: u32 },
+
     #[snafu(display("The field '{field_name}' has an unsupported data type: {data_type}."))]
     UnsupportedDataType {
         data_type: String,
@@ -108,6 +118,48 @@ pub enum Error {
 }
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
+
+/// The Arrow scale used for a Postgres `numeric` column that declares no scale of its own
+/// (bare `numeric`, and anything derived from it such as `max()`, `avg()` or arithmetic).
+///
+/// Such a column has no fixed scale in Postgres: every row may carry a different number of
+/// decimal places. The Arrow column, however, needs one scale for all rows, so it is pinned
+/// here instead of being inferred from whichever row happens to arrive first — inferring it
+/// made the result depend on row order and silently rounded every later, longer value.
+///
+/// This matches the scale schema inference already assigns to a bare `numeric`
+/// (`Decimal128(38, 20)`), so the row path and the schema path agree.
+const DEFAULT_UNCONSTRAINED_NUMERIC_SCALE: u32 = 20;
+
+/// Returns the `Decimal128` mantissa representing `value` in a column of scale `dest_scale`,
+/// without losing precision.
+///
+/// `Decimal::rescale` is deliberately not used: it rounds when narrowing (the cause of the
+/// silent corruption this replaces) and refuses to widen past its own 96-bit mantissa. Both
+/// directions are handled explicitly here, and anything that cannot be represented exactly is
+/// reported as an error rather than quietly rounded.
+fn decimal_to_i128_mantissa(value: Decimal, dest_scale: u32) -> Result<i128> {
+    let value_scale = value.scale();
+    let mantissa = value.mantissa();
+
+    match dest_scale.cmp(&value_scale) {
+        std::cmp::Ordering::Equal => Ok(mantissa),
+        std::cmp::Ordering::Greater => {
+            let factor = 10i128.checked_pow(dest_scale - value_scale);
+            factor
+                .and_then(|factor| mantissa.checked_mul(factor))
+                .context(DecimalOverflowsColumnScaleSnafu {
+                    value: value.to_string(),
+                    scale: dest_scale,
+                })
+        }
+        std::cmp::Ordering::Less => DecimalExceedsColumnScaleSnafu {
+            value: value.to_string(),
+            scale: dest_scale,
+        }
+        .fail(),
+    }
+}
 
 macro_rules! handle_primitive_type {
     ($builder:expr, $type:expr, $builder_ty:ty, $value_ty:ty, $row:expr, $index:expr) => {{
@@ -553,13 +605,11 @@ pub fn rows_to_arrow(rows: &[Row], projected_schema: &Option<SchemaRef>) -> Resu
                     let v: Option<Decimal> = row.try_get(i).context(FailedToGetRowValueSnafu {
                         pg_type: Type::NUMERIC,
                     })?;
-                    let scale = {
-                        if let Some(v) = &v {
-                            v.scale()
-                        } else {
-                            0
-                        }
-                    };
+                    // A declared scale (`numeric(p,s)`) comes from the projected schema; a bare
+                    // `numeric` has no scale of its own, so use the pinned default rather than
+                    // the first row's scale, which later rows would then be rounded down to.
+                    let scale =
+                        postgres_numeric_scale.unwrap_or(DEFAULT_UNCONSTRAINED_NUMERIC_SCALE);
 
                     let dec_builder = builder.get_or_insert_with(|| {
                         Box::new(
@@ -595,16 +645,12 @@ pub fn rows_to_arrow(rows: &[Row], projected_schema: &Option<SchemaRef>) -> Resu
                         *postgres_numeric_scale = Some(scale);
                     };
 
-                    let Some(mut v) = v else {
+                    let Some(v) = v else {
                         dec_builder.append_null();
                         continue;
                     };
 
-                    // Record Batch Scale is determined by first row, while Postgres Numeric Type doesn't have fixed scale
-                    // Resolve scale difference for incoming records
-                    let dest_scale = postgres_numeric_scale.unwrap_or_default();
-                    v.rescale(dest_scale);
-                    dec_builder.append_value(v.mantissa());
+                    dec_builder.append_value(decimal_to_i128_mantissa(v, scale)?);
                 }
                 Type::NUMERIC_ARRAY => {
                     let v: Option<Vec<Option<Decimal>>> =
@@ -612,15 +658,10 @@ pub fn rows_to_arrow(rows: &[Row], projected_schema: &Option<SchemaRef>) -> Resu
                             pg_type: Type::NUMERIC_ARRAY,
                         })?;
 
-                    let inferred_scale = v
-                        .iter()
-                        .flatten()
-                        .flatten()
-                        .map(Decimal::scale)
-                        .max()
-                        .unwrap_or_default();
-
-                    let dest_scale = postgres_numeric_scale.unwrap_or(inferred_scale);
+                    // As for scalar `numeric`: only a declared scale is trusted, otherwise the
+                    // pinned default, so the column's scale does not depend on the first row.
+                    let dest_scale =
+                        postgres_numeric_scale.unwrap_or(DEFAULT_UNCONSTRAINED_NUMERIC_SCALE);
                     let decimal_scale = i8::try_from(dest_scale).unwrap_or_default();
 
                     let decimal_array_builder = builder.get_or_insert_with(|| {
@@ -669,11 +710,10 @@ pub fn rows_to_arrow(rows: &[Row], projected_schema: &Option<SchemaRef>) -> Resu
                     };
 
                     for item in values {
-                        if let Some(mut decimal) = item {
-                            decimal.rescale(dest_scale);
+                        if let Some(decimal) = item {
                             decimal_array_builder
                                 .values()
-                                .append_value(decimal.mantissa());
+                                .append_value(decimal_to_i128_mantissa(decimal, dest_scale)?);
                         } else {
                             decimal_array_builder.values().append_null();
                         }
@@ -1561,6 +1601,53 @@ mod tests {
         let negative_result = Decimal::from_sql(&Type::NUMERIC, negative_raw.as_slice())
             .expect("Failed to run FromSql");
         assert_eq!(negative_result, negative);
+    }
+
+    /// Regression guard for the unconstrained `numeric` precision loss: values are widened
+    /// to the column scale exactly, and a value that would have to be rounded is rejected
+    /// instead of being silently truncated (the previous `Decimal::rescale` behaviour).
+    #[test]
+    fn test_decimal_to_i128_mantissa() {
+        // Whole number first, more decimals after: the fixture order that used to corrupt
+        // 17.685 into 18 and 15.334 into 15.
+        let scale = DEFAULT_UNCONSTRAINED_NUMERIC_SCALE;
+        for (value, expected) in [
+            ("20", 20 * 10i128.pow(20)),
+            ("17.685", 17_685 * 10i128.pow(17)),
+            ("15.334", 15_334 * 10i128.pow(17)),
+            ("-0.0045", -45 * 10i128.pow(16)),
+        ] {
+            let decimal = Decimal::from_str(value).expect("decimal parses");
+            assert_eq!(
+                decimal_to_i128_mantissa(decimal, scale).expect("value is representable"),
+                expected,
+                "value {value} must be widened to scale {scale} exactly"
+            );
+        }
+
+        // A declared scale that already matches is passed through untouched.
+        let decimal = Decimal::from_str("1.23").expect("decimal parses");
+        assert_eq!(
+            decimal_to_i128_mantissa(decimal, 2).expect("value is representable"),
+            123
+        );
+
+        // More decimal places than the column can hold is an error, not a rounded value.
+        let decimal = Decimal::from_str("1.235").expect("decimal parses");
+        let error = decimal_to_i128_mantissa(decimal, 2).expect_err("must not round silently");
+        assert!(
+            error.to_string().contains("more decimal places"),
+            "unexpected error: {error}"
+        );
+
+        // Widening that overflows 128 bits is reported rather than wrapped.
+        let decimal = Decimal::from_str("79228162514264337593543950335").expect("decimal parses");
+        let error = decimal_to_i128_mantissa(decimal, DEFAULT_UNCONSTRAINED_NUMERIC_SCALE)
+            .expect_err("must not wrap");
+        assert!(
+            error.to_string().contains("overflows"),
+            "unexpected error: {error}"
+        );
     }
 
     #[test]

--- a/crates/postgres/src/arrow_sql_gen/schema.rs
+++ b/crates/postgres/src/arrow_sql_gen/schema.rs
@@ -8,6 +8,19 @@ use super::hive_schema;
 use crate::conn::PostgresVariant;
 use datafusion_table_providers_common::UnsupportedTypeAction;
 
+/// The Arrow precision and scale used for a Postgres `numeric` that declares none of its own —
+/// a bare `numeric`, and anything derived from one such as `max()`, `avg()` or arithmetic.
+///
+/// Such a column has no fixed scale in Postgres: every row may carry a different number of
+/// decimal places. An Arrow column needs a single scale for all of its rows, so one is pinned
+/// here rather than inferred from whichever row happens to arrive first — inferring it made the
+/// result depend on row order and silently rounded every later, longer value.
+///
+/// Both the schema path ([`parse_numeric_type`]) and the row-decode path
+/// (`arrow_sql_gen::rows_to_arrow`) read these, so the two cannot drift apart.
+pub(crate) const DEFAULT_NUMERIC_PRECISION: u8 = 38;
+pub(crate) const DEFAULT_NUMERIC_SCALE: i8 = 20;
+
 #[derive(Debug, Clone)]
 pub(crate) struct ParseContext {
     pub(crate) unsupported_type_action: UnsupportedTypeAction,
@@ -247,7 +260,8 @@ fn parse_numeric_type(pg_type: &str) -> Result<(u8, i8), ArrowError> {
         .trim();
 
     if type_str.is_empty() || type_str == "()" {
-        return Ok((38, 20)); // Default precision and scale if not specified
+        // Default precision and scale if not specified — shared with the row-decode path.
+        return Ok((DEFAULT_NUMERIC_PRECISION, DEFAULT_NUMERIC_SCALE));
     }
 
     let parts: Vec<&str> = type_str


### PR DESCRIPTION
## Which issue does this PR close?

Closes #719.

## Rationale for this change

An unconstrained Postgres `numeric` column has no fixed scale — each row may carry a different number of decimal places — but the Arrow column needs a single scale. `rows_to_arrow` took that scale from the first non-null row and then `Decimal::rescale`d every later value down to it. `rescale` rounds, so longer values were silently corrupted:

```sql
SELECT v FROM (VALUES (20::numeric),(17.685::numeric),(15.334::numeric)) t(v)
-- returned 20, 18, 15
```

The same values in a different order came back exact, and a single-row result is always exact, so the loss survives casual testing. `max()`, `min()`, `avg()` and arithmetic over a `numeric` column all return this unconstrained type, so aggregates were the common exposure. Columns with a declared scale (`numeric(10,3)`) were unaffected — they take the schema-driven path.

## What changes are included in this PR?

- The Arrow scale for a `numeric` column that declares none is pinned to `Decimal128(38, 20)` instead of being inferred from the first row. That is the same scale schema inference already assigns to a bare `numeric`, so the row path and the schema path now agree, and the result no longer depends on row order or on how rows are chunked into batches.
- Values are converted to the column's mantissa by exact `i128` arithmetic (`decimal_to_i128_mantissa`) rather than `Decimal::rescale`, which rounds when narrowing and silently refuses to widen past its own 96-bit mantissa. A value that cannot be represented exactly at the column scale is now an error (`DecimalExceedsColumnScale` / `DecimalOverflowsColumnScale`) instead of a quietly rounded value.
- `numeric[]` derived its scale from the first row's widest element and had the same order dependence; it is fixed the same way.
- Columns with a declared scale keep taking their scale from the projected schema, unchanged.

## Are there any user-facing changes?

Yes, and they are intended:

- Unconstrained `numeric` columns now always come back as `Decimal128(38, 20)` rather than at whichever scale the first row happened to have. Values that were previously rounded are now exact.
- A `numeric` value with more decimal places than the column's scale is rejected with an error instead of being silently rounded. Previously this loss was invisible.

No public API changes.

## Testing

- `core/tests/postgres/mod.rs`: `test_postgres_unconstrained_numeric_precision` runs the issue's repro through `query_arrow` with no projected schema and asserts both the column scale and every value. The fixture is deliberately ordered whole-number first (`20, 17.685, 15.334`) — ordered the other way it passes against the unfixed code. Verified failing before the fix (`left: 0, right: 20`, i.e. the zero-decimal worst case) and passing after.
- `crates/postgres/src/arrow_sql_gen/mod.rs`: unit tests for `decimal_to_i128_mantissa` covering exact widening, an already-matching declared scale, refusal to round, and 128-bit overflow.
- `cargo fmt --all -- --check`, `cargo clippy -p datafusion-table-providers-postgres --all-features -- -D warnings`, `cargo test -p datafusion-table-providers-postgres --lib` (57 passed), and the full Docker-backed Postgres integration suite `cargo test -p datafusion-table-providers --features postgres --test integration postgres` (21 passed) all clean locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
