### PR TITLE
feat(postgres): keep the source type as Arrow field metadata

### DIFF
--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -9,6 +9,7 @@
 
 pub use datafusion_table_providers_common::{
     common, schema_projection, util, Error, UnsupportedTypeAction, DESCRIPTION_METADATA_KEY,
+    SOURCE_TYPE_METADATA_KEY,
 };
 
 pub mod sql {

--- a/core/tests/postgres/schema.rs
+++ b/core/tests/postgres/schema.rs
@@ -13,6 +13,7 @@ use crate::postgres::PostgresTableProviderFactory;
 use datafusion_table_providers::postgres::PostgresTableFactory;
 use datafusion_table_providers::sql::db_connection_pool::postgrespool::PostgresConnectionPool;
 use datafusion_table_providers::util::secrets::to_secret_map;
+use datafusion_table_providers::SOURCE_TYPE_METADATA_KEY;
 
 const COMPLEX_TABLE_SQL: &str = include_str!("scripts/complex_table.sql");
 
@@ -36,6 +37,37 @@ fn get_schema() -> SchemaRef {
             true,
         ),
     ];
+
+    Arc::new(Schema::new(fields))
+}
+
+/// [`get_schema`] plus the source type `pg_catalog.format_type` reports for each
+/// column of the table the factory creates from it, as field metadata.
+fn expected_inferred_schema() -> SchemaRef {
+    let source_types = [
+        ("id", "integer"),
+        ("large_id", "bigint"),
+        ("name", "text"),
+        ("age", "smallint"),
+        ("height", "double precision"),
+        ("is_active", "boolean"),
+        ("created_at", "timestamp without time zone"),
+        ("data", "bytea"),
+        ("tags", "text[]"),
+    ];
+
+    let fields = get_schema()
+        .fields()
+        .iter()
+        .zip(source_types)
+        .map(|(field, (name, source_type))| {
+            assert_eq!(field.name(), name, "column order drifted from get_schema()");
+            field.as_ref().clone().with_metadata(HashMap::from([(
+                SOURCE_TYPE_METADATA_KEY.to_string(),
+                source_type.to_string(),
+            )]))
+        })
+        .collect::<Vec<_>>();
 
     Arc::new(Schema::new(fields))
 }
@@ -84,7 +116,7 @@ async fn test_postgres_schema_inference() {
         .await
         .expect("to create table provider");
 
-    assert_eq!(table_provider.schema(), get_schema());
+    assert_eq!(table_provider.schema(), expected_inferred_schema());
 
     // Tear down
     container
@@ -125,6 +157,26 @@ async fn test_postgres_schema_inference_complex_types() {
         .table_provider(TableReference::bare(table_name))
         .await
         .expect("to create table provider");
+
+    // The Arrow mapping is lossy for each of these: precision and scale survive
+    // Decimal128 but width, enum identity, and element type do not.
+    let schema = table_provider.schema();
+    for (column, source_type) in [
+        ("numeric_col", "numeric(10,2)"),
+        ("varchar_col", "character varying(255)"),
+        ("mood_col", "mood"),
+        ("text_array_col", "text[]"),
+    ] {
+        let field = schema.field_with_name(column).expect("column to exist");
+        assert_eq!(
+            field
+                .metadata()
+                .get(SOURCE_TYPE_METADATA_KEY)
+                .map(String::as_str),
+            Some(source_type),
+            "unexpected source type metadata on {column}"
+        );
+    }
 
     let pretty_schema = format!("{:#?}", table_provider.schema());
     insta::assert_snapshot!(pretty_schema);

--- a/core/tests/postgres/snapshots/integration__postgres__schema__postgres_materialized_view_schema_inference.snap
+++ b/core/tests/postgres/snapshots/integration__postgres__schema__postgres_materialized_view_schema_inference.snap
@@ -8,21 +8,33 @@ Schema {
             name: "id",
             data_type: Int32,
             nullable: true,
+            metadata: {
+                "source_type": "integer",
+            },
         },
         Field {
             name: "small_int_col",
             data_type: Int16,
             nullable: true,
+            metadata: {
+                "source_type": "smallint",
+            },
         },
         Field {
             name: "integer_col",
             data_type: Int32,
             nullable: true,
+            metadata: {
+                "source_type": "integer",
+            },
         },
         Field {
             name: "big_int_col",
             data_type: Int64,
             nullable: true,
+            metadata: {
+                "source_type": "bigint",
+            },
         },
         Field {
             name: "decimal_col",
@@ -31,6 +43,9 @@ Schema {
                 2,
             ),
             nullable: true,
+            metadata: {
+                "source_type": "numeric(10,2)",
+            },
         },
         Field {
             name: "numeric_col",
@@ -39,41 +54,65 @@ Schema {
                 2,
             ),
             nullable: true,
+            metadata: {
+                "source_type": "numeric(10,2)",
+            },
         },
         Field {
             name: "real_col",
             data_type: Float32,
             nullable: true,
+            metadata: {
+                "source_type": "real",
+            },
         },
         Field {
             name: "double_col",
             data_type: Float64,
             nullable: true,
+            metadata: {
+                "source_type": "double precision",
+            },
         },
         Field {
             name: "char_col",
             data_type: Utf8,
             nullable: true,
+            metadata: {
+                "source_type": "character(10)",
+            },
         },
         Field {
             name: "varchar_col",
             data_type: Utf8,
             nullable: true,
+            metadata: {
+                "source_type": "character varying(255)",
+            },
         },
         Field {
             name: "text_col",
             data_type: Utf8,
             nullable: true,
+            metadata: {
+                "source_type": "text",
+            },
         },
         Field {
             name: "bytea_col",
             data_type: Binary,
             nullable: true,
+            metadata: {
+                "source_type": "bytea",
+            },
         },
         Field {
             name: "date_col",
             data_type: Date32,
             nullable: true,
+            metadata: {
+                "source_type": "date",
+            },
         },
         Field {
             name: "time_col",
@@ -81,6 +120,9 @@ Schema {
                 Nanosecond,
             ),
             nullable: true,
+            metadata: {
+                "source_type": "time without time zone",
+            },
         },
         Field {
             name: "timestamp_col",
@@ -89,6 +131,9 @@ Schema {
                 None,
             ),
             nullable: true,
+            metadata: {
+                "source_type": "timestamp without time zone",
+            },
         },
         Field {
             name: "timestamptz_col",
@@ -99,6 +144,9 @@ Schema {
                 ),
             ),
             nullable: true,
+            metadata: {
+                "source_type": "timestamp with time zone",
+            },
         },
         Field {
             name: "interval_col",
@@ -106,11 +154,17 @@ Schema {
                 MonthDayNano,
             ),
             nullable: true,
+            metadata: {
+                "source_type": "interval",
+            },
         },
         Field {
             name: "boolean_col",
             data_type: Boolean,
             nullable: true,
+            metadata: {
+                "source_type": "boolean",
+            },
         },
         Field {
             name: "mood_col",
@@ -119,16 +173,25 @@ Schema {
                 Utf8,
             ),
             nullable: true,
+            metadata: {
+                "source_type": "mood",
+            },
         },
         Field {
             name: "uuid_col",
             data_type: Utf8,
             nullable: true,
+            metadata: {
+                "source_type": "uuid",
+            },
         },
         Field {
             name: "json_col",
             data_type: Utf8,
             nullable: true,
+            metadata: {
+                "source_type": "json",
+            },
         },
         Field {
             name: "int_array_col",
@@ -139,6 +202,9 @@ Schema {
                 },
             ),
             nullable: true,
+            metadata: {
+                "source_type": "integer[]",
+            },
         },
         Field {
             name: "text_array_col",
@@ -149,6 +215,9 @@ Schema {
                 },
             ),
             nullable: true,
+            metadata: {
+                "source_type": "text[]",
+            },
         },
         Field {
             name: "int_range_col",
@@ -167,6 +236,9 @@ Schema {
                 ],
             ),
             nullable: true,
+            metadata: {
+                "source_type": "int4range",
+            },
         },
         Field {
             name: "composite_col",
@@ -198,6 +270,9 @@ Schema {
                 ],
             ),
             nullable: true,
+            metadata: {
+                "source_type": "complex_type",
+            },
         },
     ],
     metadata: {},

--- a/core/tests/postgres/snapshots/integration__postgres__schema__postgres_schema_inference_complex_types.snap
+++ b/core/tests/postgres/snapshots/integration__postgres__schema__postgres_schema_inference_complex_types.snap
@@ -7,21 +7,33 @@ Schema {
         Field {
             name: "id",
             data_type: Int32,
+            metadata: {
+                "source_type": "integer",
+            },
         },
         Field {
             name: "small_int_col",
             data_type: Int16,
             nullable: true,
+            metadata: {
+                "source_type": "smallint",
+            },
         },
         Field {
             name: "integer_col",
             data_type: Int32,
             nullable: true,
+            metadata: {
+                "source_type": "integer",
+            },
         },
         Field {
             name: "big_int_col",
             data_type: Int64,
             nullable: true,
+            metadata: {
+                "source_type": "bigint",
+            },
         },
         Field {
             name: "decimal_col",
@@ -30,6 +42,9 @@ Schema {
                 2,
             ),
             nullable: true,
+            metadata: {
+                "source_type": "numeric(10,2)",
+            },
         },
         Field {
             name: "numeric_col",
@@ -38,41 +53,65 @@ Schema {
                 2,
             ),
             nullable: true,
+            metadata: {
+                "source_type": "numeric(10,2)",
+            },
         },
         Field {
             name: "real_col",
             data_type: Float32,
             nullable: true,
+            metadata: {
+                "source_type": "real",
+            },
         },
         Field {
             name: "double_col",
             data_type: Float64,
             nullable: true,
+            metadata: {
+                "source_type": "double precision",
+            },
         },
         Field {
             name: "char_col",
             data_type: Utf8,
             nullable: true,
+            metadata: {
+                "source_type": "character(10)",
+            },
         },
         Field {
             name: "varchar_col",
             data_type: Utf8,
             nullable: true,
+            metadata: {
+                "source_type": "character varying(255)",
+            },
         },
         Field {
             name: "text_col",
             data_type: Utf8,
             nullable: true,
+            metadata: {
+                "source_type": "text",
+            },
         },
         Field {
             name: "bytea_col",
             data_type: Binary,
             nullable: true,
+            metadata: {
+                "source_type": "bytea",
+            },
         },
         Field {
             name: "date_col",
             data_type: Date32,
             nullable: true,
+            metadata: {
+                "source_type": "date",
+            },
         },
         Field {
             name: "time_col",
@@ -80,6 +119,9 @@ Schema {
                 Nanosecond,
             ),
             nullable: true,
+            metadata: {
+                "source_type": "time without time zone",
+            },
         },
         Field {
             name: "timestamp_col",
@@ -88,6 +130,9 @@ Schema {
                 None,
             ),
             nullable: true,
+            metadata: {
+                "source_type": "timestamp without time zone",
+            },
         },
         Field {
             name: "timestamptz_col",
@@ -98,6 +143,9 @@ Schema {
                 ),
             ),
             nullable: true,
+            metadata: {
+                "source_type": "timestamp with time zone",
+            },
         },
         Field {
             name: "interval_col",
@@ -105,11 +153,17 @@ Schema {
                 MonthDayNano,
             ),
             nullable: true,
+            metadata: {
+                "source_type": "interval",
+            },
         },
         Field {
             name: "boolean_col",
             data_type: Boolean,
             nullable: true,
+            metadata: {
+                "source_type": "boolean",
+            },
         },
         Field {
             name: "mood_col",
@@ -118,16 +172,25 @@ Schema {
                 Utf8,
             ),
             nullable: true,
+            metadata: {
+                "source_type": "mood",
+            },
         },
         Field {
             name: "uuid_col",
             data_type: Utf8,
             nullable: true,
+            metadata: {
+                "source_type": "uuid",
+            },
         },
         Field {
             name: "json_col",
             data_type: Utf8,
             nullable: true,
+            metadata: {
+                "source_type": "json",
+            },
         },
         Field {
             name: "int_array_col",
@@ -138,6 +201,9 @@ Schema {
                 },
             ),
             nullable: true,
+            metadata: {
+                "source_type": "integer[]",
+            },
         },
         Field {
             name: "text_array_col",
@@ -148,6 +214,9 @@ Schema {
                 },
             ),
             nullable: true,
+            metadata: {
+                "source_type": "text[]",
+            },
         },
         Field {
             name: "int_range_col",
@@ -166,6 +235,9 @@ Schema {
                 ],
             ),
             nullable: true,
+            metadata: {
+                "source_type": "int4range",
+            },
         },
         Field {
             name: "composite_col",
@@ -197,6 +269,9 @@ Schema {
                 ],
             ),
             nullable: true,
+            metadata: {
+                "source_type": "complex_type",
+            },
         },
     ],
     metadata: {},

--- a/core/tests/postgres/snapshots/integration__postgres__schema__postgres_view_schema_inference.snap
+++ b/core/tests/postgres/snapshots/integration__postgres__schema__postgres_view_schema_inference.snap
@@ -8,21 +8,33 @@ Schema {
             name: "id",
             data_type: Int32,
             nullable: true,
+            metadata: {
+                "source_type": "integer",
+            },
         },
         Field {
             name: "small_int_col",
             data_type: Int16,
             nullable: true,
+            metadata: {
+                "source_type": "smallint",
+            },
         },
         Field {
             name: "integer_col",
             data_type: Int32,
             nullable: true,
+            metadata: {
+                "source_type": "integer",
+            },
         },
         Field {
             name: "big_int_col",
             data_type: Int64,
             nullable: true,
+            metadata: {
+                "source_type": "bigint",
+            },
         },
         Field {
             name: "decimal_col",
@@ -31,6 +43,9 @@ Schema {
                 2,
             ),
             nullable: true,
+            metadata: {
+                "source_type": "numeric(10,2)",
+            },
         },
         Field {
             name: "numeric_col",
@@ -39,41 +54,65 @@ Schema {
                 2,
             ),
             nullable: true,
+            metadata: {
+                "source_type": "numeric(10,2)",
+            },
         },
         Field {
             name: "real_col",
             data_type: Float32,
             nullable: true,
+            metadata: {
+                "source_type": "real",
+            },
         },
         Field {
             name: "double_col",
             data_type: Float64,
             nullable: true,
+            metadata: {
+                "source_type": "double precision",
+            },
         },
         Field {
             name: "char_col",
             data_type: Utf8,
             nullable: true,
+            metadata: {
+                "source_type": "character(10)",
+            },
         },
         Field {
             name: "varchar_col",
             data_type: Utf8,
             nullable: true,
+            metadata: {
+                "source_type": "character varying(255)",
+            },
         },
         Field {
             name: "text_col",
             data_type: Utf8,
             nullable: true,
+            metadata: {
+                "source_type": "text",
+            },
         },
         Field {
             name: "bytea_col",
             data_type: Binary,
             nullable: true,
+            metadata: {
+                "source_type": "bytea",
+            },
         },
         Field {
             name: "date_col",
             data_type: Date32,
             nullable: true,
+            metadata: {
+                "source_type": "date",
+            },
         },
         Field {
             name: "time_col",
@@ -81,6 +120,9 @@ Schema {
                 Nanosecond,
             ),
             nullable: true,
+            metadata: {
+                "source_type": "time without time zone",
+            },
         },
         Field {
             name: "timestamp_col",
@@ -89,6 +131,9 @@ Schema {
                 None,
             ),
             nullable: true,
+            metadata: {
+                "source_type": "timestamp without time zone",
+            },
         },
         Field {
             name: "timestamptz_col",
@@ -99,6 +144,9 @@ Schema {
                 ),
             ),
             nullable: true,
+            metadata: {
+                "source_type": "timestamp with time zone",
+            },
         },
         Field {
             name: "interval_col",
@@ -106,11 +154,17 @@ Schema {
                 MonthDayNano,
             ),
             nullable: true,
+            metadata: {
+                "source_type": "interval",
+            },
         },
         Field {
             name: "boolean_col",
             data_type: Boolean,
             nullable: true,
+            metadata: {
+                "source_type": "boolean",
+            },
         },
         Field {
             name: "mood_col",
@@ -119,16 +173,25 @@ Schema {
                 Utf8,
             ),
             nullable: true,
+            metadata: {
+                "source_type": "mood",
+            },
         },
         Field {
             name: "uuid_col",
             data_type: Utf8,
             nullable: true,
+            metadata: {
+                "source_type": "uuid",
+            },
         },
         Field {
             name: "json_col",
             data_type: Utf8,
             nullable: true,
+            metadata: {
+                "source_type": "json",
+            },
         },
         Field {
             name: "int_array_col",
@@ -139,6 +202,9 @@ Schema {
                 },
             ),
             nullable: true,
+            metadata: {
+                "source_type": "integer[]",
+            },
         },
         Field {
             name: "text_array_col",
@@ -149,6 +215,9 @@ Schema {
                 },
             ),
             nullable: true,
+            metadata: {
+                "source_type": "text[]",
+            },
         },
         Field {
             name: "int_range_col",
@@ -167,6 +236,9 @@ Schema {
                 ],
             ),
             nullable: true,
+            metadata: {
+                "source_type": "int4range",
+            },
         },
         Field {
             name: "composite_col",
@@ -198,6 +270,9 @@ Schema {
                 ],
             ),
             nullable: true,
+            metadata: {
+                "source_type": "complex_type",
+            },
         },
     ],
     metadata: {},

--- a/crates/common/src/lib.rs
+++ b/crates/common/src/lib.rs
@@ -10,6 +10,13 @@ pub mod util;
 
 pub const DESCRIPTION_METADATA_KEY: &str = "description";
 
+/// Arrow field metadata key holding the column type exactly as the source
+/// database reports it (e.g. `numeric(10,2)`, `varchar(50)`, an enum or domain
+/// name). The Arrow mapping is lossy, so this preserves the source type for
+/// consumers that need it (round-tripping DDL, catalog export, type-aware
+/// pushdown).
+pub const SOURCE_TYPE_METADATA_KEY: &str = "source_type";
+
 #[derive(Debug, Snafu)]
 pub enum Error {
     #[snafu(display("The database file path is not within the current directory: {path}"))]

--- a/crates/postgres/src/conn.rs
+++ b/crates/postgres/src/conn.rs
@@ -174,8 +174,8 @@ struct ColumnDef {
     /// Fully formatted SQL type string (e.g. `numeric(10,2)`, `array<struct<...>>`).
     data_type: String,
     /// The source type as the database names it, before any categorization the Arrow
-    /// mapping needs. `None` where the variant's query cannot report one.
-    source_type: Option<String>,
+    /// mapping needs.
+    source_type: String,
     nullable: bool,
     type_details: Option<serde_json::Value>,
 }
@@ -429,15 +429,11 @@ impl<'a> AsyncDbConnection<PostgresPooledConnection, &'a (dyn ToSql + Sync)>
 
             // The Arrow mapping is lossy (`varchar(50)` and `citext` both land on
             // `Utf8`), so keep the source type the catalog reported alongside it.
-            let mut field = Field::new(column.name, arrow_type, column.nullable);
-            if let Some(source_type) = column.source_type {
-                field = field.with_metadata(HashMap::from([(
-                    SOURCE_TYPE_METADATA_KEY.to_string(),
-                    source_type,
-                )]));
-            }
-
-            fields.push(field);
+            fields.push(
+                Field::new(column.name, arrow_type, column.nullable).with_metadata(HashMap::from(
+                    [(SOURCE_TYPE_METADATA_KEY.to_string(), column.source_type)],
+                )),
+            );
         }
 
         let schema = Arc::new(Schema::new(fields));
@@ -567,7 +563,7 @@ impl PostgresConnection {
                         // composites, which the query rewrites to the labels
                         // `pg_data_type_to_arrow_type` dispatches on.
                         data_type: row.get::<usize, String>(1),
-                        source_type: Some(row.get::<usize, String>(2)),
+                        source_type: row.get::<usize, String>(2),
                         nullable: row.get::<usize, String>(3) == "YES",
                         type_details: row.get::<usize, Option<serde_json::Value>>(4),
                     })
@@ -674,7 +670,7 @@ impl PostgresConnection {
                     name,
                     // `SHOW COLUMNS` reports the full formatted type and this path does
                     // not categorize it, so it is already the source type.
-                    source_type: Some(data_type.clone()),
+                    source_type: data_type.clone(),
                     data_type,
                     nullable,
                     type_details: None,

--- a/crates/postgres/src/conn.rs
+++ b/crates/postgres/src/conn.rs
@@ -1,4 +1,5 @@
 use std::any::Any;
+use std::collections::HashMap;
 use std::error::Error;
 use std::sync::Arc;
 
@@ -15,6 +16,7 @@ use bb8_postgres::tokio_postgres::types::ToSql;
 use datafusion_table_providers_common::util::handle_unsupported_type_error;
 use datafusion_table_providers_common::util::schema::SchemaValidator;
 use datafusion_table_providers_common::UnsupportedTypeAction;
+use datafusion_table_providers_common::SOURCE_TYPE_METADATA_KEY;
 
 fn maybe_db_source_err(err: tokio_postgres::Error) -> Box<dyn Error + Send + Sync> {
     if let Some(err) = err.as_db_error() {
@@ -92,6 +94,10 @@ SELECT
     WHEN t.typtype = 'c' THEN 'composite'
     ELSE pg_catalog.format_type(a.atttypid, a.atttypmod)
     END AS data_type,
+    -- The type as Postgres itself names it, uncategorized: the branches above replace
+    -- `text[]`/`mood` with the 'array'/'enum' labels the Arrow mapping dispatches on,
+    -- which loses exactly the types the Arrow mapping is lossiest about.
+    pg_catalog.format_type(a.atttypid, a.atttypmod) AS source_type,
     CASE WHEN a.attnotnull THEN 'NO' ELSE 'YES' END AS is_nullable,
     CASE
     WHEN t.typcategory = 'A' THEN
@@ -167,6 +173,9 @@ struct ColumnDef {
     name: String,
     /// Fully formatted SQL type string (e.g. `numeric(10,2)`, `array<struct<...>>`).
     data_type: String,
+    /// The source type as the database names it, before any categorization the Arrow
+    /// mapping needs. `None` where the variant's query cannot report one.
+    source_type: Option<String>,
     nullable: bool,
     type_details: Option<serde_json::Value>,
 }
@@ -418,7 +427,17 @@ impl<'a> AsyncDbConnection<PostgresPooledConnection, &'a (dyn ToSql + Sync)>
                 continue;
             };
 
-            fields.push(Field::new(column.name, arrow_type, column.nullable));
+            // The Arrow mapping is lossy (`varchar(50)` and `citext` both land on
+            // `Utf8`), so keep the source type the catalog reported alongside it.
+            let mut field = Field::new(column.name, arrow_type, column.nullable);
+            if let Some(source_type) = column.source_type {
+                field = field.with_metadata(HashMap::from([(
+                    SOURCE_TYPE_METADATA_KEY.to_string(),
+                    source_type,
+                )]));
+            }
+
+            fields.push(field);
         }
 
         let schema = Arc::new(Schema::new(fields));
@@ -543,11 +562,14 @@ impl PostgresConnection {
                 rows.iter()
                     .map(|row| ColumnDef {
                         name: row.get::<usize, String>(0),
-                        // `data_type` is already a formatted type string via
-                        // `pg_catalog.format_type` (e.g. `numeric(10,2)`).
+                        // `data_type` is the categorized column: a `format_type`
+                        // string (e.g. `numeric(10,2)`) except for arrays, enums, and
+                        // composites, which the query rewrites to the labels
+                        // `pg_data_type_to_arrow_type` dispatches on.
                         data_type: row.get::<usize, String>(1),
-                        nullable: row.get::<usize, String>(2) == "YES",
-                        type_details: row.get::<usize, Option<serde_json::Value>>(3),
+                        source_type: Some(row.get::<usize, String>(2)),
+                        nullable: row.get::<usize, String>(3) == "YES",
+                        type_details: row.get::<usize, Option<serde_json::Value>>(4),
                     })
                     .collect()
             }
@@ -650,6 +672,9 @@ impl PostgresConnection {
 
                 ColumnDef {
                     name,
+                    // `SHOW COLUMNS` reports the full formatted type and this path does
+                    // not categorize it, so it is already the source type.
+                    source_type: Some(data_type.clone()),
                     data_type,
                     nullable,
                     type_details: None,


### PR DESCRIPTION
## Motivation

Postgres schema inference already asks the catalog for the exact source type. `SCHEMA_QUERY` in `crates/postgres/src/conn.rs` computes `pg_catalog.format_type(a.atttypid, a.atttypmod)`, uses it to pick an Arrow type — and then drops it on the floor at `Field::new(...)`.

That mapping is lossy in ways callers notice. `varchar(50)`, `text`, `citext`, a domain over `text`, and an enum all arrive as `Utf8`. Once the string is discarded there is no way back: nothing downstream can tell a 50-character varchar from an unbounded text column, or recover the enum's name. Anything round-tripping DDL, exporting a catalog, or making a type-aware pushdown decision has to re-query `pg_catalog` for something the provider already had in hand.

## What this does

Keeps the string, as Arrow field metadata:

- New `pub const SOURCE_TYPE_METADATA_KEY: &str = "source_type"` in `datafusion-table-providers-common`, re-exported from the facade — following the `DESCRIPTION_METADATA_KEY` precedent, so the key is a named constant consumers can match on rather than a bare string they have to hardcode.
- `SCHEMA_QUERY` selects `format_type` a second time, uncategorized, as `source_type`. The existing `data_type` column keeps its `CASE`, which rewrites arrays, enums, and composites to the labels `pg_data_type_to_arrow_type` dispatches on — so `text[]` arrives as `'array'` and a `mood` enum as `'enum'`. Reusing that column would have attached those labels as the source type, losing exactly the types the Arrow mapping is lossiest about. The dispatch column is untouched; the new one is purely additive.
- `ColumnDef` carries `source_type: String` and `get_schema` attaches it to every field it builds. The Redshift path fills it from its own `SHOW COLUMNS` type, which is already the full formatted type and is not categorized.

Arrow types are unchanged; only metadata is added.

The `infer_schema_from_data` sample-row fallback derives Arrow types from returned values and has no source-type string to attach, so those fields stay bare — a consumer reads absence as "unknown", never as "no source type".

Scoped to Postgres deliberately: the key lives in `common` so MySQL, DuckDB, and SQLite can populate it the same way from their own catalogs, but each has its own type-string story and this seemed better as one connector's worth of change to react to. Happy to generalize it here if you'd prefer.

## Compatibility

Arrow `Field` equality includes metadata, so a caller comparing an inferred Postgres schema field-for-field against a hand-built `Schema` will now see a difference. The write path is unaffected: `PostgresTableWriter`'s schema check goes through `SchemaExt::equivalent_names_and_types`, which ignores metadata.

## Testing

`core/tests/postgres/schema.rs` asserts the metadata on representative lossy columns — `numeric(10,2)`, `character varying(255)`, the `mood` enum, and `text[]` — plus the full inferred-schema comparison. The insta snapshots in `core/tests/postgres/snapshots/` are re-blessed; the diff is the added `metadata` entries only. `cargo fmt --all -- --check` and clippy at `-D warnings` are clean.

