### PR TITLE
fix(release): restore correct regex escaping in bump step

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -132,7 +132,7 @@ jobs:
           cargo_text = cargo_toml.read_text()
           for name in workspace_crate_names:
               pattern = (
-                  rf'(?m)^({re.escape(name)}\s*=\s*\{\s*version\s*=\s*")[^"]+(\")'
+                  rf'(?m)^({re.escape(name)}\s*=\s*\{{\s*version\s*=\s*")[^"]+(")'
               )
               cargo_text, count = re.subn(pattern, rf"\g<1>{version}\g<2>", cargo_text, count=1)
               if count != 1:
@@ -148,7 +148,7 @@ jobs:
               "datafusion-table-providers-python",
           ):
               pattern = (
-                  rf'(?m)(^\[\[package\]\]\nname = "{re.escape(name)}"\nversion = ")[^"]+(\")'
+                  rf'(?m)(^\[\[package\]\]\nname = "{re.escape(name)}"\nversion = ")[^"]+(")'
               )
               lock_text, count = re.subn(pattern, rf"\g<1>{version}\g<2>", lock_text, count=1)
               if count != 1:


### PR DESCRIPTION
## Problem

The parallel-publish rewrite (#729) accidentally changed the workspace-deps regex in the 'Bump workspace version' step from \\\\{{ (an f-string escape for a literal {) to \\{ (a single brace, which starts an f-string field). The field then began with a backslash, so Python raised:

SyntaxError: unexpected character after line continuation character

and the whole release run died in the 'Bump workspace version' step (run 33145956189) before any publish job ran.

## Fix

Restored the exact working pattern lines from 9a6c323 (the last known-good release workflow). Two lines changed, both in the bump step.

## Verification

- The bump-step Python now compiles cleanly (no SyntaxError)
- A functional run against copies of the real Cargo.toml/Cargo.lock rewrites all 11 workspace deps + the lock entries correctly (bumped to a test version, confirmed 12/14 occurrences)

Once merged, re-dispatching release.yaml with 0.13.1 will skip all already-done steps and validate the parallel publish structure end-to-end.