### PR TITLE
fix(release): add release to needs of provider/facade publish jobs

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -231,7 +231,9 @@ jobs:
 
   publish-provider:
     name: Publish provider
-    needs: publish-common
+    needs:
+      - release
+      - publish-common
     runs-on: ubuntu-latest
     environment: crates-io
     strategy:
@@ -283,7 +285,9 @@ jobs:
 
   publish-facade:
     name: Publish facade
-    needs: publish-provider
+    needs:
+      - release
+      - publish-provider
     runs-on: ubuntu-latest
     environment: crates-io
     steps:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -132,7 +132,7 @@ jobs:
           cargo_text = cargo_toml.read_text()
           for name in workspace_crate_names:
               pattern = (
-                  rf'(?m)^({re.escape(name)}\s*=\s*\{\s*version\s*=\s*")[^"]+(\")'
+                  rf'(?m)^({re.escape(name)}\s*=\s*\{{\s*version\s*=\s*")[^"]+(")'
               )
               cargo_text, count = re.subn(pattern, rf"\g<1>{version}\g<2>", cargo_text, count=1)
               if count != 1:
@@ -148,7 +148,7 @@ jobs:
               "datafusion-table-providers-python",
           ):
               pattern = (
-                  rf'(?m)(^\[\[package\]\]\nname = "{re.escape(name)}"\nversion = ")[^"]+(\")'
+                  rf'(?m)(^\[\[package\]\]\nname = "{re.escape(name)}"\nversion = ")[^"]+(")'
               )
               lock_text, count = re.subn(pattern, rf"\g<1>{version}\g<2>", lock_text, count=1)
               if count != 1:


### PR DESCRIPTION
## Problem

Run 33146574889 (structural validation of the staged-parallel workflow) failed in all 9 provider jobs:

```
error: crate datafusion-table-providers-mongodb@0.13.1 already exists on crates.io index
```

The env block in the logs shows why: `version=""` (empty). `publish-provider` and `publish-facade` reference `needs.release.outputs.version` but only listed `publish-common` / `publish-provider` in their `needs`, so `needs.release` wasn't in their context and the version resolved to empty. The skip check (`'' in nums` → False) then fell through to `cargo publish`, which correctly refused to republish.

Note: `publish-common` (which does `need` `release`) skipped correctly — confirming the skip logic itself is sound.

## Fix

Add `release` to the `needs` of `publish-provider` and `publish-facade` so `needs.release.outputs.version` resolves. The job graph is unchanged (release → publish-common → 9× publish-provider → publish-facade).

## Validation

Re-dispatching 0.13.1 from main after merge will skip every already-published crate and confirm the full staged-parallel structure end-to-end.